### PR TITLE
[auto] Translate JAVA API Reference to Chinese

### DIFF
--- a/chinese/java/_index.md
+++ b/chinese/java/_index.md
@@ -1,0 +1,13 @@
+---
+title: Aspose.3D for Java
+type: docs
+weight: 11
+url: /zh/java/
+description: Aspose.3D for Java API 参考包含示例、代码片段和 API 文档。它提供包、类、接口以及其他 API 细节。
+is_root: true
+---
+
+## Packages
+| 包 | 描述 |
+| --- | --- |
+| [com.aspose.threed](./com.aspose.threed) |  |


### PR DESCRIPTION
Automated translation of the JAVA API Reference to **Chinese** (`zh`) generated by RDA.

- Pages translated: 316/316
- Errors: 0
- Source: `english/java`
- Output: `chinese/java`

🤖 Generated by RDA