### PR TITLE
[auto] Translate JAVA API Reference to French

### DIFF
--- a/french/java/_index.md
+++ b/french/java/_index.md
@@ -1,0 +1,13 @@
+---
+title: Aspose.3D pour Java
+type: docs
+weight: 11
+url: /fr/java/
+description: Les références d'API Aspose.3D pour Java contiennent des exemples, des extraits de code et de la documentation API. Elles fournissent des packages, des classes, des interfaces et d'autres détails d'API.
+is_root: true
+---
+
+## Packages
+| Package | Description |
+| --- | --- |
+| [com.aspose.threed](./com.aspose.threed) |  |


### PR DESCRIPTION
Automated translation of the JAVA API Reference to **French** (`fr`) generated by RDA.

- Pages translated: 316/316
- Errors: 0
- Source: `english/java`
- Output: `french/java`

🤖 Generated by RDA