### PR TITLE
[auto] Translate NODEJS-JAVA API Reference to Japanese

### DIFF
--- a/japanese/nodejs-java/_index.md
+++ b/japanese/nodejs-java/_index.md
@@ -1,0 +1,13 @@
+---
+title: "Node.js 用 Java 経由の Aspose.3D"
+type: docs
+weight: 11
+url: /ja/nodejs-java/
+description: "Node.js 用 Java 経由の Aspose.3D API リファレンスには、例、コードスニペット、API ドキュメントが含まれています。パッケージ、クラス、インターフェイス、その他の API 詳細が提供されます。"
+is_root: true
+---
+
+## Packages
+| パッケージ | 説明 |
+| --- | --- |
+| [aspose.threed](./aspose.threed) |  |

--- a/japanese/nodejs-java/aspose.threed/_index.md
+++ b/japanese/nodejs-java/aspose.threed/_index.md
@@ -1,0 +1,217 @@
+---
+title: "aspose.threed"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+keywords: "Aspose.3D for Node.js via Java, Aspose.3D, STL, OBJ, Aspose API Reference."
+type: docs
+weight: 10
+url: /ja/nodejs-java/aspose.threed/
+---
+
+
+## クラス
+
+| クラス | 説明 |
+| --- | --- |
+| [A3DObject](../aspose.threed/a3dobject) | すべての Aspose.ThreeD オブジェクトの基底クラスで、すべてのサブクラスは動的プロパティをサポートします。 |
+| [A3dwSaveOptions](../aspose.threed/a3dwsaveoptions) | A3DW フォーマットの保存オプション。 |
+| [AmfSaveOptions](../aspose.threed/amfsaveoptions) | AMF の保存オプション |
+| [AnimationChannel](../aspose.threed/animationchannel) | チャネルはプロパティのコンポーネントフィールドをキー フレーム シーケンスのセットにマッピングします  @hideconstructor |
+| [AnimationClip](../aspose.threed/animationclip) | Animation クリップはアニメーションのコレクションです。シーンは 1 つ以上のアニメーション クリップを持つことができます。 |
+| [AnimationNode](../aspose.threed/animationnode) | Aspose.3D はアニメーション階層をサポートし、各アニメーションは複数のアニメーションとアニメーションのキーフレーム定義で構成できます。AnimationNode は時間経過に伴うプロパティ値の変換を定義します。例えば、animation node はノードの変換や他の A3DObject オブジェクトの数値プロパティを制御するために使用できます。 |
+| [ArbitraryProfile](../aspose.threed/arbitraryprofile) | このクラスを使用すると、任意の曲線から直接 2D プロファイルを構築できます。 |
+| [AssetInfo](../aspose.threed/assetinfo) | アセット情報。アセット情報は Scene に添付できます。子シーンは独自の AssetInfo を持ち、親の定義を上書きできます。 |
+| [BindPoint](../aspose.threed/bindpoint) | BindPoint は通常、オブジェクトのプロパティ上に作成されます。一部のプロパティ型は複数のコンポーネントフィールド（Vector3 フィールドなど）を含み、BindPoint は各コンポーネントフィールドに対してチャネルを生成し、チャネルを介してフィールドを 1 つ以上のキー フレーム シーケンス インスタンスに接続します。 |
+| [Bone](../aspose.threed/bone) | ボーンはジオメトリのコントロールポイントのサブセットを定義し、各コントロールポイントにブレンドウェイトを設定します。Bone オブジェクトは直接使用できず、SkinDeformer インスタンスがジオメトリを変形させます。SkinDeformer には複数のボーンが含まれ、各ボーンはノードにリンクされています。NOTE: ジオメトリのコントロールポイントは複数の Bones にバインドできる場合があります。 |
+| [BonePose](../aspose.threed/bonepose) | BonePose はボーンノードの変換行列を含みます。 |
+| [BoundingBox](../aspose.threed/boundingbox) | 軸整列バウンディングボックス |
+| [BoundingBox2D](../aspose.threed/boundingbox2d) | Vector2 の軸整列バウンディングボックス |
+| [Box](../aspose.threed/box) | ボックス。 |
+| [Camera](../aspose.threed/camera) | カメラはシーンを見る視聴者の視点（アイポイント）を表します。 |
+| [Circle](../aspose.threed/circle) | 円曲線は円形のエッジ上の点の集合で構成されます。 |
+| [CircleShape](../aspose.threed/circleshape) | IFC 互換の円形プロファイルで、LinearExtrusion によってメッシュを構築するために使用できます。 |
+| [ColladaSaveOptions](../aspose.threed/colladasaveoptions) | collada の保存オプション |
+| [CompositeCurve](../aspose.threed/compositecurve) | CompositeCurve は複数の曲線セグメントで構成されています。 |
+| [CShape](../aspose.threed/cshape) | IFC 互換の C 形状プロファイルはパラメータで定義されます。 プロファイルの中心位置はバウンディングボックスの中心にあります。 |
+| [Curve](../aspose.threed/curve) | すべての曲線実装の基底クラスです。  @hideconstructor |
+| [CustomObject](../aspose.threed/customobject) | 3D ファイルで使用されるメタデータまたはカスタムオブジェクトはこのクラスで管理されます。 すべてのカスタムプロパティは動的プロパティとして保存されます。 |
+| [Cylinder](../aspose.threed/cylinder) | パラメータ化されたシリンダーです。 radiusTop または radiusBottom のいずれかがゼロの場合、円錐を表すためにも使用できます。 |
+| [Deformer](../aspose.threed/deformer) | SkinDeformer と MorphTargetDeformer の基底クラス |
+| [DescriptorSetUpdater](../aspose.threed/descriptorsetupdater) | このクラスはチェーン操作で com.aspose.threed.IDescriptorSet を更新できるようにします。  @hideconstructor |
+| [Discreet3dsLoadOptions](../aspose.threed/discreet3dsloadoptions) | 3DS ファイルの読み込みオプションです。 |
+| [Discreet3dsSaveOptions](../aspose.threed/discreet3dssaveoptions) | 3DS ファイルの保存オプションです。 |
+| [Dish](../aspose.threed/dish) | パラメータ化されたディッシュです。 |
+| [DracoFormat](../aspose.threed/dracoformat) | Google Draco フォーマット  @hideconstructor |
+| [DracoSaveOptions](../aspose.threed/dracosaveoptions) | Google Draco ファイルの保存オプション |
+| [DriverException](../aspose.threed/driverexception) | 内部レンダリングドライバーによって発生する例外です。  @hideconstructor |
+| [DummyFileSystem](../aspose.threed/dummyfilesystem) | 読み取り/書き込み操作はダミー操作です。 |
+| [Ellipse](../aspose.threed/ellipse) | 楕円は楕円形を形成する点の集合を定義します。 |
+| [EllipseShape](../aspose.threed/ellipseshape) | IFC 互換の楕円形はパラメータで定義されます。 プロファイルの中心位置はバウンディングボックスの中心にあります。 |
+| [EndPoint](../aspose.threed/endpoint) | 曲線をトリムする終点は、パラメータ値またはデカルト座標点のいずれかです。 |
+| [Entity](../aspose.threed/entity) | すべてのエンティティの基底クラスです。 エンティティは Light/Geometry のようなノードの下に付随する具体的なオブジェクトを表します。 |
+| [EntityRenderer](../aspose.threed/entityrenderer) | これをサブクラス化して、さまざまな種類のエンティティのレンダリングを実装します。 |
+| [EntityRendererKey](../aspose.threed/entityrendererkey) | 登録されたエンティティレンダラーのキー |
+| [ExportException](../aspose.threed/exportexception) | Aspose.3D がシーンをファイルにエクスポートできなかったときの例外 |
+| [Extrapolation](../aspose.threed/extrapolation) | 外挿は、サンプリングされた値が最初と最後のキーフレームで定義された範囲外にある場合の処理方法を定義します。  @hideconstructor |
+| [FbxLoadOptions](../aspose.threed/fbxloadoptions) | Fbx フォーマットの読み込みオプションです。 |
+| [FbxSaveOptions](../aspose.threed/fbxsaveoptions) | Fbx ファイルの保存オプションです。 |
+| [FileFormat](../aspose.threed/fileformat) | ファイル形式の定義  @hideconstructor |
+| [FileFormatType](../aspose.threed/fileformattype) | ファイル形式のタイプ  @hideconstructor |
+| [FileSystem](../aspose.threed/filesystem) | ファイルシステムのカプセル化。Aspose.3D はこれを使用して依存関係の読み書きを行います。  @hideconstructor |
+| [FMatrix4](../aspose.threed/fmatrix4) | すべての要素が float 型の 4x4 行列 |
+| [FontFile](../aspose.threed/fontfile) | フォントファイルにはグリフの定義が含まれており、テキストプロファイルの作成に使用されます。  @hideconstructor |
+| [Frustum](../aspose.threed/frustum) | Camera と Light の基底クラス  @hideconstructor |
+| [FVector2](../aspose.threed/fvector2) | 2 要素の float ベクトルです。 |
+| [FVector3](../aspose.threed/fvector3) | 3 要素の float ベクトルです。 |
+| [FVector4](../aspose.threed/fvector4) | 4 要素の float ベクトルです。 |
+| [Geometry](../aspose.threed/geometry) | すべてのレンダリング可能な幾何オブジェクト（Mesh、NurbsSurface、Patch など）の基底クラスです。Geometry 基底クラスは以下をサポートします：制御点の管理、制御点はジオメトリの基本的な 3D 空間構造を定義し、ジオメトリの種類に応じて具体的な 3D モデルの定義方法が異なります。頂点要素の定義、頂点要素は法線や UV 座標、頂点カラーなどの追加情報をジオメトリに適用します。詳細は VertexElement を参照してください。オブジェクトの変形、Deformer を結合してジオメトリの形状をアニメーション化できます。 |
+| [GlobalTransform](../aspose.threed/globaltransform) | Global transform は Transform と似ていますが、最終的に評価された変換を表すため不変です。グローバルトランスフォームの評価には右手座標系が使用されます。  @hideconstructor |
+| [GLSLSource](../aspose.threed/glslsource) | GLSL のシェーダーのソースコード |
+| [GltfLoadOptions](../aspose.threed/gltfloadoptions) | glTF 形式のロードオプション |
+| [GltfSaveOptions](../aspose.threed/gltfsaveoptions) | glTF 形式の保存オプションです。 |
+| [HollowCircleShape](../aspose.threed/hollowcircleshape) | IFC 互換の中空円形プロファイルです。 |
+| [HollowRectangleShape](../aspose.threed/hollowrectangleshape) | IFC 互換の中空長方形形状で、内側と外側の角が丸められています。 |
+| [HShape](../aspose.threed/hshape) | HShape は 'H' または 'I' 形状の定義パラメータを提供します。 |
+| [Html5SaveOptions](../aspose.threed/html5saveoptions) | HTML5 の保存オプション |
+| [ImageRenderOptions](../aspose.threed/imagerenderoptions) | Scene.render(com.aspose.threed.Camera, java.lang.String, com.aspose.threed.Vector2, java.lang.String, com.aspose.threed.ImageRenderOptions) および Scene.render(com.aspose.threed.Camera, com.aspose.threed.TextureData, com.aspose.threed.ImageRenderOptions) のオプション |
+| [ImportException](../aspose.threed/importexception) | Aspose.3D が指定されたソースのオープンに失敗したときの例外 |
+| [InitializationException](../aspose.threed/initializationexception) | レンダーパイプライン初期化時の例外 |
+| [IOConfig](../aspose.threed/ioconfig) | シリアライズ/デシリアライズ用の IO 設定です。ユーザーは依存関係の検索パスなどの詳細設定や、ここでフォーマット関連の設定を指定できます。  @hideconstructor |
+| [IOUtils](../aspose.threed/ioutils) | 行列/ベクトルを書き込むためのユーティリティ（バイナリライター用）  @hideconstructor |
+| [KeyFrame](../aspose.threed/keyframe) | キーフレームは主に時間と値で定義され、いくつかの補間タイプでは接線/テンション/バイアス/連続性が最終的なサンプル値の計算に使用されます。キーフレーム以外の時間位置のサンプル値は、前後のキーフレーム間で補間されます。最初または最後のキーフレームの前後の値は Extrapolation クラスによって計算されます。 |
+| [KeyframeSequence](../aspose.threed/keyframesequence) | キーフレームのシーケンスで、サンプル値が時間とともに変化する様子を記述します。 |
+| [LambertMaterial](../aspose.threed/lambertmaterial) | Lambertシェーディングモデル用のマテリアル |
+| [License](../aspose.threed/license) | コンポーネントのライセンスを取得するためのメソッドを提供します。 |
+| [Light](../aspose.threed/light) | 光はシーンを照らします。光の総減衰を計算する式は次のとおりです:  A = ConstantAttenuation + (Dist  LinearAttenuation) + ((Dist^2)  QuadraticAttenuation) |
+| [Line](../aspose.threed/line) | ポリラインは Geometry.ControlPoints で定義された点の集合で構成され、Segments によって接続されたパスです。つまり、接続された線分の集合とも言えます。ラインは通常線形オブジェクトであり、曲線を表すことはできません。曲線を表現するには NurbsCurve を使用します。 |
+| [LinearExtrusion](../aspose.threed/linearextrusion) | 線形押し出しは 2D 形状を入力として受け取り、形状を第3次元に拡張します。 |
+| [LoadOptions](../aspose.threed/loadoptions) | さまざまなタイプのファイル読み込みオプションを構成するための基底クラスです @hideconstructor |
+| [LocalFileSystem](../aspose.threed/localfilesystem) | LocalFileSystem は読み書き操作をローカルディレクトリにマップします。 |
+| [LShape](../aspose.threed/lshape) | パラメータで定義された IFC 互換の L 形プロファイルです。 |
+| [Material](../aspose.threed/material) | Material はジオメトリの視覚的外観に必要なパラメータを定義します。Aspose.3D は LambertMaterial、PhongMaterial、ShaderMaterial のシェーディングモデルを提供します @hideconstructor |
+| [MathUtils](../aspose.threed/mathutils) | 便利な数学ユーティリティのセットです @hideconstructor |
+| [Matrix4](../aspose.threed/matrix4) | 4x4 行列の実装です。 |
+| [MemoryFileSystem](../aspose.threed/memoryfilesystem) | MemoryFileSystem は読み書き操作をメモリにマップします。 |
+| [Mesh](../aspose.threed/mesh) | メッシュは多数の n 辺ポリゴンで構成されています。 |
+| [Metered](../aspose.threed/metered) | メータ付きキーを設定するためのメソッドを提供します。 |
+| [MirroredProfile](../aspose.threed/mirroredprofile) | IFC 互換のミラープロファイルです。このプロファイルは、ベースプロファイルを y 軸で鏡像化することで新しいプロファイルを定義します。 |
+| [MorphTargetChannel](../aspose.threed/morphtargetchannel) | MorphTargetChannel は MorphTargetDeformer によってターゲットジオメトリを整理するために使用されます。FBX のような一部のファイル形式は複数のチャネルを同時にサポートします。ウェイトは 0 から 1.0 の範囲で、ターゲットのデフォルトウェイトは 0.0 です； |
+| [MorphTargetDeformer](../aspose.threed/morphtargetdeformer) | MorphTargetDeformer は頂点単位のアニメーションを提供します。MorphTargetDeformer はすべてのターゲットを MorphTargetChannel を介して整理し、各チャネルは複数のターゲットを管理できます。モーフターゲットデフォーマーの一般的な使用例は、キャラクターに表情を適用することです。詳細は https://en.wikipedia.org/wiki/Morph_target_animation にあります。 |
+| [Node](../aspose.threed/node) | シーングラフ内の要素を表します。シーングラフは Node オブジェクトのツリーです。ツリー管理サービスはこのクラスに自己完結しています。Aspose.3D SDK は構築されたシーングラフの有効性を検証しないことに注意してください。呼び出し側の責任で、ノード階層に循環グラフが生成されないようにする必要があります。ツリー管理に加えて、このクラスはシーン内のオブジェクトの位置を記述するために必要なすべてのプロパティを定義します。この情報には基本的な Translation、Rotation、Scaling プロパティと、ピボット、リミット、IK ジョイント属性（剛性や減衰など）の高度なオプションが含まれます。最初に作成されたとき、Node オブジェクトは "empty"（つまり、位置情報のみを保持し、グラフィカルな表現を持たないオブジェクト）です。この状態では、ノードツリー構造の親を表すために使用できますが、それ以上の用途はほとんどありません。この種のオブジェクトの通常の使用方法は、ノードを専門化するエンティティ（"Entity"参照）を追加することです。エンティティはそれ自体がオブジェクトであり、Node に接続されます。これは、同じエンティティを複数のノードで共有できることも意味します。Camera、Light、Mesh などはすべてエンティティであり、すべて基底クラス Entity から派生しています。 |
+| [NurbsCurve](../aspose.threed/nurbscurve) | NURBS 曲線は NURBS（Non-uniform rational basis spline）で表現される曲線です。NURBS 曲線はその Order、重み付き Geometry.ControlPoints の集合、そして KnotVectors によって定義されます。制御点の w 成分は制御点の重みとして使用され、CurveDimension.TWO_DIMENSIONAL であろうと CurveDimension.THREE_DIMENSIONAL であろうと同様です。 |
+| [NurbsDirection](../aspose.threed/nurbsdirection) | 3D NurbsSurface には 2 つの方向、NurbsSurface.U と NurbsSurface.V があり、NurbsDirection は各方向のデータを定義します。方向は実際には NURBS 曲線であり、Order、KnotVectors、そして NurbsSurface で定義された重み付き制御点の集合によっても定義されます。 |
+| [NurbsSurface](../aspose.threed/nurbssurface) | NurbsSurface は NURBS（Non-uniform rational basis spline）で表現されるサーフェスです。NurbsSurface は 2 つの NurbsDirectionU と V によって定義されます。制御点の w 成分は、方向のタイプが CurveDimension.TWO_DIMENSIONAL であろうと CurveDimension.THREE_DIMENSIONAL であろうと、制御点の重みとして使用されます。 |
+| [ObjLoadOptions](../aspose.threed/objloadoptions) | Wavefront OBJ のロードオプション |
+| [ObjSaveOptions](../aspose.threed/objsaveoptions) | Wavefront OBJ ファイルの保存オプション |
+| [ParameterizedProfile](../aspose.threed/parameterizedprofile) | すべてのパラメトリックプロファイルの基底クラスです @hideconstructor |
+| [ParseException](../aspose.threed/parseexception) | Aspose.3D が入力の解析に失敗したときの例外です。 |
+| [Patch](../aspose.threed/patch) | Patchはパラメトリックモデリングサーフェスで、NurbsSurfaceに似ており、UとVという2つのPatchDirectionで定義されます。ただし、PatchとNurbsSurfaceの違いは、PatchDirection曲線がPatchDirectionType.BEZIER、PatchDirectionType.QUADRATIC_BEZIER、PatchDirectionType.BASIS_SPLINE、PatchDirectionType.CARDINAL_SPLINE、PatchDirectionType.LINEARのいずれかになり得ることです。 |
+| [PatchDirection](../aspose.threed/patchdirection) | PatchのU方向とV方向。 |
+| [PbrMaterial](../aspose.threed/pbrmaterial) | アルベドカラー/メタリック/ラフネスに基づく物理ベースレンダリング用マテリアル |
+| [PbrSpecularMaterial](../aspose.threed/pbrspecularmaterial) | 拡散カラー/スペキュラ/光沢に基づく物理ベースレンダリング用マテリアル |
+| [PdfFormat](../aspose.threed/pdfformat) | AdobeのPortable Document Format  @hideconstructor |
+| [PdfLoadOptions](../aspose.threed/pdfloadoptions) | PDF読み込み用オプション |
+| [PdfSaveOptions](../aspose.threed/pdfsaveoptions) | PDFエクスポート時の保存オプション。 |
+| [PhongMaterial](../aspose.threed/phongmaterial) | Blinn-Phongシェーディングモデル用マテリアル。 |
+| [PixelMapping](../aspose.threed/pixelmapping) | @hideconstructor |
+| [Plane](../aspose.threed/plane) | パラメトリック平面。 |
+| [PlyFormat](../aspose.threed/plyformat) | PLY形式。  @hideconstructor |
+| [PlyLoadOptions](../aspose.threed/plyloadoptions) | PLYファイルの読み込みオプション |
+| [PlySaveOptions](../aspose.threed/plysaveoptions) | シーンをPLYファイルとしてエクスポートする際の保存オプション。 |
+| [PointCloud](../aspose.threed/pointcloud) | ポイントクラウドはトポロジ情報を持たず、制御点と頂点要素のみを含みます。 |
+| [PolygonBuilder](../aspose.threed/polygonbuilder) | Mesh用ポリゴンを構築するヘルパークラス |
+| [PolygonModifier](../aspose.threed/polygonmodifier) | ポリゴンを変更するユーティリティ  @hideconstructor |
+| [Pose](../aspose.threed/pose) | ジオメトリがスキンされているときに変換行列を保存するために使用されるポーズです。ポーズはBonePoseの集合で、各BonePoseはボーンノードの具体的な変換情報を保存します。 |
+| [PostProcessing](../aspose.threed/postprocessing) | ポストプロセッシングエフェクト  @hideconstructor |
+| [Primitive](../aspose.threed/primitive) | すべてのプリミティブの基底クラス |
+| [Profile](../aspose.threed/profile) | xy平面上の2Dプロファイル  @hideconstructor |
+| [Property](../aspose.threed/property) | ユーザー定義プロパティを保持するクラス。  @hideconstructor |
+| [PropertyCollection](../aspose.threed/propertycollection) | プロパティのコレクション  @hideconstructor |
+| [PushConstant](../aspose.threed/pushconstant) | プッシュ定数を介してシェーダーにデータを提供するユーティリティ。 |
+| [Pyramid](../aspose.threed/pyramid) | パラメトリックピラミッド。 |
+| [Quaternion](../aspose.threed/quaternion) | Quaternionはコンピュータグラフィックスで回転を実行するために通常使用されます。 |
+| [Rect](../aspose.threed/rect) | 矩形を表すクラス |
+| [RectangleShape](../aspose.threed/rectangleshape) | IFC 互換の角が丸められた矩形形状。 |
+| [RectangularTorus](../aspose.threed/rectangulartorus) | パラメータ化された矩形トーラス。 |
+| [RelativeRectangle](../aspose.threed/relativerectangle) | 相対矩形  相対コンポーネントと絶対値の間の式は:  Scale  (Reference Width) + offset  したがって、絶対値を表したい場合は、すべてのスケールフィールドをゼロにし、代わりにオフセットフィールドを使用してください。 |
+| [Renderer](../aspose.threed/renderer) | レンダラーに関するコンテキスト。  @hideconstructor |
+| [RendererVariableManager](../aspose.threed/renderervariablemanager) | このクラスはレンダリングで使用される変数を管理します  @hideconstructor |
+| [RenderFactory](../aspose.threed/renderfactory) | RenderFactory はレンダリングパイプラインで表現されるすべてのリソースを作成します。  @hideconstructor |
+| [RenderParameters](../aspose.threed/renderparameters) | レンダーターゲットのパラメータを記述します |
+| [RenderResource](../aspose.threed/renderresource) | すべてのレンダーリソースの抽象クラス  レンダラーが解放されると、すべてのレンダーリソースは破棄されます。  Mesh/Texture のようなクラスは対応する RenderResource を持ちます。  @hideconstructor |
+| [RenderState](../aspose.threed/renderstate) | パイプライン構築用のレンダー状態  レンダー状態に加えた変更は、作成されたパイプラインインスタンスに影響しません。 |
+| [RevolvedAreaSolid](../aspose.threed/revolvedareasolid) | このクラスは、プロファイルで提供された断面を軸の周りに回転させることで、ソリッドモデルを表現します。 |
+| [RvmFormat](../aspose.threed/rvmformat) | RVM フォーマット  @hideconstructor |
+| [RvmLoadOptions](../aspose.threed/rvmloadoptions) | AVEVA Plant Design Management System の RVM ファイルのロードオプション。 |
+| [RvmSaveOptions](../aspose.threed/rvmsaveoptions) | Aveva PDMS RVM ファイルの保存オプション。 |
+| [SaveOptions](../aspose.threed/saveoptions) | さまざまなタイプのファイル保存オプションを構成するための基底クラス  @hideconstructor |
+| [Scene](../aspose.threed/scene) | シーンは、ノード、ジオメトリ、マテリアル、テクスチャ、アニメーション、ポーズ、サブシーンなどを含むトップレベルオブジェクトです。シーンはサブシーンを持つことができ、collada/blender/fbx などのファイルにおけるマルチドキュメントサポートとして機能します。ノード階層は RootNodeLibrary を通じてアクセスでき、シリアライズ中（メタデータやカスタムオブジェクトなど）に未接続オブジェクトへの参照を保持するために使用され、ライブラリとして利用できます。 |
+| [SceneObject](../aspose.threed/sceneobject) | シーン内に格納されるオブジェクトのルートクラスです。 |
+| [ShaderException](../aspose.threed/shaderexception) | シェーダー関連の例外 |
+| [ShaderMaterial](../aspose.threed/shadermaterial) | シェーダーマテリアルは、外部のレンダリングエンジンまたはシェーダー言語でマテリアルを記述できるようにします。ShaderMaterial は ShaderTechnique を使用して具体的なレンダリング詳細を記述し、最終的なレンダリングプラットフォームに応じて最適なものが使用されます。例えば、ShaderMaterial インスタンスは 2 つのテクニックを持つことができ、1 つは HLSL で定義され、もう 1 つは GLSL で定義されます。ウィンドウ以外のプラットフォームでは、GLSL を使用すべきです。 |
+| [ShaderProgram](../aspose.threed/shaderprogram) | シェーダープログラム  @hideconstructor |
+| [ShaderSet](../aspose.threed/shaderset) | 各種マテリアル用のシェーダープログラム |
+| [ShaderSource](../aspose.threed/shadersource) | シェーダーのソースコード  @hideconstructor |
+| [ShaderTechnique](../aspose.threed/shadertechnique) | シェーダーテクニックは具体的なレンダリング実装を表します。 |
+| [ShaderVariable](../aspose.threed/shadervariable) | シェーダー変数 |
+| [Shape](../aspose.threed/shape) | シェイプは制御点の集合に対する変形を記述し、Maya のクラスターデフォーマーに似ています。例えば、作成したジオメトリにシェイプを追加できます。シェイプとジオメトリは同じトポロジ情報を持ちますが、制御点の位置が異なります。影響度の違いにより、ジオメトリは変形効果を実行します。 |
+| [Skeleton](../aspose.threed/skeleton) | Skeletonは主にCADソフトウェアで使用され、設計者が骨格構造の変換を操作できるようにしますが、CADソフトウェア外では通常役に立ちません。Skeleton階層をCADソフトウェア内で1つのオブジェクトとして機能させるには、上位SkeletonノードをTypeをSkeletonType.SKELETONに設定してルートとしてマークし、すべての子ノードをSkeletonType.BONEに設定する必要があります。 |
+| [SkinDeformer](../aspose.threed/skindeformer) | スキンデフォーマーは複数のボーンを含み、各ボーンはコントロールポイントのウェイトによってジオメトリの一部をブレンドします。 |
+| [Sphere](../aspose.threed/sphere) | パラメータ化された球体。 |
+| [SPIRVSource](../aspose.threed/spirvsource) | SPIR-V形式のコンパイル済みシェーダー。 |
+| [StencilState](../aspose.threed/stencilstate) | 面ごとのステンシルステート。  @hideconstructor |
+| [StlLoadOptions](../aspose.threed/stlloadoptions) | STLのロードオプション |
+| [StlSaveOptions](../aspose.threed/stlsaveoptions) | STLの保存オプション |
+| [SweptAreaSolid](../aspose.threed/sweptareasolid) | SweptAreaSolidはプロファイルを導軌に沿って掃引することでジオメトリを構築します。 |
+| [Text](../aspose.threed/text) | テキストプロファイル。このプロファイルはフォントとテキストを使用して輪郭を記述します。 |
+| [Texture](../aspose.threed/texture) | このクラスは外部ファイルからテクスチャを定義します。 |
+| [TextureBase](../aspose.threed/texturebase) | すべての具体的なテクスチャの基底クラス。Textureはジオメトリ表面の外観と質感を定義します。 |
+| [TextureCodec](../aspose.threed/texturecodec) | テクスチャのエンコーダーとデコーダーを管理するクラス。 |
+| [TextureData](../aspose.threed/texturedata) | このクラスはテクスチャの生データとフォーマット定義を含みます。 |
+| [TextureSlot](../aspose.threed/textureslot) | Material内のテクスチャスロットで、マテリアルインスタンスを通じて列挙可能です。  @hideconstructor |
+| [Torus](../aspose.threed/torus) | パラメータ化されたトーラス。 |
+| [Transform](../aspose.threed/transform) | 変換はオブジェクトの平行移動/スケール/回転または変換行列へのアクセスを最小コストで可能にする情報を含みます。これはローカル変換で使用されます。  @hideconstructor |
+| [TransformBuilder](../aspose.threed/transformbuilder) | TransformBuilderは変換のチェーンによって変換行列を構築するために使用されます。 |
+| [TransformedCurve](../aspose.threed/transformedcurve) | TransformedCurveは変換行列を使用して曲線に配置を与えます。これによりTrimmedCurveやCompositeCurve内で変換を実行できます。 |
+| [TrapeziumShape](../aspose.threed/trapeziumshape) | パラメータで定義されたIFC互換の台形形状。 |
+| [TrialException](../aspose.threed/trialexception) | Scene.Open/Scene.Saveでライセンスが適用されていない場合にこの例外が発生します。SuppressTrialExceptionをtrueに設定することでこの例外を無効にできます。 |
+| [TriMesh](../aspose.threed/trimesh) | TriMeshはGPUが直接使用できる生データを含みます。このクラスは頂点ごとのデータのみを含むメッシュの構築を支援するユーティリティです。 |
+| [TrimmedCurve](../aspose.threed/trimmedcurve) | 両端で基底曲線をトリムした有界曲線。 |
+| [TShape](../aspose.threed/tshape) | パラメータで定義されたIFC互換のT字形状。 |
+| [U3dLoadOptions](../aspose.threed/u3dloadoptions) | ユニバーサル3Dのロードオプション |
+| [U3dSaveOptions](../aspose.threed/u3dsaveoptions) | ユニバーサル3Dの保存オプション |
+| [UsdSaveOptions](../aspose.threed/usdsaveoptions) | USD/USDZ フォーマットの保存オプション。 |
+| [UShape](../aspose.threed/ushape) | IFC 互換の U 形状がパラメータで定義されました。 |
+| [Vector2](../aspose.threed/vector2) | 2 つの成分を持つベクトル。 |
+| [Vector3](../aspose.threed/vector3) | 3 つの成分を持つベクトル。 |
+| [Vector4](../aspose.threed/vector4) | 4 つの成分を持つベクトル。 |
+| [Vertex](../aspose.threed/vertex) | TriMesh の生の頂点にアクセスするために使用される頂点参照。  @hideconstructor |
+| [VertexDeclaration](../aspose.threed/vertexdeclaration) | カスタム定義された頂点構造の宣言 |
+| [VertexElement](../aspose.threed/vertexelement) | 頂点要素の基底クラス。頂点要素のタイプは VertexElementType によって識別されます。VertexElement は頂点要素がジオメトリ表面にどのようにマッピングされ、マッピング情報がメモリ上でどのように配置されるかを記述します。VertexElement は Normals、UVs、またはその他の情報を含みます。  @hideconstructor |
+| [VertexElementBinormal](../aspose.threed/vertexelementbinormal) | 指定された成分の従法線ベクトルを定義します。 |
+| [VertexElementDoublesTemplate](../aspose.threed/vertexelementdoublestemplate) | 具体的な VertexElement 実装を定義するためのヘルパークラス。  @hideconstructor |
+| [VertexElementEdgeCrease](../aspose.threed/vertexelementedgecrease) | 指定された成分のエッジクレーズを定義します |
+| [VertexElementHole](../aspose.threed/vertexelementhole) | 指定されたポリゴンが穴であるかどうかを定義します |
+| [VertexElementIntsTemplate](../aspose.threed/vertexelementintstemplate) | 具体的な VertexElement 実装を定義するためのヘルパークラス。  @hideconstructor |
+| [VertexElementMaterial](../aspose.threed/vertexelementmaterial) | 指定された成分のマテリアルインデックスを定義します。ノードは複数のマテリアルを持つことができ、VertexElementMaterial はジオメトリの異なる部分を異なるマテリアルでレンダリングするために使用されます。 |
+| [VertexElementNormal](../aspose.threed/vertexelementnormal) | 指定された成分の法線ベクトルを定義します。 |
+| [VertexElementPolygonGroup](../aspose.threed/vertexelementpolygongroup) | 指定された成分のポリゴングループを定義し、関連するポリゴンをまとめます。 |
+| [VertexElementSmoothingGroup](../aspose.threed/vertexelementsmoothinggroup) | スムージンググループは、滑らかな表面を形成するように見えるポリゴンメッシュ内のポリゴンの集合です。DOS 用 3D Studio Max のような初期の 3D モデリングソフトウェアは、各メッシュ頂点の法線ベクトルの保存を回避するためにスムージンググループを使用していました。 |
+| [VertexElementSpecular](../aspose.threed/vertexelementspecular) | 指定された成分の鏡面色を定義します。 |
+| [VertexElementTangent](../aspose.threed/vertexelementtangent) | 指定された成分の接線ベクトルを定義します。 |
+| [VertexElementUserData](../aspose.threed/vertexelementuserdata) | 指定された成分のカスタムユーザーデータを定義します。通常、これは特定の目的のためのアプリケーション固有データです。 |
+| [VertexElementUV](../aspose.threed/vertexelementuv) | 指定された成分の UV 座標を定義します。ジオメトリは複数の VertexElementUV 要素を持つことができ、各要素は異なる TextureMappings を持ちます。 |
+| [VertexElementVector4](../aspose.threed/vertexelementvector4) | 具体的な VertexElement 実装を定義するためのヘルパークラス。  @hideconstructor |
+| [VertexElementVertexColor](../aspose.threed/vertexelementvertexcolor) | 指定された成分の頂点カラーを定義します |
+| [VertexElementVertexCrease](../aspose.threed/vertexelementvertexcrease) | 指定された成分の頂点クレーズを定義します |
+| [VertexElementVisibility](../aspose.threed/vertexelementvisibility) | 指定された成分が表示されるかどうかを定義します |
+| [VertexElementWeight](../aspose.threed/vertexelementweight) | 指定された成分のブレンドウェイトを定義します。 |
+| [VertexField](../aspose.threed/vertexfield) | 頂点のフィールドメモリレイアウトの説明。  @hideconstructor |
+| [Viewport](../aspose.threed/viewport) | com.aspose.threed.IRenderTarget はシーンをレンダリングするためのビューポートを少なくとも 1 つ含みます。  @hideconstructor |
+| [Watermark](../aspose.threed/watermark) | メッシュへの/からブラインドウォーターマークをエンコード/デコードするユーティリティです。  @hideconstructor |
+| [WindowHandle](../aspose.threed/windowhandle) | 異なるプラットフォーム用にカプセル化されたウィンドウハンドルです。  @hideconstructor |
+| [XLoadOptions](../aspose.threed/xloadoptions) | DirectX X ファイルのロードオプションです。 |
+| [ZipArchiveFileSystem](../aspose.threed/ziparchivefilesystem) | 指定された zip ファイルまたは zip ストリームへの読み取り専用アクセスを提供するファイルシステムです。ファイルシステムは開く/保存する操作の後に破棄されます。 |
+| [ZShape](../aspose.threed/zshape) | パラメータで定義された IFC 互換の Z 形状プロファイルです。 |
+| [CubeFace](../aspose.threed/cubeface) | 定数を含むユーティリティクラスです。キューブマップテクスチャの各面  @hideconstructor |
+| [IndexDataType](../aspose.threed/indexdatatype) | 定数を含むユーティリティクラスです。com.aspose.threed.IIndexBuffer の要素のデータ型  @hideconstructor |

--- a/japanese/nodejs-java/aspose.threed/a3dobject/_index.md
+++ b/japanese/nodejs-java/aspose.threed/a3dobject/_index.md
@@ -1,0 +1,183 @@
+---
+title: "A3DObject"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/a3dobject/
+---
+## A3DObject class
+
+すべての Aspose.ThreeD オブジェクトの基底クラスで、すべてのサブクラスは動的プロパティをサポートします。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor(name) | A3DObject クラスの新しいインスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| name | 文字列 | 名前 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload() | 名前なしで A3DObject クラスの新しいインスタンスを初期化します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/a3dwsaveoptions/_index.md
+++ b/japanese/nodejs-java/aspose.threed/a3dwsaveoptions/_index.md
@@ -1,0 +1,198 @@
+---
+title: "A3dwSaveOptions"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/a3dwsaveoptions/
+---
+## A3dwSaveOptions class
+
+A3DW フォーマットの保存オプション。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | A3dwSaveOptions のコンストラクタ |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportMetaData{#getExportMetaData}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExportMetaData() | シーン/ノードに関連付けられたメタデータをクライアントにエクスポートします。デフォルト値は true です |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportMetaData{#setExportMetaData}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExportMetaData(value) | シーン/ノードに関連付けられたメタデータをクライアントにエクスポートします。デフォルト値は true です |
+
+ **Result:**
+
+
+
+---
+
+
+### getMetaDataPrefix{#getMetaDataPrefix}
+
+| 名前 | 説明 |
+| --- | --- |
+| getMetaDataPrefix() | このプロパティが null でない場合、プレフィックスで始まる Scene/Node のプロパティのみがエクスポートされ、プレフィックスは削除されます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setMetaDataPrefix{#setMetaDataPrefix}
+
+| 名前 | 説明 |
+| --- | --- |
+| setMetaDataPrefix(value) | このプロパティが null でない場合、プレフィックスで始まる Scene/Node のプロパティのみがエクスポートされ、プレフィックスは削除されます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportTextures{#getExportTextures}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExportTextures() | シーンで使用されているテクスチャを出力ディレクトリにコピーしようとします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextures{#setExportTextures}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExportTextures(value) | シーンで使用されているテクスチャを出力ディレクトリにコピーしようとします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileFormat() | 現在の保存/読み込みオプションで指定されたファイル形式を取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEncoding() | テキストベースのファイルのデフォルトエンコーディングを取得または設定します。デフォルト値は null で、インポーター/エクスポーターが使用するエンコーディングを決定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileSystem() | ロード/セーブ時に外部依存関係を管理する方法をユーザーが処理できるようにします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFileSystem(value) | ロード/セーブ時に外部依存関係を管理する方法をユーザーが処理できるようにします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| 名前 | 説明 |
+| --- | --- |
+| getLookupPaths() | OBJ のような一部のファイルは外部ファイルに依存しており、検索パスにより Aspose.3D が外部ファイルを探してロードできるようになります。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileName() | エクスポート/インポートシーンのファイル名です。これはオプションですが、OBJ のマテリアルなど外部アセットをシリアライズする際に便利です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFileName(value) | エクスポート/インポートシーンのファイル名です。これはオプションですが、OBJ のマテリアルなど外部アセットをシリアライズする際に便利です。 |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/amfsaveoptions/_index.md
+++ b/japanese/nodejs-java/aspose.threed/amfsaveoptions/_index.md
@@ -1,0 +1,172 @@
+---
+title: "AmfSaveOptions"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/amfsaveoptions/
+---
+## AmfSaveOptions class
+
+AMF の保存オプション
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | AmfSaveOptions のコンストラクタ |
+
+ **Result:**
+
+
+
+---
+
+
+### getEnableCompression{#getEnableCompression}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEnableCompression() | 最終ファイルサイズを削減するために圧縮を使用するかどうか。デフォルト値は true です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setEnableCompression{#setEnableCompression}
+
+| 名前 | 説明 |
+| --- | --- |
+| setEnableCompression(value) | 最終ファイルサイズを削減するために圧縮を使用するかどうか。デフォルト値は true です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportTextures{#getExportTextures}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExportTextures() | シーンで使用されているテクスチャを出力ディレクトリにコピーしようとします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextures{#setExportTextures}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExportTextures(value) | シーンで使用されているテクスチャを出力ディレクトリにコピーしようとします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileFormat() | 現在の保存/読み込みオプションで指定されたファイル形式を取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEncoding() | テキストベースのファイルのデフォルトエンコーディングを取得または設定します。デフォルト値は null で、インポーター/エクスポーターが使用するエンコーディングを決定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileSystem() | ロード/セーブ時に外部依存関係を管理する方法をユーザーが処理できるようにします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFileSystem(value) | ロード/セーブ時に外部依存関係を管理する方法をユーザーが処理できるようにします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| 名前 | 説明 |
+| --- | --- |
+| getLookupPaths() | OBJ のような一部のファイルは外部ファイルに依存しており、検索パスにより Aspose.3D が外部ファイルを探してロードできるようになります。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileName() | エクスポート/インポートシーンのファイル名です。これはオプションですが、OBJ のマテリアルなど外部アセットをシリアライズする際に便利です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFileName(value) | エクスポート/インポートシーンのファイル名です。これはオプションですが、OBJ のマテリアルなど外部アセットをシリアライズする際に便利です。 |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/animationchannel/_index.md
+++ b/japanese/nodejs-java/aspose.threed/animationchannel/_index.md
@@ -1,0 +1,113 @@
+---
+title: "AnimationChannel"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/animationchannel/
+---
+## AnimationChannel class
+
+チャネルはプロパティのコンポーネントフィールドをキー フレーム シーケンスのセットにマッピングします  @hideconstructor
+
+
+## メソッド
+
+### getComponentType{#getComponentType}
+
+| 名前 | 説明 |
+| --- | --- |
+| getComponentType() | コンポーネントフィールドの型を取得します |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | チャネルの名前を取得します |
+
+ **Result:**
+
+
+
+---
+
+
+### getDefaultValue{#getDefaultValue}
+
+| 名前 | 説明 |
+| --- | --- |
+| getDefaultValue() | チャネルの Default 値を取得または設定します。チャネルにキーフレームシーケンスが接続されていない場合、アニメーション評価中に Default 値が使用されます。実際のシナリオ: アニメーションがノードの x 座標のみをアニメートし、y と z が変更されない場合、完全な変換評価中に Default 値が使用されます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setDefaultValue{#setDefaultValue}
+
+| 名前 | 説明 |
+| --- | --- |
+| setDefaultValue(value) | チャネルの Default 値を取得または設定します。チャネルにキーフレームシーケンスが接続されていない場合、アニメーション評価中に Default 値が使用されます。実際のシナリオ: アニメーションがノードの x 座標のみをアニメートし、y と z が変更されない場合、完全な変換評価中に Default 値が使用されます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getKeyframeSequences{#getKeyframeSequences}
+
+| 名前 | 説明 |
+| --- | --- |
+| getKeyframeSequences() | このチャネル内のすべてのキーフレームシーケンスを取得します |
+
+ **Result:**
+
+
+
+---
+
+
+### addKeyframeSequence{#addKeyframeSequence}
+
+| 名前 | 説明 |
+| --- | --- |
+| addKeyframeSequence(sequence) | このチャネルにキーフレームシーケンスを追加します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| シーケンス | KeyframeSequence | 追加するキーフレームシーケンスです。 |
+
+ **Result:**
+
+
+
+---
+
+
+### iterator{#iterator}
+
+| 名前 | 説明 |
+| --- | --- |
+| iterator() | 内部使用のために予約されています。 |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/animationclip/_index.md
+++ b/japanese/nodejs-java/aspose.threed/animationclip/_index.md
@@ -1,0 +1,306 @@
+---
+title: "AnimationClip"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/animationclip/
+---
+## AnimationClip class
+
+Animation クリップはアニメーションのコレクションです。シーンは 1 つ以上のアニメーション クリップを持つことができます。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | AnimationClip クラスの新しいインスタンスを初期化します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload(name) | AnimationClip クラスの新しいインスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| name | 文字列 | 名前 |
+
+ **Result:**
+
+
+
+---
+
+
+### getAnimations{#getAnimations}
+
+| 名前 | 説明 |
+| --- | --- |
+| getAnimations() | クリップ内に含まれるアニメーションを取得します。レイヤー。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getDescription{#getDescription}
+
+| 名前 | 説明 |
+| --- | --- |
+| getDescription() | このアニメーションクリップの説明を取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setDescription{#setDescription}
+
+| 名前 | 説明 |
+| --- | --- |
+| setDescription(value) | このアニメーションクリップの説明を取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getStart{#getStart}
+
+| 名前 | 説明 |
+| --- | --- |
+| getStart() | クリップの開始時刻（秒）を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setStart{#setStart}
+
+| 名前 | 説明 |
+| --- | --- |
+| setStart(value) | クリップの開始時刻（秒）を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getStop{#getStop}
+
+| 名前 | 説明 |
+| --- | --- |
+| getStop() | クリップの終了時刻（秒）を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setStop{#setStop}
+
+| 名前 | 説明 |
+| --- | --- |
+| setStop(value) | クリップの終了時刻（秒）を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 名前 | 説明 |
+| --- | --- |
+| getScene() | このオブジェクトが属するシーンを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### createAnimationNode{#createAnimationNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| createAnimationNode(nodeName) | 現在のクリップ上でアニメーションノードを作成し登録するためのショートハンド関数です。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| nodeName | 文字列 | 新しいアニメーションノードの名前 |
+
+ **Result:**
+AnimationNode
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/animationnode/_index.md
+++ b/japanese/nodejs-java/aspose.threed/animationnode/_index.md
@@ -1,0 +1,312 @@
+---
+title: "AnimationNode"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/animationnode/
+---
+## AnimationNode class
+
+Aspose.3D はアニメーション階層をサポートし、各アニメーションは複数のアニメーションとアニメーションのキーフレーム定義で構成できます。AnimationNode は時間経過に伴うプロパティ値の変換を定義します。例えば、animation node はノードの変換や他の A3DObject オブジェクトの数値プロパティを制御するために使用できます。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor(name) | AnimationNode クラスの新しいインスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| name | 文字列 | 名前 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload() | AnimationNode クラスの新しいインスタンスを初期化します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getBindPoints{#getBindPoints}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBindPoints() | 現在のプロパティバインドポイントを取得します |
+
+ **Result:**
+
+
+
+---
+
+
+### getSubAnimations{#getSubAnimations}
+
+| 名前 | 説明 |
+| --- | --- |
+| getSubAnimations() | 現在のアニメーションの下にあるサブアニメーションノードを取得します |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### findBindPoint{#findBindPoint}
+
+| 名前 | 説明 |
+| --- | --- |
+| findBindPoint(name) | 名前でバインドポイントを検索します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| name | 文字列 | 検索するバインドポイントの名前。 |
+
+ **Result:**
+BindPoint
+
+
+---
+
+
+### getBindPoint{#getBindPoint}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBindPoint(target, propName, create) | 指定されたプロパティのアニメーションバインドポイントを取得します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| ターゲット | A3DObject | バインドポイントを作成するオブジェクトを指定します。 |
+| propName | 文字列 | プロパティの名前です。 |
+| 作成 | boolean | 設定する場合は |
+
+ **Result:**
+BindPoint
+
+
+---
+
+
+### getKeyframeSequence{#getKeyframeSequence}
+
+| 名前 | 説明 |
+| --- | --- |
+| getKeyframeSequence(target, propName, channelName, create) | 指定されたプロパティとチャンネルのキーフレームシーケンスを取得します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| ターゲット | A3DObject | キーフレームシーケンスを作成するインスタンスを指定します。 |
+| propName | 文字列 | プロパティの名前です。 |
+| channelName | 文字列 | チャンネル名です。 |
+| 作成 | boolean | 設定する場合は |
+
+ **Result:**
+KeyframeSequence
+
+
+---
+
+
+### getKeyframeSequence{#getKeyframeSequence}
+
+| 名前 | 説明 |
+| --- | --- |
+| getKeyframeSequence(target, propName, create) | 指定されたプロパティのキーフレームシーケンスを取得します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| ターゲット | A3DObject | キーフレームシーケンスを作成するインスタンスを指定します。 |
+| propName | 文字列 | プロパティの名前です。 |
+| 作成 | boolean | 設定する場合は |
+
+ **Result:**
+KeyframeSequence
+
+
+---
+
+
+### createBindPoint{#createBindPoint}
+
+| 名前 | 説明 |
+| --- | --- |
+| createBindPoint(obj, propName) | プロパティのデータ型に基づいて BindPoint を作成します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| obj | A3DObject | オブジェクト。 |
+| propName | 文字列 | プロパティ名。 |
+
+ **Result:**
+BindPoint
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/arbitraryprofile/_index.md
+++ b/japanese/nodejs-java/aspose.threed/arbitraryprofile/_index.md
@@ -1,0 +1,313 @@
+---
+title: "ArbitraryProfile"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/arbitraryprofile/
+---
+## ArbitraryProfile class
+
+このクラスを使用すると、任意の曲線から直接 2D プロファイルを構築できます。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | ArbitraryProfile のコンストラクタ |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload(curve) | 初期曲線を持つ ArbitraryProfile のコンストラクタです。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| curv | 曲線 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### getCurve{#getCurve}
+
+| 名前 | 説明 |
+| --- | --- |
+| getCurve() | プロファイルの構築に使用される曲線です |
+
+ **Result:**
+
+
+
+---
+
+
+### setCurve{#setCurve}
+
+| 名前 | 説明 |
+| --- | --- |
+| setCurve(value) | プロファイルの構築に使用される曲線です |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNodes() | すべての親ノードを取得します。エンティティはジオメトリインスタンシングのために複数の親ノードにアタッチできます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExcluded() | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExcluded(value) | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNode() | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setParentNode(value) | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 名前 | 説明 |
+| --- | --- |
+| getScene() | このオブジェクトが属するシーンを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEntityRendererKey() | レンダラーに登録されたエンティティレンダラーのキーを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBoundingBox() | 現在のエンティティのオブジェクト空間座標系におけるバウンディングボックスを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/assetinfo/_index.md
+++ b/japanese/nodejs-java/aspose.threed/assetinfo/_index.md
@@ -1,0 +1,586 @@
+---
+title: "AssetInfo"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/assetinfo/
+---
+## AssetInfo class
+
+アセット情報。アセット情報は Scene に添付できます。子シーンは独自の AssetInfo を持ち、親の定義を上書きできます。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | AssetInfo クラスの新しいインスタンスを初期化します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload(name) | AssetInfo クラスの新しいインスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| name | 文字列 | 名前 |
+
+ **Result:**
+
+
+
+---
+
+
+### getCreationTime{#getCreationTime}
+
+| 名前 | 説明 |
+| --- | --- |
+| getCreationTime() | このアセットの作成時刻を取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getModificationTime{#getModificationTime}
+
+| 名前 | 説明 |
+| --- | --- |
+| getModificationTime() | このアセットの更新時刻を取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getAmbient{#getAmbient}
+
+| 名前 | 説明 |
+| --- | --- |
+| getAmbient() | このアセットのデフォルト環境色を取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getUrl{#getUrl}
+
+| 名前 | 説明 |
+| --- | --- |
+| getUrl() | このアセットの URL を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setUrl{#setUrl}
+
+| 名前 | 説明 |
+| --- | --- |
+| setUrl(value) | このアセットの URL を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getApplicationVendor{#getApplicationVendor}
+
+| 名前 | 説明 |
+| --- | --- |
+| getApplicationVendor() | アプリケーションベンダーの名前を取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setApplicationVendor{#setApplicationVendor}
+
+| 名前 | 説明 |
+| --- | --- |
+| setApplicationVendor(value) | アプリケーションベンダーの名前を取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getCopyright{#getCopyright}
+
+| 名前 | 説明 |
+| --- | --- |
+| getCopyright() | ドキュメントの著作権情報を取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setCopyright{#setCopyright}
+
+| 名前 | 説明 |
+| --- | --- |
+| setCopyright(value) | ドキュメントの著作権情報を取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getApplicationName{#getApplicationName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getApplicationName() | このアセットを作成したアプリケーションを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setApplicationName{#setApplicationName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setApplicationName(value) | このアセットを作成したアプリケーションを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getApplicationVersion{#getApplicationVersion}
+
+| 名前 | 説明 |
+| --- | --- |
+| getApplicationVersion() | このアセットを作成したアプリケーションのバージョンを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setApplicationVersion{#setApplicationVersion}
+
+| 名前 | 説明 |
+| --- | --- |
+| setApplicationVersion(value) | このアセットを作成したアプリケーションのバージョンを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getTitle{#getTitle}
+
+| 名前 | 説明 |
+| --- | --- |
+| getTitle() | このアセットのタイトルを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setTitle{#setTitle}
+
+| 名前 | 説明 |
+| --- | --- |
+| setTitle(value) | このアセットのタイトルを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getSubject{#getSubject}
+
+| 名前 | 説明 |
+| --- | --- |
+| getSubject() | このアセットの件名を取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setSubject{#setSubject}
+
+| 名前 | 説明 |
+| --- | --- |
+| setSubject(value) | このアセットの件名を取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getAuthor{#getAuthor}
+
+| 名前 | 説明 |
+| --- | --- |
+| getAuthor() | このアセットの作者を取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setAuthor{#setAuthor}
+
+| 名前 | 説明 |
+| --- | --- |
+| setAuthor(value) | このアセットの作者を取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getKeywords{#getKeywords}
+
+| 名前 | 説明 |
+| --- | --- |
+| getKeywords() | このアセットのキーワードを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setKeywords{#setKeywords}
+
+| 名前 | 説明 |
+| --- | --- |
+| setKeywords(value) | このアセットのキーワードを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getRevision{#getRevision}
+
+| 名前 | 説明 |
+| --- | --- |
+| getRevision() | このアセットのリビジョン番号を取得または設定します。通常はバージョン管理システムで使用されます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setRevision{#setRevision}
+
+| 名前 | 説明 |
+| --- | --- |
+| setRevision(value) | このアセットのリビジョン番号を取得または設定します。通常はバージョン管理システムで使用されます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getComment{#getComment}
+
+| 名前 | 説明 |
+| --- | --- |
+| getComment() | このアセットのコメントを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setComment{#setComment}
+
+| 名前 | 説明 |
+| --- | --- |
+| setComment(value) | このアセットのコメントを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getUnitName{#getUnitName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getUnitName() | このアセットで使用される長さの単位を取得または設定します。例: cm/m/km/inch/feet |
+
+ **Result:**
+
+
+
+---
+
+
+### setUnitName{#setUnitName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setUnitName(value) | このアセットで使用される長さの単位を取得または設定します。例: cm/m/km/inch/feet |
+
+ **Result:**
+
+
+
+---
+
+
+### getUnitScaleFactor{#getUnitScaleFactor}
+
+| 名前 | 説明 |
+| --- | --- |
+| getUnitScaleFactor() | 実際のメートルへのスケール係数を取得または設定します。単位名が null の場合、シリアライズ時に無視されます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setUnitScaleFactor{#setUnitScaleFactor}
+
+| 名前 | 説明 |
+| --- | --- |
+| setUnitScaleFactor(value) | 実際のメートルへのスケール係数を取得または設定します。単位名が null の場合、シリアライズ時に無視されます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getCoordinatedSystem{#getCoordinatedSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| getCoordinatedSystem() | このアセットで使用される座標系を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getUpVector{#getUpVector}
+
+| 名前 | 説明 |
+| --- | --- |
+| getUpVector() | このアセットで使用される上方向ベクトルを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/bindpoint/_index.md
+++ b/japanese/nodejs-java/aspose.threed/bindpoint/_index.md
@@ -1,0 +1,386 @@
+---
+title: "BindPoint"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/bindpoint/
+---
+## BindPoint class
+
+BindPoint は通常、オブジェクトのプロパティ上に作成されます。一部のプロパティ型は複数のコンポーネントフィールド（Vector3 フィールドなど）を含み、BindPoint は各コンポーネントフィールドに対してチャネルを生成し、チャネルを介してフィールドを 1 つ以上のキー フレーム シーケンス インスタンスに接続します。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor(scene, prop) | BindPoint クラスの新しいインスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| シーン | Scene | アニメーションを含むシーンです。 |
+| プロパティ | Property | プロパティ。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty() | CurveMapping に関連付けられたプロパティを取得します |
+
+ **Result:**
+
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(value) | CurveMapping に関連付けられたプロパティを取得します |
+
+ **Result:**
+
+
+
+---
+
+
+### getChannelsCount{#getChannelsCount}
+
+| 名前 | 説明 |
+| --- | --- |
+| getChannelsCount() | このアニメーションカーブマッピングで定義されたプロパティチャンネルの総数を取得します。 |
+
+ **Result:**
+数
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+数
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+数
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+数
+
+
+---
+
+
+### get{#get}
+
+| 名前 | 説明 |
+| --- | --- |
+| get(channelName) |  |
+
+ **Result:**
+数
+
+
+---
+
+
+### getKeyframeSequence{#getKeyframeSequence}
+
+| 名前 | 説明 |
+| --- | --- |
+| getKeyframeSequence(channelName) | 指定されたチャンネルの最初のキーフレームシーケンスを取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| channelName | 文字列 | 検索するチャンネル名 |
+
+ **Result:**
+KeyframeSequence
+
+
+---
+
+
+### getKeyframeSequences{#getKeyframeSequences}
+
+| 名前 | 説明 |
+| --- | --- |
+| getKeyframeSequences(channelName) | 指定されたチャンネルのすべてのキーフレームシーケンスを取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| channelName | 文字列 | 検索するチャンネル名 |
+
+ **Result:**
+0, Culture=neutral, PublicKeyToken=f071c641d0b4582b]]
+
+
+---
+
+
+### createKeyframeSequence{#createKeyframeSequence}
+
+| 名前 | 説明 |
+| --- | --- |
+| createKeyframeSequence(name) | 新しいカーブを作成し、カーブマッピングの最初のチャンネルに接続します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| name | 文字列 | 新しいシーケンスの名前。 |
+
+ **Result:**
+KeyframeSequence
+
+
+---
+
+
+### bindKeyframeSequence{#bindKeyframeSequence}
+
+| 名前 | 説明 |
+| --- | --- |
+| bindKeyframeSequence(channelName, sequence) | キーフレームシーケンスを指定されたチャンネルにバインドします |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| channelName | 文字列 | キーフレームシーケンスがバインドされるチャンネル |
+| シーケンス | KeyframeSequence | バインドするキーフレームシーケンス |
+
+ **Result:**
+KeyframeSequence
+
+
+---
+
+
+### getChannel{#getChannel}
+
+| 名前 | 説明 |
+| --- | --- |
+| getChannel(channelName) | 指定された名前でチャンネルを取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| channelName | 文字列 | 検索するチャンネル名 |
+
+ **Result:**
+AnimationChannel
+
+
+---
+
+
+### addChannel{#addChannel}
+
+| 名前 | 説明 |
+| --- | --- |
+| addChannel(name, value) | 指定されたチャンネルプロパティを追加します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| name | 文字列 | 名前。 |
+| 値 | オブジェクト | 値。 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### addChannel{#addChannel}
+
+| 名前 | 説明 |
+| --- | --- |
+| addChannel(name, type, value) | 指定されたチャンネルプロパティを追加します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| name | 文字列 | 名前。 |
+| type | クラス | 型。 |
+| 値 | オブジェクト | 値。 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### resetChannels{#resetChannels}
+
+| 名前 | 説明 |
+| --- | --- |
+| resetChannels() | このアニメーションカーブマッピングのプロパティチャンネルを空にします |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### toString{#toString}
+
+| 名前 | 説明 |
+| --- | --- |
+| toString() | オブジェクトを文字列にフォーマットします |
+
+ **Result:**
+文字列
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/bone/_index.md
+++ b/japanese/nodejs-java/aspose.threed/bone/_index.md
@@ -1,0 +1,339 @@
+---
+title: "ボーン"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/bone/
+---
+## Bone class
+
+ボーンはジオメトリのコントロールポイントのサブセットを定義し、各コントロールポイントにブレンドウェイトを設定します。Bone オブジェクトは直接使用できず、SkinDeformer インスタンスがジオメトリを変形させます。SkinDeformer には複数のボーンが含まれ、各ボーンはノードにリンクされています。NOTE: ジオメトリのコントロールポイントは複数の Bones にバインドできる場合があります。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor(name) | Bone クラスの新しいインスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| name | 文字列 | 名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload() | Bone クラスの新しいインスタンスを初期化します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getWeightCount{#getWeightCount}
+
+| 名前 | 説明 |
+| --- | --- |
+| getWeightCount() | 重みの数を取得します。これは setWeight(int, double) によって自動的に拡張されます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getTransform{#getTransform}
+
+| 名前 | 説明 |
+| --- | --- |
+| getTransform() | ボーンを含むノードの変換行列を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setTransform{#setTransform}
+
+| 名前 | 説明 |
+| --- | --- |
+| setTransform(value) | ボーンを含むノードの変換行列を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getBoneTransform{#getBoneTransform}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBoneTransform() | ボーンの変換行列を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setBoneTransform{#setBoneTransform}
+
+| 名前 | 説明 |
+| --- | --- |
+| setBoneTransform(value) | ボーンの変換行列を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getNode{#getNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getNode() | ノードを取得または設定します。ボーンノードはスキンが付随するボーンで、SkinDeformer はボーンノードを使用してコントロールポイントの変位に影響を与えます。ボーンノードには通常 Skeleton が付随しますが、必須ではありません。付随した Skeleton は通常、DCC ソフトウェアでユーザーにスケルトンを表示するために使用されます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setNode{#setNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setNode(value) | ノードを取得または設定します。ボーンノードはスキンが付随するボーンで、SkinDeformer はボーンノードを使用してコントロールポイントの変位に影響を与えます。ボーンノードには通常 Skeleton が付随しますが、必須ではありません。付随した Skeleton は通常、DCC ソフトウェアでユーザーにスケルトンを表示するために使用されます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### get{#get}
+
+| 名前 | 説明 |
+| --- | --- |
+| get(index) |  |
+
+ **Result:**
+
+
+
+---
+
+
+### set{#set}
+
+| 名前 | 説明 |
+| --- | --- |
+| set(index, value) |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getWeight{#getWeight}
+
+| 名前 | 説明 |
+| --- | --- |
+| getWeight(index) | インデックスで指定されたコントロールポイントの重みを取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| index | 数 | コントロールポイントのインデックス |
+
+ **Result:**
+数
+
+
+---
+
+
+### setWeight{#setWeight}
+
+| 名前 | 説明 |
+| --- | --- |
+| setWeight(index, weight) | インデックスで指定されたコントロールポイントの重みを設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| index | 数 | コントロールポイントのインデックス |
+| ウェイト | 数 | 新しいウェイト |
+
+ **Result:**
+数
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/bonepose/_index.md
+++ b/japanese/nodejs-java/aspose.threed/bonepose/_index.md
@@ -1,0 +1,107 @@
+---
+title: "ボーンポーズ"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/bonepose/
+---
+## BonePose class
+
+BonePose はボーンノードの変換行列を含みます。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getNode{#getNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getNode() | シーンノードを取得または設定します。スキン付きスケルトンノードを指します |
+
+ **Result:**
+
+
+
+---
+
+
+### setNode{#setNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setNode(value) | シーンノードを取得または設定します。スキン付きスケルトンノードを指します |
+
+ **Result:**
+
+
+
+---
+
+
+### getMatrix{#getMatrix}
+
+| 名前 | 説明 |
+| --- | --- |
+| getMatrix() | 現在のポーズにおけるノードの変換行列を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setMatrix{#setMatrix}
+
+| 名前 | 説明 |
+| --- | --- |
+| setMatrix(value) | 現在のポーズにおけるノードの変換行列を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### isLocal{#isLocal}
+
+| 名前 | 説明 |
+| --- | --- |
+| isLocal() | 行列がローカル座標で定義されているかを取得または設定します。インスタンスがローカル空間の場合は true、そうでない場合は false（グローバル空間を意味します）。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setLocal{#setLocal}
+
+| 名前 | 説明 |
+| --- | --- |
+| setLocal(value) | 行列がローカル座標で定義されているかを取得または設定します。インスタンスがローカル空間の場合は true、そうでない場合は false（グローバル空間を意味します）。 |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/boundingbox/_index.md
+++ b/japanese/nodejs-java/aspose.threed/boundingbox/_index.md
@@ -1,0 +1,198 @@
+---
+title: "BoundingBox"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/boundingbox/
+---
+## BoundingBox class
+
+軸整列バウンディングボックス
+
+
+## プロパティ
+
+| 名前 | 説明 |
+| --- | --- |
+| NULL | null バウンディングボックス |
+| INFINITE | 無限のバウンディングボックス |
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload(minimum, maximum) | 指定された minimum と maximum のコーナーで有限バウンディングボックスを初期化します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| minimum | Vector3 | minimum コーナー |
+| maximum | Vector3 | maximum コーナー |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload2(minX, minY, minZ, maxX, maxY, maxZ) | 指定された minimum と maximum のコーナーで有限バウンディングボックスを初期化します |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtent{#getExtent}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExtent() | バウンディングボックスの範囲を取得します。プロパティの値は BoundingBoxExtent 整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getMinimum{#getMinimum}
+
+| 名前 | 説明 |
+| --- | --- |
+| getMinimum() | バウンディングボックスの minimum コーナー |
+
+ **Result:**
+
+
+
+---
+
+
+### getMaximum{#getMaximum}
+
+| 名前 | 説明 |
+| --- | --- |
+| getMaximum() | バウンディングボックスの maximum コーナー |
+
+ **Result:**
+
+
+
+---
+
+
+### getSize{#getSize}
+
+| 名前 | 説明 |
+| --- | --- |
+| getSize() | バウンディングボックスのサイズ |
+
+ **Result:**
+
+
+
+---
+
+
+### getCenter{#getCenter}
+
+| 名前 | 説明 |
+| --- | --- |
+| getCenter() | バウンディングボックスの中心。 |
+
+ **Result:**
+
+
+
+---
+
+
+### fromGeometry{#fromGeometry}
+
+| 名前 | 説明 |
+| --- | --- |
+| fromGeometry(geometry) | 与えられたジオメトリからバウンディングボックスを構築します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| geometr | ジオメトリ | null |
+
+ **Result:**
+BoundingBox
+
+
+---
+
+
+### toString{#toString}
+
+| 名前 | 説明 |
+| --- | --- |
+| toString() | バウンディングボックスの文字列表現を取得します。 |
+
+ **Result:**
+文字列
+
+
+---
+
+
+### hashCode{#hashCode}
+
+| 名前 | 説明 |
+| --- | --- |
+| hashCode() | このインスタンスのハッシュコードを返します |
+
+ **Result:**
+数
+
+
+---
+
+
+### equals{#equals}
+
+| 名前 | 説明 |
+| --- | --- |
+| equals(obj) | 2つのオブジェクトが等しいかどうかを判定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| ob | オブジェクト | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/boundingbox2d/_index.md
+++ b/japanese/nodejs-java/aspose.threed/boundingbox2d/_index.md
@@ -1,0 +1,146 @@
+---
+title: "BoundingBox2D"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/boundingbox2d/
+---
+## BoundingBox2D class
+
+Vector2 の軸整列バウンディングボックス
+
+
+## プロパティ
+
+| 名前 | 説明 |
+| --- | --- |
+| NULL | null バウンディングボックス |
+| INFINITE | 無限のバウンディングボックス |
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload(minimum, maximum) | 指定された minimum と maximum のコーナーで有限バウンディングボックスを初期化します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| minimum | Vector2 | minimum コーナー |
+| maximum | Vector2 | maximum コーナー |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtent{#getExtent}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExtent() | バウンディングボックスの範囲を取得します。プロパティの値は BoundingBoxExtent 整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getMinimum{#getMinimum}
+
+| 名前 | 説明 |
+| --- | --- |
+| getMinimum() | バウンディングボックスの minimum コーナー |
+
+ **Result:**
+
+
+
+---
+
+
+### getMaximum{#getMaximum}
+
+| 名前 | 説明 |
+| --- | --- |
+| getMaximum() | バウンディングボックスの maximum コーナー |
+
+ **Result:**
+
+
+
+---
+
+
+### merge{#merge}
+
+| 名前 | 説明 |
+| --- | --- |
+| merge(pt) | 新しいボックスを現在のバウンディングボックスにマージします。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| p | Vector2 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### merge{#merge}
+
+| 名前 | 説明 |
+| --- | --- |
+| merge(bb) | 新しいボックスを現在のバウンディングボックスにマージします。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| b | BoundingBox2D | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| 名前 | 説明 |
+| --- | --- |
+| toString() | バウンディングボックスの文字列表現を取得します。 |
+
+ **Result:**
+文字列
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/box/_index.md
+++ b/japanese/nodejs-java/aspose.threed/box/_index.md
@@ -1,0 +1,535 @@
+---
+title: "Box"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/box/
+---
+## Box class
+
+ボックス。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | Box クラスの新しいインスタンスを初期化します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload(length, width, height) | Box クラスの新しいインスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| length | 数 | z 軸に沿って配置された箱の長さです。 |
+| 幅 | 数 | x 軸に沿って配置された箱の幅です。 |
+| height | 数 | y 軸に沿って配置された箱の高さです。 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload2(name, length, width, height, lengthSegments, widthSegments, heightSegments) | Box クラスの新しいインスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| name | 文字列 | 箱の名前です。 |
+| length | 数 | z 軸に沿って配置された箱の長さです。 |
+| 幅 | 数 | x 軸に沿って配置された箱の幅です。 |
+| height | 数 | y 軸に沿って配置された箱の高さです。 |
+| lengthSegments | 数 | 長さのセグメント。 |
+| widthSegments | 数 | 幅のセグメント。 |
+| heightSegments | 数 | 高さセグメント。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getLengthSegments{#getLengthSegments}
+
+| 名前 | 説明 |
+| --- | --- |
+| getLengthSegments() | 長さセグメントを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setLengthSegments{#setLengthSegments}
+
+| 名前 | 説明 |
+| --- | --- |
+| setLengthSegments(value) | 長さセグメントを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getWidthSegments{#getWidthSegments}
+
+| 名前 | 説明 |
+| --- | --- |
+| getWidthSegments() | 幅セグメントを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setWidthSegments{#setWidthSegments}
+
+| 名前 | 説明 |
+| --- | --- |
+| setWidthSegments(value) | 幅セグメントを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getHeightSegments{#getHeightSegments}
+
+| 名前 | 説明 |
+| --- | --- |
+| getHeightSegments() | 高さセグメントを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setHeightSegments{#setHeightSegments}
+
+| 名前 | 説明 |
+| --- | --- |
+| setHeightSegments(value) | 高さセグメントを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getLength{#getLength}
+
+| 名前 | 説明 |
+| --- | --- |
+| getLength() | z 軸に沿って配置された箱の長さを取得または設定します。z 軸に沿った長さです。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setLength{#setLength}
+
+| 名前 | 説明 |
+| --- | --- |
+| setLength(value) | z 軸に沿って配置された箱の長さを取得または設定します。z 軸に沿った長さです。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getWidth{#getWidth}
+
+| 名前 | 説明 |
+| --- | --- |
+| getWidth() | ボックスの x 軸に沿って配置された幅を取得または設定します。x 軸に沿って配置された幅です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setWidth{#setWidth}
+
+| 名前 | 説明 |
+| --- | --- |
+| setWidth(value) | ボックスの x 軸に沿って配置された幅を取得または設定します。x 軸に沿って配置された幅です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getHeight{#getHeight}
+
+| 名前 | 説明 |
+| --- | --- |
+| getHeight() | ボックスの y 軸に沿って配置された高さを取得または設定します。y 軸に沿って配置された高さです。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setHeight{#setHeight}
+
+| 名前 | 説明 |
+| --- | --- |
+| setHeight(value) | ボックスの y 軸に沿って配置された高さを取得または設定します。y 軸に沿って配置された高さです。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastShadows{#getCastShadows}
+
+| 名前 | 説明 |
+| --- | --- |
+| getCastShadows() | このジオメトリが影を落とすかどうかを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastShadows{#setCastShadows}
+
+| 名前 | 説明 |
+| --- | --- |
+| setCastShadows(value) | このジオメトリが影を落とすかどうかを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getReceiveShadows{#getReceiveShadows}
+
+| 名前 | 説明 |
+| --- | --- |
+| getReceiveShadows() | このジオメトリが影を受け取るかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setReceiveShadows{#setReceiveShadows}
+
+| 名前 | 説明 |
+| --- | --- |
+| setReceiveShadows(value) | このジオメトリが影を受け取るかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNodes() | すべての親ノードを取得します。エンティティはジオメトリインスタンシングのために複数の親ノードにアタッチできます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExcluded() | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExcluded(value) | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNode() | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setParentNode(value) | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 名前 | 説明 |
+| --- | --- |
+| getScene() | このオブジェクトが属するシーンを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### toMesh{#toMesh}
+
+| 名前 | 説明 |
+| --- | --- |
+| toMesh() | 現在のオブジェクトをメッシュに変換します |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBoundingBox() | 現在のエンティティのオブジェクト空間座標系におけるバウンディングボックスを取得します。 |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEntityRendererKey() | レンダラーに登録されたエンティティレンダラーのキーを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/camera/_index.md
+++ b/japanese/nodejs-java/aspose.threed/camera/_index.md
@@ -1,0 +1,813 @@
+---
+title: "カメラ"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/camera/
+---
+## Camera class
+
+カメラはシーンを見る視聴者の視点（アイポイント）を表します。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | Camera クラスの新しいインスタンスを初期化します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload(projectionType) | Camera クラスの新しいインスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| projectionType | ProjectionType | ProjectionType |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload2(name) | Camera クラスの新しいインスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| name | 文字列 | 名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload3{#constructor_overload3}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload3(name, projectionType) | Camera クラスの新しいインスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| name | 文字列 | 名前。 |
+| projectionType | ProjectionType | ProjectionType |
+
+ **Result:**
+
+
+
+---
+
+
+### getApertureMode{#getApertureMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getApertureMode() | カメラの絞りモードを取得または設定します。このプロパティの値は ApertureMode 整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setApertureMode{#setApertureMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setApertureMode(value) | カメラの絞りモードを取得または設定します。このプロパティの値は ApertureMode 整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFieldOfView{#getFieldOfView}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFieldOfView() | カメラの視野角（度）を取得または設定します。このプロパティは、ApertureMode が ApertureMode.HORIZONTAL または ApertureMode.VERTICAL の場合にのみ使用されます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFieldOfView{#setFieldOfView}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFieldOfView(value) | カメラの視野角（度）を取得または設定します。このプロパティは、ApertureMode が ApertureMode.HORIZONTAL または ApertureMode.VERTICAL の場合にのみ使用されます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFieldOfViewX{#getFieldOfViewX}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFieldOfViewX() | カメラの水平視野角（度）を取得または設定します。このプロパティは、ApertureMode が ApertureMode.HORIZ_AND_VERT の場合にのみ使用されます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFieldOfViewX{#setFieldOfViewX}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFieldOfViewX(value) | カメラの水平視野角（度）を取得または設定します。このプロパティは、ApertureMode が ApertureMode.HORIZ_AND_VERT の場合にのみ使用されます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFieldOfViewY{#getFieldOfViewY}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFieldOfViewY() | カメラの垂直視野角（度）を取得または設定します。このプロパティは、ApertureMode が ApertureMode.HORIZ_AND_VERT の場合にのみ使用されます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFieldOfViewY{#setFieldOfViewY}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFieldOfViewY(value) | カメラの垂直視野角（度）を取得または設定します。このプロパティは、ApertureMode が ApertureMode.HORIZ_AND_VERT の場合にのみ使用されます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getWidth{#getWidth}
+
+| 名前 | 説明 |
+| --- | --- |
+| getWidth() | ビュー平面の幅（インチ）を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setWidth{#setWidth}
+
+| 名前 | 説明 |
+| --- | --- |
+| setWidth(value) | ビュー平面の幅（インチ）を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getHeight{#getHeight}
+
+| 名前 | 説明 |
+| --- | --- |
+| getHeight() | ビュー平面の高さ（インチ）を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setHeight{#setHeight}
+
+| 名前 | 説明 |
+| --- | --- |
+| setHeight(value) | ビュー平面の高さ（インチ）を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getAspectRatio{#getAspectRatio}
+
+| 名前 | 説明 |
+| --- | --- |
+| getAspectRatio() | ビュー平面のアスペクト比を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setAspectRatio{#setAspectRatio}
+
+| 名前 | 説明 |
+| --- | --- |
+| setAspectRatio(value) | ビュー平面のアスペクト比を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getMagnification{#getMagnification}
+
+| 名前 | 説明 |
+| --- | --- |
+| getMagnification() | 正射影カメラで使用される倍率を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setMagnification{#setMagnification}
+
+| 名前 | 説明 |
+| --- | --- |
+| setMagnification(value) | 正射影カメラで使用される倍率を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProjectionType{#getProjectionType}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProjectionType() | カメラの投影タイプを取得または設定します。デフォルトではパースペクティブ投影が使用されます。このプロパティの値は ProjectionType 整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setProjectionType{#setProjectionType}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProjectionType(value) | カメラの投影タイプを取得または設定します。デフォルトではパースペクティブ投影が使用されます。このプロパティの値は ProjectionType 整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getRotationMode{#getRotationMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getRotationMode() | 視錐台の向きモードを取得または設定します。このプロパティは Target が null の場合にのみ機能します。値が RotationMode.FIXED_TARGET の場合、方向は常に LookAt プロパティによって計算されます。それ以外の場合、LookAt は常に Direction によって計算されます。プロパティの値は RotationMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setRotationMode{#setRotationMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setRotationMode(value) | 視錐台の向きモードを取得または設定します。このプロパティは Target が null の場合にのみ機能します。値が RotationMode.FIXED_TARGET の場合、方向は常に LookAt プロパティによって計算されます。それ以外の場合、LookAt は常に Direction によって計算されます。プロパティの値は RotationMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getNearPlane{#getNearPlane}
+
+| 名前 | 説明 |
+| --- | --- |
+| getNearPlane() | 視錐台の近接平面距離を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setNearPlane{#setNearPlane}
+
+| 名前 | 説明 |
+| --- | --- |
+| setNearPlane(value) | 視錐台の近接平面距離を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFarPlane{#getFarPlane}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFarPlane() | フラスタムの遠平面距離を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFarPlane{#setFarPlane}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFarPlane(value) | フラスタムの遠平面距離を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getAspect{#getAspect}
+
+| 名前 | 説明 |
+| --- | --- |
+| getAspect() | フラスタムのアスペクト比を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setAspect{#setAspect}
+
+| 名前 | 説明 |
+| --- | --- |
+| setAspect(value) | フラスタムのアスペクト比を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getOrthoHeight{#getOrthoHeight}
+
+| 名前 | 説明 |
+| --- | --- |
+| getOrthoHeight() | フラスタムが正射影の場合の高さを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setOrthoHeight{#setOrthoHeight}
+
+| 名前 | 説明 |
+| --- | --- |
+| setOrthoHeight(value) | フラスタムが正射影の場合の高さを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getUp{#getUp}
+
+| 名前 | 説明 |
+| --- | --- |
+| getUp() | カメラの上方向ベクトルを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setUp{#setUp}
+
+| 名前 | 説明 |
+| --- | --- |
+| setUp(value) | カメラの上方向ベクトルを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookAt{#getLookAt}
+
+| 名前 | 説明 |
+| --- | --- |
+| getLookAt() | カメラが注目している位置を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setLookAt{#setLookAt}
+
+| 名前 | 説明 |
+| --- | --- |
+| setLookAt(value) | カメラが注目している位置を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getDirection{#getDirection}
+
+| 名前 | 説明 |
+| --- | --- |
+| getDirection() | カメラが向いている方向を取得または設定します。このプロパティの変更は LookAt と Target にも影響します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setDirection{#setDirection}
+
+| 名前 | 説明 |
+| --- | --- |
+| setDirection(value) | カメラが向いている方向を取得または設定します。このプロパティの変更は LookAt と Target にも影響します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getTarget{#getTarget}
+
+| 名前 | 説明 |
+| --- | --- |
+| getTarget() | カメラが向いているターゲットを取得または設定します。ユーザーがこのプロパティをサポートしている場合、LookAt プロパティよりも先に設定すべきです。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setTarget{#setTarget}
+
+| 名前 | 説明 |
+| --- | --- |
+| setTarget(value) | カメラが向いているターゲットを取得または設定します。ユーザーがこのプロパティをサポートしている場合、LookAt プロパティよりも先に設定すべきです。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNodes() | すべての親ノードを取得します。エンティティはジオメトリインスタンシングのために複数の親ノードにアタッチできます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExcluded() | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExcluded(value) | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNode() | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setParentNode(value) | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 名前 | 説明 |
+| --- | --- |
+| getScene() | このオブジェクトが属するシーンを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### moveForward{#moveForward}
+
+| 名前 | 説明 |
+| --- | --- |
+| moveForward(distance) | カメラをその方向またはターゲットに向かって前方に移動します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| distance | 数 | 前方にどれだけ移動するか |
+
+ **Result:**
+
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBoundingBox() | 現在のエンティティのオブジェクト空間座標系におけるバウンディングボックスを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEntityRendererKey() | レンダラーに登録されたエンティティレンダラーのキーを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/circle/_index.md
+++ b/japanese/nodejs-java/aspose.threed/circle/_index.md
@@ -1,0 +1,339 @@
+---
+title: "円"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/circle/
+---
+## Circle class
+
+円曲線は円形のエッジ上の点の集合で構成されます。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | Circle のコンストラクタ |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload(radius) | Circle のコンストラクタ |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| 半径 | 数 | 円曲線の半径です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getRadius{#getRadius}
+
+| 名前 | 説明 |
+| --- | --- |
+| getRadius() | 円曲線の半径、デフォルト値は 10 です |
+
+ **Result:**
+
+
+
+---
+
+
+### setRadius{#setRadius}
+
+| 名前 | 説明 |
+| --- | --- |
+| setRadius(value) | 円曲線の半径、デフォルト値は 10 です |
+
+ **Result:**
+
+
+
+---
+
+
+### getColor{#getColor}
+
+| 名前 | 説明 |
+| --- | --- |
+| getColor() | 線の色を取得または設定します。デフォルト値は白 (1, 1, 1) です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setColor{#setColor}
+
+| 名前 | 説明 |
+| --- | --- |
+| setColor(value) | 線の色を取得または設定します。デフォルト値は白 (1, 1, 1) です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNodes() | すべての親ノードを取得します。エンティティはジオメトリインスタンシングのために複数の親ノードにアタッチできます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExcluded() | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExcluded(value) | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNode() | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setParentNode(value) | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 名前 | 説明 |
+| --- | --- |
+| getScene() | このオブジェクトが属するシーンを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEntityRendererKey() | レンダラーに登録されたエンティティレンダラーのキーを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBoundingBox() | 現在のエンティティのオブジェクト空間座標系におけるバウンディングボックスを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/circleshape/_index.md
+++ b/japanese/nodejs-java/aspose.threed/circleshape/_index.md
@@ -1,0 +1,326 @@
+---
+title: "CircleShape"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/circleshape/
+---
+## CircleShape class
+
+IFC 互換の円形プロファイルで、LinearExtrusion によってメッシュを構築するために使用できます。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | デフォルト半径 (5) の CircleShape プロファイルを構築します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload(radius) | 指定された半径の CircleShape プロファイルを構築します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| radiu | 数 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### getRadius{#getRadius}
+
+| 名前 | 説明 |
+| --- | --- |
+| getRadius() | 円の半径を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setRadius{#setRadius}
+
+| 名前 | 説明 |
+| --- | --- |
+| setRadius(value) | 円の半径を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNodes() | すべての親ノードを取得します。エンティティはジオメトリインスタンシングのために複数の親ノードにアタッチできます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExcluded() | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExcluded(value) | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNode() | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setParentNode(value) | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 名前 | 説明 |
+| --- | --- |
+| getScene() | このオブジェクトが属するシーンを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtent{#getExtent}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExtent() | x と y の次元での範囲を取得します |
+
+ **Result:**
+Vector2
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEntityRendererKey() | レンダラーに登録されたエンティティレンダラーのキーを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBoundingBox() | 現在のエンティティのオブジェクト空間座標系におけるバウンディングボックスを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/colladasaveoptions/_index.md
+++ b/japanese/nodejs-java/aspose.threed/colladasaveoptions/_index.md
@@ -1,0 +1,198 @@
+---
+title: "ColladaSaveOptions"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/colladasaveoptions/
+---
+## ColladaSaveOptions class
+
+collada の保存オプション
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | ColladaSaveOptions のコンストラクタ |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndented{#getIndented}
+
+| 名前 | 説明 |
+| --- | --- |
+| getIndented() | エクスポートされたXMLドキュメントがインデントされるかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndented{#setIndented}
+
+| 名前 | 説明 |
+| --- | --- |
+| setIndented(value) | エクスポートされたXMLドキュメントがインデントされるかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getTransformStyle{#getTransformStyle}
+
+| 名前 | 説明 |
+| --- | --- |
+| getTransformStyle() | ノード変換のスタイルを取得または設定します。プロパティの値は ColladaTransformStyle 整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setTransformStyle{#setTransformStyle}
+
+| 名前 | 説明 |
+| --- | --- |
+| setTransformStyle(value) | ノード変換のスタイルを取得または設定します。プロパティの値は ColladaTransformStyle 整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportTextures{#getExportTextures}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExportTextures() | シーンで使用されているテクスチャを出力ディレクトリにコピーしようとします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextures{#setExportTextures}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExportTextures(value) | シーンで使用されているテクスチャを出力ディレクトリにコピーしようとします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileFormat() | 現在の保存/読み込みオプションで指定されたファイル形式を取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEncoding() | テキストベースのファイルのデフォルトエンコーディングを取得または設定します。デフォルト値は null で、インポーター/エクスポーターが使用するエンコーディングを決定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileSystem() | ロード/セーブ時に外部依存関係を管理する方法をユーザーが処理できるようにします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFileSystem(value) | ロード/セーブ時に外部依存関係を管理する方法をユーザーが処理できるようにします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| 名前 | 説明 |
+| --- | --- |
+| getLookupPaths() | OBJ のような一部のファイルは外部ファイルに依存しており、検索パスにより Aspose.3D が外部ファイルを探してロードできるようになります。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileName() | エクスポート/インポートシーンのファイル名です。これはオプションですが、OBJ のマテリアルなど外部アセットをシリアライズする際に便利です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFileName(value) | エクスポート/インポートシーンのファイル名です。これはオプションですが、OBJ のマテリアルなど外部アセットをシリアライズする際に便利です。 |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/compositecurve/_index.md
+++ b/japanese/nodejs-java/aspose.threed/compositecurve/_index.md
@@ -1,0 +1,327 @@
+---
+title: "CompositeCurve"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/compositecurve/
+---
+## CompositeCurve class
+
+CompositeCurve は複数の曲線セグメントで構成されています。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | CompositeCurve のコンストラクタ |
+
+ **Result:**
+
+
+
+---
+
+
+### getSegments{#getSegments}
+
+| 名前 | 説明 |
+| --- | --- |
+| getSegments() | 曲線のセグメント。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getColor{#getColor}
+
+| 名前 | 説明 |
+| --- | --- |
+| getColor() | 線の色を取得または設定します。デフォルト値は白 (1, 1, 1) です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setColor{#setColor}
+
+| 名前 | 説明 |
+| --- | --- |
+| setColor(value) | 線の色を取得または設定します。デフォルト値は白 (1, 1, 1) です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNodes() | すべての親ノードを取得します。エンティティはジオメトリインスタンシングのために複数の親ノードにアタッチできます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExcluded() | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExcluded(value) | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNode() | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setParentNode(value) | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 名前 | 説明 |
+| --- | --- |
+| getScene() | このオブジェクトが属するシーンを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### addSegment{#addSegment}
+
+| 名前 | 説明 |
+| --- | --- |
+| addSegment(curve, sameDirection) | その |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| curv | 曲線 | null |
+| sameDirectio | boolean | null |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEntityRendererKey() | レンダラーに登録されたエンティティレンダラーのキーを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBoundingBox() | 現在のエンティティのオブジェクト空間座標系におけるバウンディングボックスを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/cshape/_index.md
+++ b/japanese/nodejs-java/aspose.threed/cshape/_index.md
@@ -1,0 +1,411 @@
+---
+title: "CShape"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/cshape/
+---
+## CShape class
+
+IFC 互換の C 形状プロファイルはパラメータで定義されます。 プロファイルの中心位置はバウンディングボックスの中心にあります。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | CShape のコンストラクタ |
+
+ **Result:**
+
+
+
+---
+
+
+### getDepth{#getDepth}
+
+| 名前 | 説明 |
+| --- | --- |
+| getDepth() | プロファイルの深さを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setDepth{#setDepth}
+
+| 名前 | 説明 |
+| --- | --- |
+| setDepth(value) | プロファイルの深さを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getWidth{#getWidth}
+
+| 名前 | 説明 |
+| --- | --- |
+| getWidth() | プロファイルの幅を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setWidth{#setWidth}
+
+| 名前 | 説明 |
+| --- | --- |
+| setWidth(value) | プロファイルの幅を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getGirth{#getGirth}
+
+| 名前 | 説明 |
+| --- | --- |
+| getGirth() | 周囲の長さを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setGirth{#setGirth}
+
+| 名前 | 説明 |
+| --- | --- |
+| setGirth(value) | 周囲の長さを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getWallThickness{#getWallThickness}
+
+| 名前 | 説明 |
+| --- | --- |
+| getWallThickness() | 壁の厚さを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setWallThickness{#setWallThickness}
+
+| 名前 | 説明 |
+| --- | --- |
+| setWallThickness(value) | 壁の厚さを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getInternalFilletRadius{#getInternalFilletRadius}
+
+| 名前 | 説明 |
+| --- | --- |
+| getInternalFilletRadius() | 内部フィレット半径を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setInternalFilletRadius{#setInternalFilletRadius}
+
+| 名前 | 説明 |
+| --- | --- |
+| setInternalFilletRadius(value) | 内部フィレット半径を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNodes() | すべての親ノードを取得します。エンティティはジオメトリインスタンシングのために複数の親ノードにアタッチできます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExcluded() | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExcluded(value) | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNode() | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setParentNode(value) | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 名前 | 説明 |
+| --- | --- |
+| getScene() | このオブジェクトが属するシーンを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtent{#getExtent}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExtent() | x と y の次元での範囲を取得します |
+
+ **Result:**
+Vector2
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEntityRendererKey() | レンダラーに登録されたエンティティレンダラーのキーを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBoundingBox() | 現在のエンティティのオブジェクト空間座標系におけるバウンディングボックスを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/cubeface/_index.md
+++ b/japanese/nodejs-java/aspose.threed/cubeface/_index.md
@@ -1,0 +1,13 @@
+---
+title: "CubeFace"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/cubeface/
+---
+## CubeFace class
+
+定数を含むユーティリティクラスです。キューブマップテクスチャの各面  @hideconstructor
+
+

--- a/japanese/nodejs-java/aspose.threed/curve/_index.md
+++ b/japanese/nodejs-java/aspose.threed/curve/_index.md
@@ -1,0 +1,281 @@
+---
+title: "曲線"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/curve/
+---
+## Curve class
+
+すべての曲線実装の基底クラスです。  @hideconstructor
+
+
+## メソッド
+
+### getColor{#getColor}
+
+| 名前 | 説明 |
+| --- | --- |
+| getColor() | 線の色を取得または設定します。デフォルト値は白 (1, 1, 1) です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setColor{#setColor}
+
+| 名前 | 説明 |
+| --- | --- |
+| setColor(value) | 線の色を取得または設定します。デフォルト値は白 (1, 1, 1) です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNodes() | すべての親ノードを取得します。エンティティはジオメトリインスタンシングのために複数の親ノードにアタッチできます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExcluded() | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExcluded(value) | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNode() | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setParentNode(value) | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 名前 | 説明 |
+| --- | --- |
+| getScene() | このオブジェクトが属するシーンを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEntityRendererKey() | レンダラーに登録されたエンティティレンダラーのキーを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBoundingBox() | 現在のエンティティのオブジェクト空間座標系におけるバウンディングボックスを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/customobject/_index.md
+++ b/japanese/nodejs-java/aspose.threed/customobject/_index.md
@@ -1,0 +1,183 @@
+---
+title: "CustomObject"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/customobject/
+---
+## CustomObject class
+
+3D ファイルで使用されるメタデータまたはカスタムオブジェクトはこのクラスで管理されます。 すべてのカスタムプロパティは動的プロパティとして保存されます。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | CustomObject クラスの新しいインスタンスを初期化します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload(name) | CustomObject クラスの新しいインスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| name | 文字列 | 名前 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/cylinder/_index.md
+++ b/japanese/nodejs-java/aspose.threed/cylinder/_index.md
@@ -1,0 +1,763 @@
+---
+title: "Cylinder"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/cylinder/
+---
+## Cylinder class
+
+パラメータ化されたシリンダーです。 radiusTop または radiusBottom のいずれかがゼロの場合、円錐を表すためにも使用できます。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | Cylinder クラスの新しいインスタンスを初期化します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload(radius, height) | Cylinder クラスの新しいインスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| 半径 | 数 | 上部と下部のキャップの半径。 |
+| height | 数 | 高さ。 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload2(radiusTop, radiusBottom, height) | Cylinder クラスの新しいインスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| radiusTop | 数 | 上部の半径。 |
+| radiusBottom | 数 | 下部の半径。 |
+| height | 数 | 高さ。 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload3{#constructor_overload3}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload3(radiusTop, radiusBottom, height, radialSegments, heightSegments, openEnded) | Cylinder クラスの新しいインスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| radiusTop | 数 | Cylinder の上部キャップの半径。 |
+| radiusBottom | 数 | Cylinder の下部キャップの半径。 |
+| height | 数 | Cylinder の高さ。 |
+| radialSegments | 数 | 上部と下部の円のラジアルセグメント.. |
+| heightSegments | 数 | 高さセグメント。 |
+| openEnded | boolean | 設定する場合は |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload4{#constructor_overload4}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload4(name, radiusTop, radiusBottom, height, radialSegments, heightSegments, openEnded, thetaStart, thetaLength) | Cylinder クラスの新しいインスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| name | 文字列 | このオブジェクトの名前 |
+| radiusTop | 数 | Cylinder の上部キャップの半径。 |
+| radiusBottom | 数 | Cylinder の下部キャップの半径。 |
+| height | 数 | Cylinder の高さ。 |
+| radialSegments | 数 | 上部と下部の円のラジアルセグメント.. |
+| heightSegments | 数 | 高さセグメント。 |
+| openEnded | boolean | 設定する場合は |
+| thetaStart | 数 | Theta の開始。 |
+| thetaLength | 数 | Theta の長さ。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getOffsetBottom{#getOffsetBottom}
+
+| 名前 | 説明 |
+| --- | --- |
+| getOffsetBottom() | 底面側の頂点変換オフセットを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setOffsetBottom{#setOffsetBottom}
+
+| 名前 | 説明 |
+| --- | --- |
+| setOffsetBottom(value) | 底面側の頂点変換オフセットを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getOffsetTop{#getOffsetTop}
+
+| 名前 | 説明 |
+| --- | --- |
+| getOffsetTop() | 上面側の頂点変換オフセットを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setOffsetTop{#setOffsetTop}
+
+| 名前 | 説明 |
+| --- | --- |
+| setOffsetTop(value) | 上面側の頂点変換オフセットを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getGenerateFanCylinder{#getGenerateFanCylinder}
+
+| 名前 | 説明 |
+| --- | --- |
+| getGenerateFanCylinder() | ThetaLength が 2π 未満のときにファン形シリンダーを生成するかどうかを取得または設定します。そうでない場合、モデルはカットされません。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setGenerateFanCylinder{#setGenerateFanCylinder}
+
+| 名前 | 説明 |
+| --- | --- |
+| setGenerateFanCylinder(value) | ThetaLength が 2π 未満のときにファン形シリンダーを生成するかどうかを取得または設定します。そうでない場合、モデルはカットされません。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getShearBottom{#getShearBottom}
+
+| 名前 | 説明 |
+| --- | --- |
+| getShearBottom() | 底面のせん断変換を取得または設定します。ベクトルはラジアンで測定された (x 軸, z 軸) のせん断値を格納し、デフォルト値は (0, 0) です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setShearBottom{#setShearBottom}
+
+| 名前 | 説明 |
+| --- | --- |
+| setShearBottom(value) | 底面のせん断変換を取得または設定します。ベクトルはラジアンで測定された (x 軸, z 軸) のせん断値を格納し、デフォルト値は (0, 0) です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getShearTop{#getShearTop}
+
+| 名前 | 説明 |
+| --- | --- |
+| getShearTop() | 上面のせん断変換を取得または設定します。ベクトルはラジアンで測定された (x 軸, z 軸) のせん断値を格納し、デフォルト値は (0, 0) です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setShearTop{#setShearTop}
+
+| 名前 | 説明 |
+| --- | --- |
+| setShearTop(value) | 上面のせん断変換を取得または設定します。ベクトルはラジアンで測定された (x 軸, z 軸) のせん断値を格納し、デフォルト値は (0, 0) です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getRadiusTop{#getRadiusTop}
+
+| 名前 | 説明 |
+| --- | --- |
+| getRadiusTop() | シリンダーの上部キャップの半径を取得または設定します。上部キャップの半径です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setRadiusTop{#setRadiusTop}
+
+| 名前 | 説明 |
+| --- | --- |
+| setRadiusTop(value) | シリンダーの上部キャップの半径を取得または設定します。上部キャップの半径です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getRadiusBottom{#getRadiusBottom}
+
+| 名前 | 説明 |
+| --- | --- |
+| getRadiusBottom() | シリンダーの下部キャップの半径を取得または設定します。下部キャップの半径です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setRadiusBottom{#setRadiusBottom}
+
+| 名前 | 説明 |
+| --- | --- |
+| setRadiusBottom(value) | シリンダーの下部キャップの半径を取得または設定します。下部キャップの半径です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getHeight{#getHeight}
+
+| 名前 | 説明 |
+| --- | --- |
+| getHeight() | シリンダーの高さを取得または設定します。高さです。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setHeight{#setHeight}
+
+| 名前 | 説明 |
+| --- | --- |
+| setHeight(value) | シリンダーの高さを取得または設定します。高さです。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getRadialSegments{#getRadialSegments}
+
+| 名前 | 説明 |
+| --- | --- |
+| getRadialSegments() | ラジアルセグメントを取得または設定します。ラジアルセグメントです。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setRadialSegments{#setRadialSegments}
+
+| 名前 | 説明 |
+| --- | --- |
+| setRadialSegments(value) | ラジアルセグメントを取得または設定します。ラジアルセグメントです。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getHeightSegments{#getHeightSegments}
+
+| 名前 | 説明 |
+| --- | --- |
+| getHeightSegments() | 高さセグメントを取得または設定します。高さセグメント。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setHeightSegments{#setHeightSegments}
+
+| 名前 | 説明 |
+| --- | --- |
+| setHeightSegments(value) | 高さセグメントを取得または設定します。高さセグメント。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getOpenEnded{#getOpenEnded}
+
+| 名前 | 説明 |
+| --- | --- |
+| getOpenEnded() | このシリンダーが開口部かどうかを示す値を取得または設定します。デフォルト値は false です。開口部の場合は true、そうでなければ上部/下部のキャップが存在します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setOpenEnded{#setOpenEnded}
+
+| 名前 | 説明 |
+| --- | --- |
+| setOpenEnded(value) | このシリンダーが開口部かどうかを示す値を取得または設定します。デフォルト値は false です。開口部の場合は true、そうでなければ上部/下部のキャップが存在します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getThetaStart{#getThetaStart}
+
+| 名前 | 説明 |
+| --- | --- |
+| getThetaStart() | シータ開始角度を取得または設定します。デフォルト値は 0 です。シータ開始角度です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setThetaStart{#setThetaStart}
+
+| 名前 | 説明 |
+| --- | --- |
+| setThetaStart(value) | シータ開始角度を取得または設定します。デフォルト値は 0 です。シータ開始角度です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getThetaLength{#getThetaLength}
+
+| 名前 | 説明 |
+| --- | --- |
+| getThetaLength() | シータの長さを取得または設定します。デフォルト値は 2π です。シータの長さです。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setThetaLength{#setThetaLength}
+
+| 名前 | 説明 |
+| --- | --- |
+| setThetaLength(value) | シータの長さを取得または設定します。デフォルト値は 2π です。シータの長さです。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastShadows{#getCastShadows}
+
+| 名前 | 説明 |
+| --- | --- |
+| getCastShadows() | このジオメトリが影を落とすかどうかを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastShadows{#setCastShadows}
+
+| 名前 | 説明 |
+| --- | --- |
+| setCastShadows(value) | このジオメトリが影を落とすかどうかを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getReceiveShadows{#getReceiveShadows}
+
+| 名前 | 説明 |
+| --- | --- |
+| getReceiveShadows() | このジオメトリが影を受け取るかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setReceiveShadows{#setReceiveShadows}
+
+| 名前 | 説明 |
+| --- | --- |
+| setReceiveShadows(value) | このジオメトリが影を受け取るかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNodes() | すべての親ノードを取得します。エンティティはジオメトリインスタンシングのために複数の親ノードにアタッチできます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExcluded() | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExcluded(value) | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNode() | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setParentNode(value) | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 名前 | 説明 |
+| --- | --- |
+| getScene() | このオブジェクトが属するシーンを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### toMesh{#toMesh}
+
+| 名前 | 説明 |
+| --- | --- |
+| toMesh() | 現在のオブジェクトをメッシュに変換します |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBoundingBox() | 現在のエンティティのオブジェクト空間座標系におけるバウンディングボックスを取得します。 |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEntityRendererKey() | レンダラーに登録されたエンティティレンダラーのキーを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/deformer/_index.md
+++ b/japanese/nodejs-java/aspose.threed/deformer/_index.md
@@ -1,0 +1,183 @@
+---
+title: "Deformer"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/deformer/
+---
+## Deformer class
+
+SkinDeformer と MorphTargetDeformer の基底クラス
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor(name) | Deformer クラスの新しいインスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| name | 文字列 | 名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getOwner{#getOwner}
+
+| 名前 | 説明 |
+| --- | --- |
+| getOwner() | このデフォーマーを所有するジオメトリを取得します |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/descriptorsetupdater/_index.md
+++ b/japanese/nodejs-java/aspose.threed/descriptorsetupdater/_index.md
@@ -1,0 +1,137 @@
+---
+title: "DescriptorSetUpdater"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/descriptorsetupdater/
+---
+## DescriptorSetUpdater class
+
+このクラスはチェーン操作で com.aspose.threed.IDescriptorSet を更新できるようにします。  @hideconstructor
+
+
+## メソッド
+
+### bind{#bind}
+
+| 名前 | 説明 |
+| --- | --- |
+| bind(buffer, offset, size) | バッファを現在のディスクリプタセットにバインドします。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| buffer | IBuffer | バインドするバッファはどれですか |
+| offset | 数 | バインドするバッファのオフセット |
+| サイズ | 数 | バインドするバッファのサイズ |
+
+ **Result:**
+DescriptorSetUpdater
+
+
+---
+
+
+### bind{#bind}
+
+| 名前 | 説明 |
+| --- | --- |
+| bind(buffer) | バッファ全体を現在のディスクリプタにバインドします。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| バッファ | IBuffer | null |
+
+ **Result:**
+DescriptorSetUpdater
+
+
+---
+
+
+### bind{#bind}
+
+| 名前 | 説明 |
+| --- | --- |
+| bind(binding, buffer) | 指定されたバインディング位置でバッファを現在のディスクリプタセットにバインドします。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| バインディング | 数 | バインディング位置 |
+| buffer | IBuffer | バインドする全体のバッファ |
+
+ **Result:**
+DescriptorSetUpdater
+
+
+---
+
+
+### bind{#bind}
+
+| 名前 | 説明 |
+| --- | --- |
+| bind(binding, buffer, offset, size) | 指定されたバインディング位置でバッファを現在のディスクリプタセットにバインドします。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| バインディング | 数 | バインディング位置 |
+| buffer | IBuffer | バインドするバッファ |
+| offset | 数 | バインドするバッファのオフセット |
+| サイズ | 数 | バインドするバッファのサイズ |
+
+ **Result:**
+DescriptorSetUpdater
+
+
+---
+
+
+### bind{#bind}
+
+| 名前 | 説明 |
+| --- | --- |
+| bind(texture) | テクスチャユニットを現在のディスクリプタセットにバインドします |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| texture | ITextureUnit | バインドするテクスチャユニット |
+
+ **Result:**
+DescriptorSetUpdater
+
+
+---
+
+
+### bind{#bind}
+
+| 名前 | 説明 |
+| --- | --- |
+| bind(binding, texture) | テクスチャユニットを現在のディスクリプタセットにバインドします |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| バインディング | 数 | バインディング位置 |
+| texture | ITextureUnit | バインドするテクスチャユニット |
+
+ **Result:**
+DescriptorSetUpdater
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/discreet3dsloadoptions/_index.md
+++ b/japanese/nodejs-java/aspose.threed/discreet3dsloadoptions/_index.md
@@ -1,0 +1,198 @@
+---
+title: "Discreet3dsLoadOptions"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/discreet3dsloadoptions/
+---
+## Discreet3dsLoadOptions class
+
+3DS ファイルの読み込みオプションです。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | Discreet3dsLoadOptions のコンストラクタ |
+
+ **Result:**
+
+
+
+---
+
+
+### getGammaCorrectedColor{#getGammaCorrectedColor}
+
+| 名前 | 説明 |
+| --- | --- |
+| getGammaCorrectedColor() | 3ds ファイルは同じ属性に対して元の色とガンマ補正された色の両方を含む場合があります。この設定を true にすると、可能な限りガンマ補正された色が使用され、そうでなければ Aspose.3D は元の色を使用しようとします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setGammaCorrectedColor{#setGammaCorrectedColor}
+
+| 名前 | 説明 |
+| --- | --- |
+| setGammaCorrectedColor(value) | 3ds ファイルは同じ属性に対して元の色とガンマ補正された色の両方を含む場合があります。この設定を true にすると、可能な限りガンマ補正された色が使用され、そうでなければ Aspose.3D は元の色を使用しようとします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlipCoordinateSystem{#getFlipCoordinateSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFlipCoordinateSystem() | インポート/エクスポート時にコントロールポイント/法線のフリップ座標系を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlipCoordinateSystem{#setFlipCoordinateSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFlipCoordinateSystem(value) | インポート/エクスポート時にコントロールポイント/法線のフリップ座標系を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getApplyAnimationTransform{#getApplyAnimationTransform}
+
+| 名前 | 説明 |
+| --- | --- |
+| getApplyAnimationTransform() | アニメーショントラックの最初のフレームで定義された変換を使用するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setApplyAnimationTransform{#setApplyAnimationTransform}
+
+| 名前 | 説明 |
+| --- | --- |
+| setApplyAnimationTransform(value) | アニメーショントラックの最初のフレームで定義された変換を使用するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileFormat() | 現在の保存/読み込みオプションで指定されたファイル形式を取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEncoding() | テキストベースのファイルのデフォルトエンコーディングを取得または設定します。デフォルト値は null で、インポーター/エクスポーターが使用するエンコーディングを決定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileSystem() | ロード/セーブ時に外部依存関係を管理する方法をユーザーが処理できるようにします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFileSystem(value) | ロード/セーブ時に外部依存関係を管理する方法をユーザーが処理できるようにします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| 名前 | 説明 |
+| --- | --- |
+| getLookupPaths() | OBJ のような一部のファイルは外部ファイルに依存しており、検索パスにより Aspose.3D が外部ファイルを探してロードできるようになります。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileName() | エクスポート/インポートシーンのファイル名です。これはオプションですが、OBJ のマテリアルなど外部アセットをシリアライズする際に便利です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFileName(value) | エクスポート/インポートシーンのファイル名です。これはオプションですが、OBJ のマテリアルなど外部アセットをシリアライズする際に便利です。 |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/discreet3dssaveoptions/_index.md
+++ b/japanese/nodejs-java/aspose.threed/discreet3dssaveoptions/_index.md
@@ -1,0 +1,380 @@
+---
+title: "Discreet3dsSaveOptions"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/discreet3dssaveoptions/
+---
+## Discreet3dsSaveOptions class
+
+3DS ファイルの保存オプションです。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | Discreet3dsSaveOptions のコンストラクタ |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportLight{#getExportLight}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExportLight() | シーン内のすべてのライトをエクスポートするかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportLight{#setExportLight}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExportLight(value) | シーン内のすべてのライトをエクスポートするかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportCamera{#getExportCamera}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExportCamera() | シーン内のすべてのカメラをエクスポートするかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportCamera{#setExportCamera}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExportCamera(value) | シーン内のすべてのカメラをエクスポートするかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getDuplicatedNameSeparator{#getDuplicatedNameSeparator}
+
+| 名前 | 説明 |
+| --- | --- |
+| getDuplicatedNameSeparator() | オブジェクト名と重複カウンタの間の区切り文字で、デフォルト値は "_" です。シーンに同じ名前を使用するオブジェクトが含まれる場合、Aspose.3D 3DS エクスポーターはオブジェクトに別の名前を生成します。例えば、"Box" という名前のノードが2つある場合、最初のノードは名前 "Box" を持ち、2番目のノードはデフォルト設定を使用して新しい名前 "Box_2" になります。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setDuplicatedNameSeparator{#setDuplicatedNameSeparator}
+
+| 名前 | 説明 |
+| --- | --- |
+| setDuplicatedNameSeparator(value) | オブジェクト名と重複カウンタの間の区切り文字で、デフォルト値は "_" です。シーンに同じ名前を使用するオブジェクトが含まれる場合、Aspose.3D 3DS エクスポーターはオブジェクトに別の名前を生成します。例えば、"Box" という名前のノードが2つある場合、最初のノードは名前 "Box" を持ち、2番目のノードはデフォルト設定を使用して新しい名前 "Box_2" になります。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getDuplicatedNameCounterBase{#getDuplicatedNameCounterBase}
+
+| 名前 | 説明 |
+| --- | --- |
+| getDuplicatedNameCounterBase() | 重複した名前の新しい名前を生成する際に使用されるカウンタで、デフォルト値は 2 です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setDuplicatedNameCounterBase{#setDuplicatedNameCounterBase}
+
+| 名前 | 説明 |
+| --- | --- |
+| setDuplicatedNameCounterBase(value) | 重複した名前の新しい名前を生成する際に使用されるカウンタで、デフォルト値は 2 です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getDuplicatedNameCounterFormat{#getDuplicatedNameCounterFormat}
+
+| 名前 | 説明 |
+| --- | --- |
+| getDuplicatedNameCounterFormat() | 重複カウンタの形式で、デフォルト値は空文字列です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setDuplicatedNameCounterFormat{#setDuplicatedNameCounterFormat}
+
+| 名前 | 説明 |
+| --- | --- |
+| setDuplicatedNameCounterFormat(value) | 重複カウンタの形式で、デフォルト値は空文字列です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getMasterScale{#getMasterScale}
+
+| 名前 | 説明 |
+| --- | --- |
+| getMasterScale() | エクスポート時に使用されるマスタースケールを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setMasterScale{#setMasterScale}
+
+| 名前 | 説明 |
+| --- | --- |
+| setMasterScale(value) | エクスポート時に使用されるマスタースケールを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getGammaCorrectedColor{#getGammaCorrectedColor}
+
+| 名前 | 説明 |
+| --- | --- |
+| getGammaCorrectedColor() | 3ds ファイルは同じ属性に対して元の色とガンマ補正された色の両方を含む場合があります。この設定を true にすると、可能な限りガンマ補正された色が使用され、そうでなければ Aspose.3D は元の色を使用しようとします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setGammaCorrectedColor{#setGammaCorrectedColor}
+
+| 名前 | 説明 |
+| --- | --- |
+| setGammaCorrectedColor(value) | 3ds ファイルは同じ属性に対して元の色とガンマ補正された色の両方を含む場合があります。この設定を true にすると、可能な限りガンマ補正された色が使用され、そうでなければ Aspose.3D は元の色を使用しようとします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlipCoordinateSystem{#getFlipCoordinateSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFlipCoordinateSystem() | インポート/エクスポート時にコントロールポイント/法線のフリップ座標系を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlipCoordinateSystem{#setFlipCoordinateSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFlipCoordinateSystem(value) | インポート/エクスポート時にコントロールポイント/法線のフリップ座標系を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getHighPreciseColor{#getHighPreciseColor}
+
+| 名前 | 説明 |
+| --- | --- |
+| getHighPreciseColor() | この値が true の場合、生成された 3ds ファイルは高精度カラーを使用します。つまり、赤/緑/青の各チャンネルが 32 ビット浮動小数点になります。そうでない場合、生成されたファイルは 24 ビットカラーを使用し、各チャンネルは 8 ビットバイトになります。デフォルト値は false です。すべてのアプリケーションが高精度カラーをサポートしているわけではないためです。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setHighPreciseColor{#setHighPreciseColor}
+
+| 名前 | 説明 |
+| --- | --- |
+| setHighPreciseColor(value) | この値が true の場合、生成された 3ds ファイルは高精度カラーを使用します。つまり、赤/緑/青の各チャンネルが 32 ビット浮動小数点になります。そうでない場合、生成されたファイルは 24 ビットカラーを使用し、各チャンネルは 8 ビットバイトになります。デフォルト値は false です。すべてのアプリケーションが高精度カラーをサポートしているわけではないためです。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportTextures{#getExportTextures}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExportTextures() | シーンで使用されているテクスチャを出力ディレクトリにコピーしようとします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextures{#setExportTextures}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExportTextures(value) | シーンで使用されているテクスチャを出力ディレクトリにコピーしようとします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileFormat() | 現在の保存/読み込みオプションで指定されたファイル形式を取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEncoding() | テキストベースのファイルのデフォルトエンコーディングを取得または設定します。デフォルト値は null で、インポーター/エクスポーターが使用するエンコーディングを決定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileSystem() | ロード/セーブ時に外部依存関係を管理する方法をユーザーが処理できるようにします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFileSystem(value) | ロード/セーブ時に外部依存関係を管理する方法をユーザーが処理できるようにします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| 名前 | 説明 |
+| --- | --- |
+| getLookupPaths() | OBJ のような一部のファイルは外部ファイルに依存しており、検索パスにより Aspose.3D が外部ファイルを探してロードできるようになります。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileName() | エクスポート/インポートシーンのファイル名です。これはオプションですが、OBJ のマテリアルなど外部アセットをシリアライズする際に便利です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFileName(value) | エクスポート/インポートシーンのファイル名です。これはオプションですが、OBJ のマテリアルなど外部アセットをシリアライズする際に便利です。 |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/dish/_index.md
+++ b/japanese/nodejs-java/aspose.threed/dish/_index.md
@@ -1,0 +1,480 @@
+---
+title: "Dish"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/dish/
+---
+## Dish class
+
+パラメータ化されたディッシュです。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | デフォルトの半径(10)とデフォルトの高さ(5)で新しい Dish インスタンスを作成します |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload(radius, height) | 指定された半径と高さで新しい Dish インスタンスを作成します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| 半径 | 数 | Dish の半径 |
+| height | 数 | Dish の高さ |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload2(name, radius, height, widthSegments, heightSegments) | 指定された半径と高さで新しい Dish インスタンスを作成します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| name | 文字列 | Dish の名前 |
+| 半径 | 数 | Dish の半径 |
+| height | 数 | Dish の高さ |
+| widthSegments | 数 | Dish の幅セグメント |
+| heightSegments | 数 | 皿の高さセグメント |
+
+ **Result:**
+
+
+
+---
+
+
+### getHeight{#getHeight}
+
+| 名前 | 説明 |
+| --- | --- |
+| getHeight() | 皿の高さ |
+
+ **Result:**
+
+
+
+---
+
+
+### setHeight{#setHeight}
+
+| 名前 | 説明 |
+| --- | --- |
+| setHeight(value) | 皿の高さ |
+
+ **Result:**
+
+
+
+---
+
+
+### getRadius{#getRadius}
+
+| 名前 | 説明 |
+| --- | --- |
+| getRadius() | 皿の半径 |
+
+ **Result:**
+
+
+
+---
+
+
+### setRadius{#setRadius}
+
+| 名前 | 説明 |
+| --- | --- |
+| setRadius(value) | 皿の半径 |
+
+ **Result:**
+
+
+
+---
+
+
+### getWidthSegments{#getWidthSegments}
+
+| 名前 | 説明 |
+| --- | --- |
+| getWidthSegments() | 幅セグメントを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setWidthSegments{#setWidthSegments}
+
+| 名前 | 説明 |
+| --- | --- |
+| setWidthSegments(value) | 幅セグメントを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getHeightSegments{#getHeightSegments}
+
+| 名前 | 説明 |
+| --- | --- |
+| getHeightSegments() | 高さセグメントを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setHeightSegments{#setHeightSegments}
+
+| 名前 | 説明 |
+| --- | --- |
+| setHeightSegments(value) | 高さセグメントを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastShadows{#getCastShadows}
+
+| 名前 | 説明 |
+| --- | --- |
+| getCastShadows() | このジオメトリが影を落とすかどうかを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastShadows{#setCastShadows}
+
+| 名前 | 説明 |
+| --- | --- |
+| setCastShadows(value) | このジオメトリが影を落とすかどうかを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getReceiveShadows{#getReceiveShadows}
+
+| 名前 | 説明 |
+| --- | --- |
+| getReceiveShadows() | このジオメトリが影を受け取るかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setReceiveShadows{#setReceiveShadows}
+
+| 名前 | 説明 |
+| --- | --- |
+| setReceiveShadows(value) | このジオメトリが影を受け取るかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNodes() | すべての親ノードを取得します。エンティティはジオメトリインスタンシングのために複数の親ノードにアタッチできます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExcluded() | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExcluded(value) | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNode() | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setParentNode(value) | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 名前 | 説明 |
+| --- | --- |
+| getScene() | このオブジェクトが属するシーンを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### toMesh{#toMesh}
+
+| 名前 | 説明 |
+| --- | --- |
+| toMesh() | 現在のオブジェクトをメッシュに変換します |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBoundingBox() | 現在のエンティティのオブジェクト空間座標系におけるバウンディングボックスを取得します。 |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEntityRendererKey() | レンダラーに登録されたエンティティレンダラーのキーを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/dracoformat/_index.md
+++ b/japanese/nodejs-java/aspose.threed/dracoformat/_index.md
@@ -1,0 +1,199 @@
+---
+title: "DracoFormat"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/dracoformat/
+---
+## DracoFormat class
+
+Google Draco フォーマット  @hideconstructor
+
+
+## メソッド
+
+### getVersion{#getVersion}
+
+| 名前 | 説明 |
+| --- | --- |
+| getVersion() | ファイル形式のバージョンを取得します |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtension{#getExtension}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExtension() | このタイプの拡張子名を取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtensions{#getExtensions}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExtensions() | このタイプの拡張子名を取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getContentType{#getContentType}
+
+| 名前 | 説明 |
+| --- | --- |
+| getContentType() | ファイル形式のコンテンツタイプを取得します。このプロパティの値は FileContentType 整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormatType{#getFileFormatType}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileFormatType() | ファイル形式のタイプを取得します |
+
+ **Result:**
+
+
+
+---
+
+
+### decode{#decode}
+
+| 名前 | 説明 |
+| --- | --- |
+| decode(fileName) | 指定されたファイル名から点群またはメッシュをデコードします |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| fileName | 文字列 | ファイル名にはdrcファイルが含まれています |
+
+ **Result:**
+ジオメトリ
+
+
+---
+
+
+### decode{#decode}
+
+| 名前 | 説明 |
+| --- | --- |
+| decode(data) | メモリデータから点群またはメッシュをデコードします |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| data | byte[] | 生のdrcバイト |
+
+ **Result:**
+ジオメトリ
+
+
+---
+
+
+### encode{#encode}
+
+| 名前 | 説明 |
+| --- | --- |
+| encode(entity, fileName, options) | エンティティを指定されたファイルにエンコードします |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| エンティティ | エンティティ | エンコードされるエンティティ |
+| fileName | 文字列 | 書き込まれるファイル名 |
+| オプション | DracoSaveOptions | 点群をエンコードするための追加オプション |
+
+ **Result:**
+ジオメトリ
+
+
+---
+
+
+### encode{#encode}
+
+| 名前 | 説明 |
+| --- | --- |
+| encode(entity, options) | エンティティをDracoの生データにエンコードします |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| エンティティ | エンティティ | エンコードされるエンティティ |
+| オプション | DracoSaveOptions | 点群をエンコードするための追加オプション |
+
+ **Result:**
+byte[]
+
+
+---
+
+
+### createLoadOptions{#createLoadOptions}
+
+| 名前 | 説明 |
+| --- | --- |
+| createLoadOptions() | このファイル形式のデフォルトのロードオプションを作成します |
+
+ **Result:**
+LoadOptions
+
+
+---
+
+
+### createSaveOptions{#createSaveOptions}
+
+| 名前 | 説明 |
+| --- | --- |
+| createSaveOptions() | このファイル形式のデフォルトの保存オプションを作成します |
+
+ **Result:**
+SaveOptions
+
+
+---
+
+
+### toString{#toString}
+
+| 名前 | 説明 |
+| --- | --- |
+| toString() | フォーマットを文字列に変換 |
+
+ **Result:**
+文字列
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/dracosaveoptions/_index.md
+++ b/japanese/nodejs-java/aspose.threed/dracosaveoptions/_index.md
@@ -1,0 +1,328 @@
+---
+title: "DracoSaveOptions"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/dracosaveoptions/
+---
+## DracoSaveOptions class
+
+Google Draco ファイルの保存オプション
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | draco ファイルを保存するためのデフォルト構成を作成します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getPositionBits{#getPositionBits}
+
+| 名前 | 説明 |
+| --- | --- |
+| getPositionBits() | 位置の量子化ビット数、デフォルト値は 14 です |
+
+ **Result:**
+
+
+
+---
+
+
+### setPositionBits{#setPositionBits}
+
+| 名前 | 説明 |
+| --- | --- |
+| setPositionBits(value) | 位置の量子化ビット数、デフォルト値は 14 です |
+
+ **Result:**
+
+
+
+---
+
+
+### getTextureCoordinateBits{#getTextureCoordinateBits}
+
+| 名前 | 説明 |
+| --- | --- |
+| getTextureCoordinateBits() | テクスチャ座標の量子化ビット数、デフォルト値は 12 です |
+
+ **Result:**
+
+
+
+---
+
+
+### setTextureCoordinateBits{#setTextureCoordinateBits}
+
+| 名前 | 説明 |
+| --- | --- |
+| setTextureCoordinateBits(value) | テクスチャ座標の量子化ビット数、デフォルト値は 12 です |
+
+ **Result:**
+
+
+
+---
+
+
+### getColorBits{#getColorBits}
+
+| 名前 | 説明 |
+| --- | --- |
+| getColorBits() | 頂点カラーの量子化ビット数、デフォルト値は 10 です |
+
+ **Result:**
+
+
+
+---
+
+
+### setColorBits{#setColorBits}
+
+| 名前 | 説明 |
+| --- | --- |
+| setColorBits(value) | 頂点カラーの量子化ビット数、デフォルト値は 10 です |
+
+ **Result:**
+
+
+
+---
+
+
+### getNormalBits{#getNormalBits}
+
+| 名前 | 説明 |
+| --- | --- |
+| getNormalBits() | 法線ベクトルの量子化ビット数、デフォルト値は 10 です |
+
+ **Result:**
+
+
+
+---
+
+
+### setNormalBits{#setNormalBits}
+
+| 名前 | 説明 |
+| --- | --- |
+| setNormalBits(value) | 法線ベクトルの量子化ビット数、デフォルト値は 10 です |
+
+ **Result:**
+
+
+
+---
+
+
+### getCompressionLevel{#getCompressionLevel}
+
+| 名前 | 説明 |
+| --- | --- |
+| getCompressionLevel() | 圧縮レベル、デフォルト値は DracoCompressionLevel.STANDARD です。このプロパティの値は DracoCompressionLevel の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setCompressionLevel{#setCompressionLevel}
+
+| 名前 | 説明 |
+| --- | --- |
+| setCompressionLevel(value) | 圧縮レベル、デフォルト値は DracoCompressionLevel.STANDARD です。このプロパティの値は DracoCompressionLevel の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getApplyUnitScale{#getApplyUnitScale}
+
+| 名前 | 説明 |
+| --- | --- |
+| getApplyUnitScale() | AssetInfo.UnitScaleFactor をメッシュに適用します。デフォルト値は false です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setApplyUnitScale{#setApplyUnitScale}
+
+| 名前 | 説明 |
+| --- | --- |
+| setApplyUnitScale(value) | AssetInfo.UnitScaleFactor をメッシュに適用します。デフォルト値は false です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getPointCloud{#getPointCloud}
+
+| 名前 | 説明 |
+| --- | --- |
+| getPointCloud() | シーンをポイントクラウドとしてエクスポートします。デフォルト値は false です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setPointCloud{#setPointCloud}
+
+| 名前 | 説明 |
+| --- | --- |
+| setPointCloud(value) | シーンをポイントクラウドとしてエクスポートします。デフォルト値は false です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportTextures{#getExportTextures}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExportTextures() | シーンで使用されているテクスチャを出力ディレクトリにコピーしようとします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextures{#setExportTextures}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExportTextures(value) | シーンで使用されているテクスチャを出力ディレクトリにコピーしようとします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileFormat() | 現在の保存/読み込みオプションで指定されたファイル形式を取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEncoding() | テキストベースのファイルのデフォルトエンコーディングを取得または設定します。デフォルト値は null で、インポーター/エクスポーターが使用するエンコーディングを決定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileSystem() | ロード/セーブ時に外部依存関係を管理する方法をユーザーが処理できるようにします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFileSystem(value) | ロード/セーブ時に外部依存関係を管理する方法をユーザーが処理できるようにします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| 名前 | 説明 |
+| --- | --- |
+| getLookupPaths() | OBJ のような一部のファイルは外部ファイルに依存しており、検索パスにより Aspose.3D が外部ファイルを探してロードできるようになります。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileName() | エクスポート/インポートシーンのファイル名です。これはオプションですが、OBJ のマテリアルなど外部アセットをシリアライズする際に便利です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFileName(value) | エクスポート/インポートシーンのファイル名です。これはオプションですが、OBJ のマテリアルなど外部アセットをシリアライズする際に便利です。 |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/driverexception/_index.md
+++ b/japanese/nodejs-java/aspose.threed/driverexception/_index.md
@@ -1,0 +1,29 @@
+---
+title: "DriverException"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/driverexception/
+---
+## DriverException class
+
+内部レンダリングドライバーによって発生する例外です。  @hideconstructor
+
+
+## メソッド
+
+### getErrorCode{#getErrorCode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getErrorCode() | ネイティブエラーコードを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/dummyfilesystem/_index.md
+++ b/japanese/nodejs-java/aspose.threed/dummyfilesystem/_index.md
@@ -1,0 +1,69 @@
+---
+title: "DummyFileSystem"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/dummyfilesystem/
+---
+## DummyFileSystem class
+
+読み取り/書き込み操作はダミー操作です。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### readFile{#readFile}
+
+| 名前 | 説明 |
+| --- | --- |
+| readFile(fileName, options) | 依存関係を読み取るためのストリームを作成します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| fileNam | 文字列 | null |
+| オプション | IOConfig | null |
+
+ **Result:**
+Stream
+
+
+---
+
+
+### writeFile{#writeFile}
+
+| 名前 | 説明 |
+| --- | --- |
+| writeFile(fileName, options) | 依存関係を書き込むためのストリームを作成します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| fileNam | 文字列 | null |
+| オプション | IOConfig | null |
+
+ **Result:**
+Stream
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/ellipse/_index.md
+++ b/japanese/nodejs-java/aspose.threed/ellipse/_index.md
@@ -1,0 +1,359 @@
+---
+title: "楕円"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/ellipse/
+---
+## Ellipse class
+
+楕円は楕円形を形成する点の集合を定義します。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | Ellipse のコンストラクタ |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload(semiAxis1, semiAxis2) | Ellipse のコンストラクタ |
+
+ **Result:**
+
+
+
+---
+
+
+### getSemiAxis1{#getSemiAxis1}
+
+| 名前 | 説明 |
+| --- | --- |
+| getSemiAxis1() | X 軸の半径 |
+
+ **Result:**
+
+
+
+---
+
+
+### setSemiAxis1{#setSemiAxis1}
+
+| 名前 | 説明 |
+| --- | --- |
+| setSemiAxis1(value) | X 軸の半径 |
+
+ **Result:**
+
+
+
+---
+
+
+### getSemiAxis2{#getSemiAxis2}
+
+| 名前 | 説明 |
+| --- | --- |
+| getSemiAxis2() | Y 軸の半径 |
+
+ **Result:**
+
+
+
+---
+
+
+### setSemiAxis2{#setSemiAxis2}
+
+| 名前 | 説明 |
+| --- | --- |
+| setSemiAxis2(value) | Y 軸の半径 |
+
+ **Result:**
+
+
+
+---
+
+
+### getColor{#getColor}
+
+| 名前 | 説明 |
+| --- | --- |
+| getColor() | 線の色を取得または設定します。デフォルト値は白 (1, 1, 1) です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setColor{#setColor}
+
+| 名前 | 説明 |
+| --- | --- |
+| setColor(value) | 線の色を取得または設定します。デフォルト値は白 (1, 1, 1) です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNodes() | すべての親ノードを取得します。エンティティはジオメトリインスタンシングのために複数の親ノードにアタッチできます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExcluded() | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExcluded(value) | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNode() | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setParentNode(value) | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 名前 | 説明 |
+| --- | --- |
+| getScene() | このオブジェクトが属するシーンを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEntityRendererKey() | レンダラーに登録されたエンティティレンダラーのキーを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBoundingBox() | 現在のエンティティのオブジェクト空間座標系におけるバウンディングボックスを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/ellipseshape/_index.md
+++ b/japanese/nodejs-java/aspose.threed/ellipseshape/_index.md
@@ -1,0 +1,333 @@
+---
+title: "EllipseShape"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/ellipseshape/
+---
+## EllipseShape class
+
+IFC 互換の楕円形はパラメータで定義されます。 プロファイルの中心位置はバウンディングボックスの中心にあります。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getSemiAxis1{#getSemiAxis1}
+
+| 名前 | 説明 |
+| --- | --- |
+| getSemiAxis1() | x 軸方向に測定された楕円の第一半径を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setSemiAxis1{#setSemiAxis1}
+
+| 名前 | 説明 |
+| --- | --- |
+| setSemiAxis1(value) | x 軸方向に測定された楕円の第一半径を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getSemiAxis2{#getSemiAxis2}
+
+| 名前 | 説明 |
+| --- | --- |
+| getSemiAxis2() | y 軸方向で測定される楕円の第2半径を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setSemiAxis2{#setSemiAxis2}
+
+| 名前 | 説明 |
+| --- | --- |
+| setSemiAxis2(value) | y 軸方向で測定される楕円の第2半径を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNodes() | すべての親ノードを取得します。エンティティはジオメトリインスタンシングのために複数の親ノードにアタッチできます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExcluded() | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExcluded(value) | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNode() | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setParentNode(value) | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 名前 | 説明 |
+| --- | --- |
+| getScene() | このオブジェクトが属するシーンを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtent{#getExtent}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExtent() | x と y の次元での範囲を取得します |
+
+ **Result:**
+Vector2
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEntityRendererKey() | レンダラーに登録されたエンティティレンダラーのキーを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBoundingBox() | 現在のエンティティのオブジェクト空間座標系におけるバウンディングボックスを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/endpoint/_index.md
+++ b/japanese/nodejs-java/aspose.threed/endpoint/_index.md
@@ -1,0 +1,157 @@
+---
+title: "EndPoint"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/endpoint/
+---
+## EndPoint class
+
+曲線をトリムする終点は、パラメータ値またはデカルト座標点のいずれかです。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload(point) | Cartesian 点から EndPoint を構築します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| poin | Vector3 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload2(v) | 実数パラメータから EndPoint を構築します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+|  | 数 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### isCartesianPoint{#isCartesianPoint}
+
+| 名前 | 説明 |
+| --- | --- |
+| isCartesianPoint() | 終点は Cartesian 点ですか？ |
+
+ **Result:**
+
+
+
+---
+
+
+### getAsPoint{#getAsPoint}
+
+| 名前 | 説明 |
+| --- | --- |
+| getAsPoint() | エンドポイントをデカルト座標として取得し、例外がスローされます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getAsValue{#getAsValue}
+
+| 名前 | 説明 |
+| --- | --- |
+| getAsValue() | エンドポイントを実数パラメータとして取得し、例外がスローされます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### fromDegree{#fromDegree}
+
+| 名前 | 説明 |
+| --- | --- |
+| fromDegree(degree) | 度で測定されたエンドポイントを作成します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| degre | 数 | null |
+
+ **Result:**
+EndPoint
+
+
+---
+
+
+### fromRadian{#fromRadian}
+
+| 名前 | 説明 |
+| --- | --- |
+| fromRadian(degree) | ラジアンで測定されたエンドポイントを作成します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| degre | 数 | null |
+
+ **Result:**
+EndPoint
+
+
+---
+
+
+### toString{#toString}
+
+| 名前 | 説明 |
+| --- | --- |
+| toString() | 現在のエンドポイントの文字列表現を返します。 |
+
+ **Result:**
+文字列
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/entity/_index.md
+++ b/japanese/nodejs-java/aspose.threed/entity/_index.md
@@ -1,0 +1,274 @@
+---
+title: "エンティティ"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/entity/
+---
+## Entity class
+
+すべてのエンティティの基底クラスです。 エンティティは Light/Geometry のようなノードの下に付随する具体的なオブジェクトを表します。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor(name) | Entity クラスの新しいインスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| name | 文字列 | 名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNodes() | すべての親ノードを取得します。エンティティはジオメトリインスタンシングのために複数の親ノードにアタッチできます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExcluded() | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExcluded(value) | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNode() | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setParentNode(value) | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 名前 | 説明 |
+| --- | --- |
+| getScene() | このオブジェクトが属するシーンを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBoundingBox() | 現在のエンティティのオブジェクト空間座標系におけるバウンディングボックスを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEntityRendererKey() | レンダラーに登録されたエンティティレンダラーのキーを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/entityrenderer/_index.md
+++ b/japanese/nodejs-java/aspose.threed/entityrenderer/_index.md
@@ -1,0 +1,185 @@
+---
+title: "EntityRenderer"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/entityrenderer/
+---
+## EntityRenderer class
+
+これをサブクラス化して、さまざまな種類のエンティティのレンダリングを実装します。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor(key, features) | EntityRenderer のコンストラクタ |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| key | 文字列 | エンティティレンダラのキー |
+| features | byte | EntityRendererFeatures |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload(key) | EntityRenderer のコンストラクタ |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| key | 文字列 | エンティティレンダラのキー |
+
+ **Result:**
+
+
+
+---
+
+
+### initialize{#initialize}
+
+| 名前 | 説明 |
+| --- | --- |
+| initialize(renderer) | エンティティレンダラを初期化します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| rendere | レンダラー | null |
+
+ **Result:**
+
+
+
+---
+
+
+### resetSceneCache{#resetSceneCache}
+
+| 名前 | 説明 |
+| --- | --- |
+| resetSceneCache() | シーンが変更または削除されたため、シーンレベルのレンダーリソースをここで破棄する必要があります。 |
+
+ **Result:**
+
+
+
+---
+
+
+### frameBegin{#frameBegin}
+
+| 名前 | 説明 |
+| --- | --- |
+| frameBegin(renderer, renderQueue) | フレームのレンダリングを開始する |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| レンダラー | レンダラー | 現在のレンダラー |
+| レンダーキュー | IRenderQueue | レンダーキュー |
+
+ **Result:**
+
+
+
+---
+
+
+### frameEnd{#frameEnd}
+
+| 名前 | 説明 |
+| --- | --- |
+| frameEnd(renderer, renderQueue) | フレームのレンダリングを終了する |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| レンダラー | レンダラー | 現在のレンダラー |
+| レンダーキュー | IRenderQueue | レンダーキュー |
+
+ **Result:**
+
+
+
+---
+
+
+### prepareRenderQueue{#prepareRenderQueue}
+
+| 名前 | 説明 |
+| --- | --- |
+| prepareRenderQueue(renderer, queue, node, entity) | 指定されたノード/エンティティのペアに対してレンダリングコマンドを準備します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| レンダラー | レンダラー | 現在のレンダラーインスタンス |
+| キュー | IRenderQueue | レンダータスクを管理するために使用されるレンダーキュー |
+| ノード | ノード | 現在のノード |
+| エンティティ | エンティティ | レンダリングが必要なエンティティ |
+
+ **Result:**
+
+
+
+---
+
+
+### renderEntity{#renderEntity}
+
+| 名前 | 説明 |
+| --- | --- |
+| renderEntity(renderer, commandList, node, renderableResource, subEntity) | com.aspose.threed.IRenderQueue にプッシュされた各レンダータスクは、具体的なレンダリングジョブを実行するために対応する RenderEntity 呼び出しを持ちます。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| レンダラー | レンダラー | レンダラー |
+| commandList | ICommandList | レンダリングコマンドを記録するために使用される commandList |
+| ノード | ノード | レンダリングされるエンティティの PrepareRenderQueue に渡された同じノード |
+| renderableResource | オブジェクト | PrepareRenderQueue 中に IRenderQueue に渡されたカスタムオブジェクト |
+| subEntity | 数 | IRenderQueue に渡されたサブエンティティのインデックス |
+
+ **Result:**
+
+
+
+---
+
+
+### dispose{#dispose}
+
+| 名前 | 説明 |
+| --- | --- |
+| dispose() | エンティティレンダラーが破棄されます。共有リソースを解放してください。 |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/entityrendererkey/_index.md
+++ b/japanese/nodejs-java/aspose.threed/entityrendererkey/_index.md
@@ -1,0 +1,48 @@
+---
+title: "EntityRendererKey"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/entityrendererkey/
+---
+## EntityRendererKey class
+
+登録されたエンティティレンダラーのキー
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor(name) | EntityRendererKey のコンストラクタ |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | 文字列 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| 名前 | 説明 |
+| --- | --- |
+| toString() |  |
+
+ **Result:**
+文字列
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/exportexception/_index.md
+++ b/japanese/nodejs-java/aspose.threed/exportexception/_index.md
@@ -1,0 +1,35 @@
+---
+title: "ExportException"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/exportexception/
+---
+## ExportException class
+
+Aspose.3D がシーンをファイルにエクスポートできなかったときの例外
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor(msg) | 新しいインスタンスを初期化します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| msg | 文字列 | エラーメッセージ |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/extrapolation/_index.md
+++ b/japanese/nodejs-java/aspose.threed/extrapolation/_index.md
@@ -1,0 +1,68 @@
+---
+title: "Extrapolation"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/extrapolation/
+---
+## Extrapolation class
+
+外挿は、サンプリングされた値が最初と最後のキーフレームで定義された範囲外にある場合の処理方法を定義します。  @hideconstructor
+
+
+## メソッド
+
+### getType{#getType}
+
+| 名前 | 説明 |
+| --- | --- |
+| getType() | 外挿のサンプリングパターンを取得および設定します。このプロパティの値は ExtrapolationType 整数定数です。型。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setType{#setType}
+
+| 名前 | 説明 |
+| --- | --- |
+| setType(value) | 外挿のサンプリングパターンを取得および設定します。このプロパティの値は ExtrapolationType 整数定数です。型。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getRepeatCount{#getRepeatCount}
+
+| 名前 | 説明 |
+| --- | --- |
+| getRepeatCount() | 外挿パターンの繰り返し回数を取得および設定します。回数。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setRepeatCount{#setRepeatCount}
+
+| 名前 | 説明 |
+| --- | --- |
+| setRepeatCount(value) | 外挿パターンの繰り返し回数を取得および設定します。回数。 |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/fbxloadoptions/_index.md
+++ b/japanese/nodejs-java/aspose.threed/fbxloadoptions/_index.md
@@ -1,0 +1,165 @@
+---
+title: "FbxLoadOptions"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/fbxloadoptions/
+---
+## FbxLoadOptions class
+
+Fbx フォーマットの読み込みオプションです。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor(format) | FbxLoadOptions のコンストラクタ |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| 形式 | ファイル形式 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload() | FbxLoadOptions のコンストラクタ |
+
+ **Result:**
+
+
+
+---
+
+
+### getKeepBuiltinGlobalSettings{#getKeepBuiltinGlobalSettings}
+
+| 名前 | 説明 |
+| --- | --- |
+| getKeepBuiltinGlobalSettings() | AssetInfo でネイティブプロパティの置き換えがある GlobalSettings の組み込みプロパティを保持するかどうかを取得または設定します。完全なプロパティを GlobalSettings に保持したい場合は true に設定してください。デフォルト値は false です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setKeepBuiltinGlobalSettings{#setKeepBuiltinGlobalSettings}
+
+| 名前 | 説明 |
+| --- | --- |
+| setKeepBuiltinGlobalSettings(value) | AssetInfo でネイティブプロパティの置き換えがある GlobalSettings の組み込みプロパティを保持するかどうかを取得または設定します。完全なプロパティを GlobalSettings に保持したい場合は true に設定してください。デフォルト値は false です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileFormat() | 現在の保存/読み込みオプションで指定されたファイル形式を取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEncoding() | テキストベースのファイルのデフォルトエンコーディングを取得または設定します。デフォルト値は null で、インポーター/エクスポーターが使用するエンコーディングを決定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileSystem() | ロード/セーブ時に外部依存関係を管理する方法をユーザーが処理できるようにします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFileSystem(value) | ロード/セーブ時に外部依存関係を管理する方法をユーザーが処理できるようにします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| 名前 | 説明 |
+| --- | --- |
+| getLookupPaths() | OBJ のような一部のファイルは外部ファイルに依存しており、検索パスにより Aspose.3D が外部ファイルを探してロードできるようになります。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileName() | エクスポート/インポートシーンのファイル名です。これはオプションですが、OBJ のマテリアルなど外部アセットをシリアライズする際に便利です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFileName(value) | エクスポート/インポートシーンのファイル名です。これはオプションですが、OBJ のマテリアルなど外部アセットをシリアライズする際に便利です。 |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/fbxsaveoptions/_index.md
+++ b/japanese/nodejs-java/aspose.threed/fbxsaveoptions/_index.md
@@ -1,0 +1,340 @@
+---
+title: "FbxSaveOptions"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/fbxsaveoptions/
+---
+## FbxSaveOptions class
+
+Fbx ファイルの保存オプションです。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor(format) | FbxSaveOptions を初期化します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| 形式 | ファイル形式 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload(contentType) | 最新のサポートバージョンを使用して FbxSaveOptions を初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| contentType | FileContentType | FileContentType |
+
+ **Result:**
+
+
+
+---
+
+
+### getReusePrimitiveMesh{#getReusePrimitiveMesh}
+
+| 名前 | 説明 |
+| --- | --- |
+| getReusePrimitiveMesh() | 同じパラメータを持つプリミティブのメッシュを再利用します。これにより、CAD ファイルからインポートされたような多数のプリミティブ形状で構成されたシーンの FBX 出力サイズが大幅に削減されます。デフォルト値は false です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setReusePrimitiveMesh{#setReusePrimitiveMesh}
+
+| 名前 | 説明 |
+| --- | --- |
+| setReusePrimitiveMesh(value) | 同じパラメータを持つプリミティブのメッシュを再利用します。これにより、CAD ファイルからインポートされたような多数のプリミティブ形状で構成されたシーンの FBX 出力サイズが大幅に削減されます。デフォルト値は false です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEnableCompression{#getEnableCompression}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEnableCompression() | FBX ファイル内の大きなバイナリデータ（例: アニメーションデータ、コントロールポイント、頂点要素データ、インデックス）を圧縮します。デフォルト値は true です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setEnableCompression{#setEnableCompression}
+
+| 名前 | 説明 |
+| --- | --- |
+| setEnableCompression(value) | FBX ファイル内の大きなバイナリデータ（例: アニメーションデータ、コントロールポイント、頂点要素データ、インデックス）を圧縮します。デフォルト値は true です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFoldRepeatedCurveData{#getFoldRepeatedCurveData}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFoldRepeatedCurveData() | 繰り返し曲線データを再利用するかどうかを取得または設定します。最後のデータの参照カウントを増やすことで再利用する場合は true、そうでない場合は false です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportLegacyMaterialProperties{#getExportLegacyMaterialProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExportLegacyMaterialProperties() | レガシー素材プロパティをエクスポートするかどうかを取得または設定します。後方互換性のために使用されます。このオプションはデフォルトで有効になっています。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportLegacyMaterialProperties{#setExportLegacyMaterialProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExportLegacyMaterialProperties(value) | レガシー素材プロパティをエクスポートするかどうかを取得または設定します。後方互換性のために使用されます。このオプションはデフォルトで有効になっています。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getVideoForTexture{#getVideoForTexture}
+
+| 名前 | 説明 |
+| --- | --- |
+| getVideoForTexture() | FBX としてエクスポートする際に、テクスチャ用の Video インスタンスを生成するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setVideoForTexture{#setVideoForTexture}
+
+| 名前 | 説明 |
+| --- | --- |
+| setVideoForTexture(value) | FBX としてエクスポートする際に、テクスチャ用の Video インスタンスを生成するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEmbedTextures{#getEmbedTextures}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEmbedTextures() | テクスチャを最終出力ファイルに埋め込むかどうかを取得または設定します。FBX エクスポーターはファイルシステムからテクスチャの生データを探し、最終 FBX ファイルに埋め込みます。デフォルト値は false です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setEmbedTextures{#setEmbedTextures}
+
+| 名前 | 説明 |
+| --- | --- |
+| setEmbedTextures(value) | テクスチャを最終出力ファイルに埋め込むかどうかを取得または設定します。FBX エクスポーターはファイルシステムからテクスチャの生データを探し、最終 FBX ファイルに埋め込みます。デフォルト値は false です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getGenerateVertexElementMaterial{#getGenerateVertexElementMaterial}
+
+| 名前 | 説明 |
+| --- | --- |
+| getGenerateVertexElementMaterial() | アタッチされたノードがマテリアルを含む場合、ジオメトリに常に VertexElementMaterial を生成するかどうかを取得または設定します。デフォルトでは無効になっています。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setGenerateVertexElementMaterial{#setGenerateVertexElementMaterial}
+
+| 名前 | 説明 |
+| --- | --- |
+| setGenerateVertexElementMaterial(value) | アタッチされたノードがマテリアルを含む場合、ジオメトリに常に VertexElementMaterial を生成するかどうかを取得または設定します。デフォルトでは無効になっています。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportTextures{#getExportTextures}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExportTextures() | シーンで使用されているテクスチャを出力ディレクトリにコピーしようとします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextures{#setExportTextures}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExportTextures(value) | シーンで使用されているテクスチャを出力ディレクトリにコピーしようとします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileFormat() | 現在の保存/読み込みオプションで指定されたファイル形式を取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEncoding() | テキストベースのファイルのデフォルトエンコーディングを取得または設定します。デフォルト値は null で、インポーター/エクスポーターが使用するエンコーディングを決定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileSystem() | ロード/セーブ時に外部依存関係を管理する方法をユーザーが処理できるようにします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFileSystem(value) | ロード/セーブ時に外部依存関係を管理する方法をユーザーが処理できるようにします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| 名前 | 説明 |
+| --- | --- |
+| getLookupPaths() | OBJ のような一部のファイルは外部ファイルに依存しており、検索パスにより Aspose.3D が外部ファイルを探してロードできるようになります。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileName() | エクスポート/インポートシーンのファイル名です。これはオプションですが、OBJ のマテリアルなど外部アセットをシリアライズする際に便利です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFileName(value) | エクスポート/インポートシーンのファイル名です。これはオプションですが、OBJ のマテリアルなど外部アセットをシリアライズする際に便利です。 |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/fileformat/_index.md
+++ b/japanese/nodejs-java/aspose.threed/fileformat/_index.md
@@ -1,0 +1,187 @@
+---
+title: "ファイル形式"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/fileformat/
+---
+## FileFormat class
+
+ファイル形式の定義  @hideconstructor
+
+
+## プロパティ
+
+| 名前 | 説明 |
+| --- | --- |
+| MAYA_BINARY | バイナリ形式のAutodesk Maya |
+| STL_BINARY | バイナリSTLファイル形式 |
+| STLASCII | ASCII STLファイル形式 |
+| COLLADA | Colladaファイル形式 |
+| GLTF | Khronos GroupのglTF |
+| GLTF_BINARY | Khronos Groupのバイナリ形式glTF |
+| PDF | Adobeのポータブルドキュメント形式 |
+| DXF | AutoCAD DXF |
+| PLY | Polygon File FormatまたはStanford Triangle Format |
+| X_BINARY | バイナリ形式のDirectX Xファイル |
+| X_TEXT | バイナリ形式のDirectX Xファイル |
+| DRACO | Google Draco Mesh |
+| RVM_TEXT | テキスト形式の AVEVA Plant Design Management System Model |
+| RVM_BINARY | バイナリ形式の AVEVA Plant Design Management System Model |
+| ASE | 3D Studio Max の ASCII Scene Exporter フォーマット。 |
+| IFC | ISO 16739-1 Industry Foundation Classes データモデル。 |
+| AMF | 付加製造ファイルフォーマット |
+| VRML | バーチャルリアリティモデリング言語 |
+| ZIP | 他の 3d ファイル形式を含む Zip アーカイブ。 |
+| USD | ユニバーサルシーン記述 |
+| USDZ | 圧縮されたユニバーサルシーン記述 |
+| XYZ | Xyz 点群ファイル |
+| PCD | PCL Point Cloud Data の ASCII モードファイル |
+| PCD_BINARY | PCL Point Cloud Data のバイナリモードファイル |
+
+## メソッド
+
+### getVersion{#getVersion}
+
+| 名前 | 説明 |
+| --- | --- |
+| getVersion() | ファイル形式のバージョンを取得します |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtension{#getExtension}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExtension() | このタイプの拡張子名を取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtensions{#getExtensions}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExtensions() | このタイプの拡張子名を取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getContentType{#getContentType}
+
+| 名前 | 説明 |
+| --- | --- |
+| getContentType() | ファイル形式のコンテンツタイプを取得します。このプロパティの値は FileContentType 整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormatType{#getFileFormatType}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileFormatType() | ファイル形式のタイプを取得します |
+
+ **Result:**
+
+
+
+---
+
+
+### getFormatByExtension{#getFormatByExtension}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFormatByExtension(extensionName) | ファイル拡張子名から優先されるファイル形式を取得します。拡張子名はピリオド（'.'）で始まる必要があります。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| extensionNam | 文字列 | null |
+
+ **Result:**
+ファイル形式
+
+
+---
+
+
+### detect{#detect}
+
+| 名前 | 説明 |
+| --- | --- |
+| detect(fileName) | ファイル名からファイル形式を検出します。ファイルは読み取り可能である必要があり、Aspose.3D はファイルヘッダーを通じてファイル形式を検出できます。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| fileNam | 文字列 | null |
+
+ **Result:**
+ファイル形式
+
+
+---
+
+
+### createLoadOptions{#createLoadOptions}
+
+| 名前 | 説明 |
+| --- | --- |
+| createLoadOptions() | このファイル形式のデフォルトのロードオプションを作成します |
+
+ **Result:**
+LoadOptions
+
+
+---
+
+
+### createSaveOptions{#createSaveOptions}
+
+| 名前 | 説明 |
+| --- | --- |
+| createSaveOptions() | このファイル形式のデフォルトの保存オプションを作成します |
+
+ **Result:**
+SaveOptions
+
+
+---
+
+
+### toString{#toString}
+
+| 名前 | 説明 |
+| --- | --- |
+| toString() | フォーマットを文字列に変換 |
+
+ **Result:**
+文字列
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/fileformattype/_index.md
+++ b/japanese/nodejs-java/aspose.threed/fileformattype/_index.md
@@ -1,0 +1,66 @@
+---
+title: "FileFormatType"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/fileformattype/
+---
+## FileFormatType class
+
+ファイル形式のタイプ  @hideconstructor
+
+
+## プロパティ
+
+| 名前 | 説明 |
+| --- | --- |
+| MAYA | Autodesk Maya のフォーマットタイプ |
+| FBX | FBX ファイルフォーマットタイプ |
+| STL | STL ファイルフォーマットタイプ |
+| COLLADA | Khronos Group の Collada ファイル形式です。 |
+| PDF | ポータブルドキュメントフォーマット |
+| GLTF | Khronos GroupのglTF |
+| DXF | AutoCAD DXF |
+| PLY | Polygon File FormatまたはStanford Triangle Format |
+| X | DirectX の X ファイル |
+| DRACO | Google Draco Mesh |
+| RVM | AVEVA Plant Design Management System モデルです。 |
+| ASE | 3D Studio Max の ASCII Scene Exporter フォーマット。 |
+| ZIP | 他の 3d ファイル形式を含む Zip アーカイブ。 |
+| USD | ユニバーサルシーン記述 |
+| PCD | Point Cloud Library が使用するポイントクラウドデータ |
+| XYZ | Xyz 点群ファイル |
+| IFC | ISO 16739-1 Industry Foundation Classes データモデル。 |
+| AMF | 付加製造ファイルフォーマット |
+| VRML | バーチャルリアリティモデリング言語 |
+
+## メソッド
+
+### getExtension{#getExtension}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExtension() | このファイル形式の拡張子名は、先頭が . です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| 名前 | 説明 |
+| --- | --- |
+| toString() | このファイル形式タイプの名前を取得します |
+
+ **Result:**
+文字列
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/filesystem/_index.md
+++ b/japanese/nodejs-java/aspose.threed/filesystem/_index.md
@@ -1,0 +1,56 @@
+---
+title: "FileSystem"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/filesystem/
+---
+## FileSystem class
+
+ファイルシステムのカプセル化。Aspose.3D はこれを使用して依存関係の読み書きを行います。  @hideconstructor
+
+
+## メソッド
+
+### readFile{#readFile}
+
+| 名前 | 説明 |
+| --- | --- |
+| readFile(fileName, options) | 依存関係を読み取るためのストリームを作成します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| fileNam | 文字列 | null |
+| オプション | IOConfig | null |
+
+ **Result:**
+Stream
+
+
+---
+
+
+### writeFile{#writeFile}
+
+| 名前 | 説明 |
+| --- | --- |
+| writeFile(fileName, options) | 依存関係を書き込むためのストリームを作成します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| fileNam | 文字列 | null |
+| オプション | IOConfig | null |
+
+ **Result:**
+Stream
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/fmatrix4/_index.md
+++ b/japanese/nodejs-java/aspose.threed/fmatrix4/_index.md
@@ -1,0 +1,190 @@
+---
+title: "FMatrix4"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/fmatrix4/
+---
+## FMatrix4 class
+
+すべての要素が float 型の 4x4 行列
+
+
+## プロパティ
+
+| 名前 | 説明 |
+| --- | --- |
+| m00 | m00です。 |
+| m01 | m01です。 |
+| m02 | m02です。 |
+| m03 | m03です。 |
+| m10 | m10です。 |
+| m11 | m11です。 |
+| m12 | m12です。 |
+| m13 | m13です。 |
+| m20 | m20です。 |
+| m21 | m21です。 |
+| m22 | m22です。 |
+| m23 | m23です。 |
+| m30 | m30です。 |
+| m31 | m31です。 |
+| m32 | m32です。 |
+| m33 | m33です。 |
+| IDENTITY | 単位行列です。 |
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload(m00, m01, m02, m03, m10, m11, m12, m13, m20, m21, m22, m23, m30, m31, m32, m33) | FMatrix4 のインスタンスを初期化する |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| m0 | 数 | null |
+| m0 | 数 | null |
+| m0 | 数 | null |
+| m0 | 数 | null |
+| m1 | 数 | null |
+| m1 | 数 | null |
+| m1 | 数 | null |
+| m1 | 数 | null |
+| m2 | 数 | null |
+| m2 | 数 | null |
+| m2 | 数 | null |
+| m2 | 数 | null |
+| m3 | 数 | null |
+| m3 | 数 | null |
+| m3 | 数 | null |
+| m3 | 数 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload2(mat) | Matrix4 インスタンスから FMatrix4 のインスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| ma | Matrix4 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload3{#constructor_overload3}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload3(r0, r1, r2, r3) | 4 行から行列を構築します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| r0 | FVector4 | R0. |
+| r1 | FVector4 | R1. |
+| r2 | FVector4 | R2. |
+| r3 | FVector4 | R3. |
+
+ **Result:**
+
+
+
+---
+
+
+### concatenate{#concatenate}
+
+| 名前 | 説明 |
+| --- | --- |
+| concatenate(m2) | 2 つの行列を連結します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| m2 | FMatrix4 | M2. |
+
+ **Result:**
+FMatrix4
+
+
+---
+
+
+### concatenate{#concatenate}
+
+| 名前 | 説明 |
+| --- | --- |
+| concatenate(m2) | 2 つの行列を連結します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| m2 | Matrix4 | M2. |
+
+ **Result:**
+FMatrix4
+
+
+---
+
+
+### transpose{#transpose}
+
+| 名前 | 説明 |
+| --- | --- |
+| transpose() | このインスタンスを転置します。 |
+
+ **Result:**
+FMatrix4
+
+
+---
+
+
+### inverse{#inverse}
+
+| 名前 | 説明 |
+| --- | --- |
+| inverse() | 現在のインスタンスの逆行列を計算します。 |
+
+ **Result:**
+FMatrix4
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/fontfile/_index.md
+++ b/japanese/nodejs-java/aspose.threed/fontfile/_index.md
@@ -1,0 +1,189 @@
+---
+title: "FontFile"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/fontfile/
+---
+## FontFile class
+
+フォントファイルにはグリフの定義が含まれており、テキストプロファイルの作成に使用されます。  @hideconstructor
+
+
+## メソッド
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### fromFile{#fromFile}
+
+| 名前 | 説明 |
+| --- | --- |
+| fromFile(fileName) | ファイル名から FontFile をロードします |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| fileName | 文字列 | フォントファイルへのパス |
+
+ **Result:**
+FontFile
+
+
+---
+
+
+### parse{#parse}
+
+| 名前 | 説明 |
+| --- | --- |
+| parse(bytes) | バイト列から FontFile を解析します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| バイト列 | byte[] | OTF フォントファイルの生データ |
+
+ **Result:**
+FontFile
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/frustum/_index.md
+++ b/japanese/nodejs-java/aspose.threed/frustum/_index.md
@@ -1,0 +1,489 @@
+---
+title: "フラスタム"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/frustum/
+---
+## Frustum class
+
+Camera と Light の基底クラス  @hideconstructor
+
+
+## メソッド
+
+### getRotationMode{#getRotationMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getRotationMode() | 視錐台の向きモードを取得または設定します。このプロパティは Target が null の場合にのみ機能します。値が RotationMode.FIXED_TARGET の場合、方向は常に LookAt プロパティによって計算されます。それ以外の場合、LookAt は常に Direction によって計算されます。プロパティの値は RotationMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setRotationMode{#setRotationMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setRotationMode(value) | 視錐台の向きモードを取得または設定します。このプロパティは Target が null の場合にのみ機能します。値が RotationMode.FIXED_TARGET の場合、方向は常に LookAt プロパティによって計算されます。それ以外の場合、LookAt は常に Direction によって計算されます。プロパティの値は RotationMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getNearPlane{#getNearPlane}
+
+| 名前 | 説明 |
+| --- | --- |
+| getNearPlane() | 視錐台の近接平面距離を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setNearPlane{#setNearPlane}
+
+| 名前 | 説明 |
+| --- | --- |
+| setNearPlane(value) | 視錐台の近接平面距離を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFarPlane{#getFarPlane}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFarPlane() | フラスタムの遠平面距離を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFarPlane{#setFarPlane}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFarPlane(value) | フラスタムの遠平面距離を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getAspect{#getAspect}
+
+| 名前 | 説明 |
+| --- | --- |
+| getAspect() | フラスタムのアスペクト比を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setAspect{#setAspect}
+
+| 名前 | 説明 |
+| --- | --- |
+| setAspect(value) | フラスタムのアスペクト比を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getOrthoHeight{#getOrthoHeight}
+
+| 名前 | 説明 |
+| --- | --- |
+| getOrthoHeight() | フラスタムが正射影の場合の高さを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setOrthoHeight{#setOrthoHeight}
+
+| 名前 | 説明 |
+| --- | --- |
+| setOrthoHeight(value) | フラスタムが正射影の場合の高さを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getUp{#getUp}
+
+| 名前 | 説明 |
+| --- | --- |
+| getUp() | カメラの上方向ベクトルを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setUp{#setUp}
+
+| 名前 | 説明 |
+| --- | --- |
+| setUp(value) | カメラの上方向ベクトルを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookAt{#getLookAt}
+
+| 名前 | 説明 |
+| --- | --- |
+| getLookAt() | カメラが注目している位置を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setLookAt{#setLookAt}
+
+| 名前 | 説明 |
+| --- | --- |
+| setLookAt(value) | カメラが注目している位置を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getDirection{#getDirection}
+
+| 名前 | 説明 |
+| --- | --- |
+| getDirection() | カメラが向いている方向を取得または設定します。このプロパティの変更は LookAt と Target にも影響します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setDirection{#setDirection}
+
+| 名前 | 説明 |
+| --- | --- |
+| setDirection(value) | カメラが向いている方向を取得または設定します。このプロパティの変更は LookAt と Target にも影響します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getTarget{#getTarget}
+
+| 名前 | 説明 |
+| --- | --- |
+| getTarget() | カメラが向いているターゲットを取得または設定します。ユーザーがこのプロパティをサポートしている場合、LookAt プロパティよりも先に設定すべきです。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setTarget{#setTarget}
+
+| 名前 | 説明 |
+| --- | --- |
+| setTarget(value) | カメラが向いているターゲットを取得または設定します。ユーザーがこのプロパティをサポートしている場合、LookAt プロパティよりも先に設定すべきです。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNodes() | すべての親ノードを取得します。エンティティはジオメトリインスタンシングのために複数の親ノードにアタッチできます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExcluded() | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExcluded(value) | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNode() | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setParentNode(value) | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 名前 | 説明 |
+| --- | --- |
+| getScene() | このオブジェクトが属するシーンを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBoundingBox() | 現在のエンティティのオブジェクト空間座標系におけるバウンディングボックスを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEntityRendererKey() | レンダラーに登録されたエンティティレンダラーのキーを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/fvector2/_index.md
+++ b/japanese/nodejs-java/aspose.threed/fvector2/_index.md
@@ -1,0 +1,126 @@
+---
+title: "FVector2"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/fvector2/
+---
+## FVector2 class
+
+2 要素の float ベクトルです。
+
+
+## プロパティ
+
+| 名前 | 説明 |
+| --- | --- |
+| x | x 成分。 |
+| y | y 成分。 |
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload(x, y) | FVector2 の新しいインスタンスを初期化します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload2(vec) | FVector2 の新しいインスタンスを初期化します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| 名前 | 説明 |
+| --- | --- |
+| toString() |  |
+
+ **Result:**
+文字列
+
+
+---
+
+
+### equals{#equals}
+
+| 名前 | 説明 |
+| --- | --- |
+| equals(rhs) | 2つのベクトルが等しいか確認します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| rh | FVector2 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### equals{#equals}
+
+| 名前 | 説明 |
+| --- | --- |
+| equals(obj) | 2つのベクトルが等しいか確認します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| ob | オブジェクト | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### hashCode{#hashCode}
+
+| 名前 | 説明 |
+| --- | --- |
+| hashCode() | このインスタンスのハッシュコードを取得します |
+
+ **Result:**
+数
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/fvector3/_index.md
+++ b/japanese/nodejs-java/aspose.threed/fvector3/_index.md
@@ -1,0 +1,123 @@
+---
+title: "FVector3"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/fvector3/
+---
+## FVector3 class
+
+3 要素の float ベクトルです。
+
+
+## プロパティ
+
+| 名前 | 説明 |
+| --- | --- |
+| x | x 成分。 |
+| y | y 成分。 |
+| z | y 成分。 |
+| ゼロ | ゼロベクトルです。 |
+| UNIT_SCALE | すべての成分が 1 の単位スケールベクトルです |
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload(x, y, z) | FVector3 の新しいインスタンスを初期化します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload2(vec) | FVector3 の新しいインスタンスを初期化します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload3{#constructor_overload3}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload3(vec) | FVector4 の新しいインスタンスを初期化します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| 名前 | 説明 |
+| --- | --- |
+| toString() |  |
+
+ **Result:**
+文字列
+
+
+---
+
+
+### normalize{#normalize}
+
+| 名前 | 説明 |
+| --- | --- |
+| normalize() | このインスタンスを正規化します。 |
+
+ **Result:**
+FVector3
+
+
+---
+
+
+### cross{#cross}
+
+| 名前 | 説明 |
+| --- | --- |
+| cross(rhs) | 2つのベクトルの外積 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| rhs | FVector3 | 右側の値です。 |
+
+ **Result:**
+FVector3
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/fvector4/_index.md
+++ b/japanese/nodejs-java/aspose.threed/fvector4/_index.md
@@ -1,0 +1,116 @@
+---
+title: "FVector4"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/fvector4/
+---
+## FVector4 class
+
+4 要素の float ベクトルです。
+
+
+## プロパティ
+
+| 名前 | 説明 |
+| --- | --- |
+| x | x 成分。 |
+| y | y 成分。 |
+| z | z 成分。 |
+| w | w コンポーネントです。 |
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload(x, y, z, w) | FVector4 の新しいインスタンスを初期化します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload2(x, y, z) | FVector4 の新しいインスタンスを初期化します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload3{#constructor_overload3}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload3(vec) | FVector4 の新しいインスタンスを初期化します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload4{#constructor_overload4}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload4(vec) | FVector4 の新しいインスタンスを初期化します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload5{#constructor_overload5}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload5(vec, w) | FVector4 の新しいインスタンスを初期化します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| 名前 | 説明 |
+| --- | --- |
+| toString() |  |
+
+ **Result:**
+文字列
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/geometry/_index.md
+++ b/japanese/nodejs-java/aspose.threed/geometry/_index.md
@@ -1,0 +1,528 @@
+---
+title: "ジオメトリ"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/geometry/
+---
+## Geometry class
+
+すべてのレンダリング可能な幾何オブジェクト（Mesh、NurbsSurface、Patch など）の基底クラスです。Geometry 基底クラスは以下をサポートします：制御点の管理、制御点はジオメトリの基本的な 3D 空間構造を定義し、ジオメトリの種類に応じて具体的な 3D モデルの定義方法が異なります。頂点要素の定義、頂点要素は法線や UV 座標、頂点カラーなどの追加情報をジオメトリに適用します。詳細は VertexElement を参照してください。オブジェクトの変形、Deformer を結合してジオメトリの形状をアニメーション化できます。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor(name) | Geometry クラスの新しいインスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| name | 文字列 | 名前 |
+
+ **Result:**
+
+
+
+---
+
+
+### getVisible{#getVisible}
+
+| 名前 | 説明 |
+| --- | --- |
+| getVisible() | ジオメトリが表示されているかどうかを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setVisible{#setVisible}
+
+| 名前 | 説明 |
+| --- | --- |
+| setVisible(value) | ジオメトリが表示されているかどうかを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getDeformers{#getDeformers}
+
+| 名前 | 説明 |
+| --- | --- |
+| getDeformers() | このジオメトリに関連付けられたすべてのデフォーマーを取得します。デフォーマー。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getControlPoints{#getControlPoints}
+
+| 名前 | 説明 |
+| --- | --- |
+| getControlPoints() | すべての制御点を取得します |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastShadows{#getCastShadows}
+
+| 名前 | 説明 |
+| --- | --- |
+| getCastShadows() | このジオメトリが影を落とすかどうかを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastShadows{#setCastShadows}
+
+| 名前 | 説明 |
+| --- | --- |
+| setCastShadows(value) | このジオメトリが影を落とすかどうかを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getReceiveShadows{#getReceiveShadows}
+
+| 名前 | 説明 |
+| --- | --- |
+| getReceiveShadows() | このジオメトリが影を受け取るかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setReceiveShadows{#setReceiveShadows}
+
+| 名前 | 説明 |
+| --- | --- |
+| setReceiveShadows(value) | このジオメトリが影を受け取るかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElements{#getVertexElements}
+
+| 名前 | 説明 |
+| --- | --- |
+| getVertexElements() | すべての頂点要素を取得します |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNodes() | すべての親ノードを取得します。エンティティはジオメトリインスタンシングのために複数の親ノードにアタッチできます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExcluded() | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExcluded(value) | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNode() | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setParentNode(value) | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 名前 | 説明 |
+| --- | --- |
+| getScene() | このオブジェクトが属するシーンを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getElement{#getElement}
+
+| 名前 | 説明 |
+| --- | --- |
+| getElement(type) | 指定されたタイプの頂点要素を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| type | VertexElementType | VertexElementType |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### getVertexElementOfUV{#getVertexElementOfUV}
+
+| 名前 | 説明 |
+| --- | --- |
+| getVertexElementOfUV(textureMapping) | 指定されたテクスチャマッピングタイプの VertexElementUV インスタンスを取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| textureMapping | TextureMapping | TextureMapping |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### createElement{#createElement}
+
+| 名前 | 説明 |
+| --- | --- |
+| createElement(type) | 指定されたタイプの頂点要素を作成し、ジオメトリに追加します。type が VertexElementType.UV の場合、テクスチャマッピングタイプが TextureMapping.DIFFUSE の VertexElementUV が作成されます。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| type | VertexElementType | VertexElementType |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### addElement{#addElement}
+
+| 名前 | 説明 |
+| --- | --- |
+| addElement(element) | 既存の頂点要素を現在のジオメトリに追加します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| element | VertexElement | 追加する頂点要素 |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### createElement{#createElement}
+
+| 名前 | 説明 |
+| --- | --- |
+| createElement(type, mappingMode, referenceMode) | 指定されたタイプの頂点要素を作成し、ジオメトリに追加します。type が VertexElementType.UV の場合、テクスチャマッピングタイプが TextureMapping.DIFFUSE の VertexElementUV が作成されます。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| type | VertexElementType | VertexElementType |
+| mappingMode | MappingMode | MappingMode |
+| referenceMode | ReferenceMode | ReferenceMode |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### createElementUV{#createElementUV}
+
+| 名前 | 説明 |
+| --- | --- |
+| createElementUV(uvMapping) | 指定されたテクスチャマッピングタイプで VertexElementUV を作成します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| uvMapping | TextureMapping | TextureMapping |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### createElementUV{#createElementUV}
+
+| 名前 | 説明 |
+| --- | --- |
+| createElementUV(uvMapping, mappingMode, referenceMode) | 指定されたテクスチャマッピングタイプで VertexElementUV を作成します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| uvMapping | TextureMapping | TextureMapping |
+| mappingMode | MappingMode | MappingMode |
+| referenceMode | ReferenceMode | ReferenceMode |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBoundingBox() | 現在のエンティティのオブジェクト空間座標系におけるバウンディングボックスを取得します。 |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEntityRendererKey() | レンダラーに登録されたエンティティレンダラーのキーを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/globaltransform/_index.md
+++ b/japanese/nodejs-java/aspose.threed/globaltransform/_index.md
@@ -1,0 +1,81 @@
+---
+title: "GlobalTransform"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/globaltransform/
+---
+## GlobalTransform class
+
+Global transform は Transform と似ていますが、最終的に評価された変換を表すため不変です。グローバルトランスフォームの評価には右手座標系が使用されます。  @hideconstructor
+
+
+## メソッド
+
+### getTranslation{#getTranslation}
+
+| 名前 | 説明 |
+| --- | --- |
+| getTranslation() | 平行移動を取得します |
+
+ **Result:**
+
+
+
+---
+
+
+### getScale{#getScale}
+
+| 名前 | 説明 |
+| --- | --- |
+| getScale() | スケールを取得します |
+
+ **Result:**
+
+
+
+---
+
+
+### getEulerAngles{#getEulerAngles}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEulerAngles() | オイラー角（度単位）で表される回転を取得します |
+
+ **Result:**
+
+
+
+---
+
+
+### getRotation{#getRotation}
+
+| 名前 | 説明 |
+| --- | --- |
+| getRotation() | クォータニオンで表される回転を取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getTransformMatrix{#getTransformMatrix}
+
+| 名前 | 説明 |
+| --- | --- |
+| getTransformMatrix() | 変換行列を取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/glslsource/_index.md
+++ b/japanese/nodejs-java/aspose.threed/glslsource/_index.md
@@ -1,0 +1,153 @@
+---
+title: "GLSLSource"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/glslsource/
+---
+## GLSLSource class
+
+GLSL のシェーダーのソースコード
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getComputeShader{#getComputeShader}
+
+| 名前 | 説明 |
+| --- | --- |
+| getComputeShader() | コンピュートシェーダーのソースコードを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setComputeShader{#setComputeShader}
+
+| 名前 | 説明 |
+| --- | --- |
+| setComputeShader(value) | コンピュートシェーダーのソースコードを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getGeometryShader{#getGeometryShader}
+
+| 名前 | 説明 |
+| --- | --- |
+| getGeometryShader() | ジオメトリシェーダーのソースコードを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setGeometryShader{#setGeometryShader}
+
+| 名前 | 説明 |
+| --- | --- |
+| setGeometryShader(value) | ジオメトリシェーダーのソースコードを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexShader{#getVertexShader}
+
+| 名前 | 説明 |
+| --- | --- |
+| getVertexShader() | 頂点シェーダーのソースコードを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setVertexShader{#setVertexShader}
+
+| 名前 | 説明 |
+| --- | --- |
+| setVertexShader(value) | 頂点シェーダーのソースコードを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getFragmentShader{#getFragmentShader}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFragmentShader() | フラグメントシェーダーのソースコードを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFragmentShader{#setFragmentShader}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFragmentShader(value) | フラグメントシェーダーのソースコードを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### defineInclude{#defineInclude}
+
+| 名前 | 説明 |
+| --- | --- |
+| defineInclude(fileName, content) | GLSL ソースコード内の #include 用の仮想ファイルを定義します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| fileName | 文字列 | 仮想ファイルのファイル名 |
+| コンテンツ | 文字列 | null |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/gltfloadoptions/_index.md
+++ b/japanese/nodejs-java/aspose.threed/gltfloadoptions/_index.md
@@ -1,0 +1,146 @@
+---
+title: "GltfLoadOptions"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/gltfloadoptions/
+---
+## GltfLoadOptions class
+
+glTF 形式のロードオプション
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | GltfLoadOptions のコンストラクタ |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlipTexCoordV{#getFlipTexCoordV}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFlipTexCoordV() | メッシュのテクスチャ座標における v(t) 座標を反転します。デフォルト値は true です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlipTexCoordV{#setFlipTexCoordV}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFlipTexCoordV(value) | メッシュのテクスチャ座標における v(t) 座標を反転します。デフォルト値は true です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileFormat() | 現在の保存/読み込みオプションで指定されたファイル形式を取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEncoding() | テキストベースのファイルのデフォルトエンコーディングを取得または設定します。デフォルト値は null で、インポーター/エクスポーターが使用するエンコーディングを決定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileSystem() | ロード/セーブ時に外部依存関係を管理する方法をユーザーが処理できるようにします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFileSystem(value) | ロード/セーブ時に外部依存関係を管理する方法をユーザーが処理できるようにします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| 名前 | 説明 |
+| --- | --- |
+| getLookupPaths() | OBJ のような一部のファイルは外部ファイルに依存しており、検索パスにより Aspose.3D が外部ファイルを探してロードできるようになります。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileName() | エクスポート/インポートシーンのファイル名です。これはオプションですが、OBJ のマテリアルなど外部アセットをシリアライズする際に便利です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFileName(value) | エクスポート/インポートシーンのファイル名です。これはオプションですが、OBJ のマテリアルなど外部アセットをシリアライズする際に便利です。 |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/gltfsaveoptions/_index.md
+++ b/japanese/nodejs-java/aspose.threed/gltfsaveoptions/_index.md
@@ -1,0 +1,470 @@
+---
+title: "GltfSaveOptions"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/gltfsaveoptions/
+---
+## GltfSaveOptions class
+
+glTF 形式の保存オプションです。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor(contentType) | GltfSaveOptions のコンストラクタ |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| contentType | FileContentType | FileContentType |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload(format) | GltfSaveOptions のコンストラクタ |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| 形式 | ファイル形式 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### getPrettyPrint{#getPrettyPrint}
+
+| 名前 | 説明 |
+| --- | --- |
+| getPrettyPrint() | GLTF ファイルの JSON コンテンツは人間が読みやすいようにインデントされます。デフォルト値は false です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setPrettyPrint{#setPrettyPrint}
+
+| 名前 | 説明 |
+| --- | --- |
+| setPrettyPrint(value) | GLTF ファイルの JSON コンテンツは人間が読みやすいようにインデントされます。デフォルト値は false です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFallbackNormal{#getFallbackNormal}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFallbackNormal() | GLTF2 エクスポーターが無効な法線を検出したとき、検証を回避するために元の値の代わりにこれが使用されます。デフォルト値は (0, 1, 0) です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEmbedAssets{#getEmbedAssets}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEmbedAssets() | すべての外部アセットを base64 でエンコードし、ASCII モードで単一ファイルに埋め込みます。デフォルト値は false です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setEmbedAssets{#setEmbedAssets}
+
+| 名前 | 説明 |
+| --- | --- |
+| setEmbedAssets(value) | すべての外部アセットを base64 でエンコードし、ASCII モードで単一ファイルに埋め込みます。デフォルト値は false です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getImageFormat{#getImageFormat}
+
+| 名前 | 説明 |
+| --- | --- |
+| getImageFormat() | 標準の glTF はテクスチャ形式として PNG/JPG のみをサポートしており、このオプションはエクスポート時に Aspose.3D が非標準画像をサポートされている形式に変換する方法を案内します。デフォルト値は GltfEmbeddedImageFormat.PNG です。このプロパティの値は GltfEmbeddedImageFormat の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setImageFormat{#setImageFormat}
+
+| 名前 | 説明 |
+| --- | --- |
+| setImageFormat(value) | 標準の glTF はテクスチャ形式として PNG/JPG のみをサポートしており、このオプションはエクスポート時に Aspose.3D が非標準画像をサポートされている形式に変換する方法を案内します。デフォルト値は GltfEmbeddedImageFormat.PNG です。このプロパティの値は GltfEmbeddedImageFormat の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getMaterialConverter{#getMaterialConverter}
+
+| 名前 | 説明 |
+| --- | --- |
+| getMaterialConverter() | ジオメトリのマテリアルを PBR マテリアルに変換するカスタムコンバータです。これが未設定の場合、glTF 2.0 エクスポーターは標準マテリアルを自動的に PBR マテリアルに変換します。デフォルト値は null です。このプロパティはシーンを glTF 2.0 ファイルにエクスポートする際に使用されます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setMaterialConverter{#setMaterialConverter}
+
+| 名前 | 説明 |
+| --- | --- |
+| setMaterialConverter(value) | ジオメトリのマテリアルを PBR マテリアルに変換するカスタムコンバータです。これが未設定の場合、glTF 2.0 エクスポーターは標準マテリアルを自動的に PBR マテリアルに変換します。デフォルト値は null です。このプロパティはシーンを glTF 2.0 ファイルにエクスポートする際に使用されます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getUseCommonMaterials{#getUseCommonMaterials}
+
+| 名前 | 説明 |
+| --- | --- |
+| getUseCommonMaterials() | KHR 共通マテリアル拡張を使用してマテリアルをシリアライズします。デフォルト値は false です。これを false に設定すると、#Error Cref: P:Aspose.ThreeD.Formats.GltfSaveOptions.ExportShaders がある場合に Aspose.3D が頂点/フラグメントシェーダのセットをエクスポートします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setUseCommonMaterials{#setUseCommonMaterials}
+
+| 名前 | 説明 |
+| --- | --- |
+| setUseCommonMaterials(value) | KHR 共通マテリアル拡張を使用してマテリアルをシリアライズします。デフォルト値は false です。これを false に設定すると、#Error Cref: P:Aspose.ThreeD.Formats.GltfSaveOptions.ExportShaders がある場合に Aspose.3D が頂点/フラグメントシェーダのセットをエクスポートします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExternalDracoEncoder{#getExternalDracoEncoder}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExternalDracoEncoder() | 外部の draco エンコーダを使用して draco 圧縮速度を高速化します。Aspose.3D はメッシュを draco 形式にエンコードするための新しいサブプロセスを作成します。自己責任で使用してください。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExternalDracoEncoder{#setExternalDracoEncoder}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExternalDracoEncoder(value) | 外部の draco エンコーダを使用して draco 圧縮速度を高速化します。Aspose.3D はメッシュを draco 形式にエンコードするための新しいサブプロセスを作成します。自己責任で使用してください。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlipTexCoordV{#getFlipTexCoordV}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFlipTexCoordV() | テクスチャ座標 v(t) 成分を反転します。デフォルト値は true です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlipTexCoordV{#setFlipTexCoordV}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFlipTexCoordV(value) | テクスチャ座標 v(t) 成分を反転します。デフォルト値は true です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getBufferFile{#getBufferFile}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBufferFile() | バイナリデータを格納するために使用される外部バッファファイルのファイル名です。このファイルが指定されていない場合、Aspose.3D が名前を自動生成します。glTF をバイナリモードでエクスポートする際は無視されます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setBufferFile{#setBufferFile}
+
+| 名前 | 説明 |
+| --- | --- |
+| setBufferFile(value) | バイナリデータを格納するために使用される外部バッファファイルのファイル名です。このファイルが指定されていない場合、Aspose.3D が名前を自動生成します。glTF をバイナリモードでエクスポートする際は無視されます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getSaveExtras{#getSaveExtras}
+
+| 名前 | 説明 |
+| --- | --- |
+| getSaveExtras() | シーンオブジェクトの動的プロパティを生成された glTF ファイルの 'extra' フィールドに保存します。アプリケーション固有のデータを提供するのに便利です。デフォルト値は false です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setSaveExtras{#setSaveExtras}
+
+| 名前 | 説明 |
+| --- | --- |
+| setSaveExtras(value) | シーンオブジェクトの動的プロパティを生成された glTF ファイルの 'extra' フィールドに保存します。アプリケーション固有のデータを提供するのに便利です。デフォルト値は false です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getApplyUnitScale{#getApplyUnitScale}
+
+| 名前 | 説明 |
+| --- | --- |
+| getApplyUnitScale() | AssetInfo.UnitScaleFactor をメッシュに適用します。デフォルト値は false です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setApplyUnitScale{#setApplyUnitScale}
+
+| 名前 | 説明 |
+| --- | --- |
+| setApplyUnitScale(value) | AssetInfo.UnitScaleFactor をメッシュに適用します。デフォルト値は false です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getDracoCompression{#getDracoCompression}
+
+| 名前 | 説明 |
+| --- | --- |
+| getDracoCompression() | draco 圧縮を有効にするかどうかを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setDracoCompression{#setDracoCompression}
+
+| 名前 | 説明 |
+| --- | --- |
+| setDracoCompression(value) | draco 圧縮を有効にするかどうかを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportTextures{#getExportTextures}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExportTextures() | シーンで使用されているテクスチャを出力ディレクトリにコピーしようとします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextures{#setExportTextures}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExportTextures(value) | シーンで使用されているテクスチャを出力ディレクトリにコピーしようとします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileFormat() | 現在の保存/読み込みオプションで指定されたファイル形式を取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEncoding() | テキストベースのファイルのデフォルトエンコーディングを取得または設定します。デフォルト値は null で、インポーター/エクスポーターが使用するエンコーディングを決定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileSystem() | ロード/セーブ時に外部依存関係を管理する方法をユーザーが処理できるようにします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFileSystem(value) | ロード/セーブ時に外部依存関係を管理する方法をユーザーが処理できるようにします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| 名前 | 説明 |
+| --- | --- |
+| getLookupPaths() | OBJ のような一部のファイルは外部ファイルに依存しており、検索パスにより Aspose.3D が外部ファイルを探してロードできるようになります。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileName() | エクスポート/インポートシーンのファイル名です。これはオプションですが、OBJ のマテリアルなど外部アセットをシリアライズする際に便利です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFileName(value) | エクスポート/インポートシーンのファイル名です。これはオプションですが、OBJ のマテリアルなど外部アセットをシリアライズする際に便利です。 |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/hollowcircleshape/_index.md
+++ b/japanese/nodejs-java/aspose.threed/hollowcircleshape/_index.md
@@ -1,0 +1,333 @@
+---
+title: "HollowCircleShape"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/hollowcircleshape/
+---
+## HollowCircleShape class
+
+IFC 互換の中空円形プロファイルです。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getWallThickness{#getWallThickness}
+
+| 名前 | 説明 |
+| --- | --- |
+| getWallThickness() | 外側半径と内側半径の差を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setWallThickness{#setWallThickness}
+
+| 名前 | 説明 |
+| --- | --- |
+| setWallThickness(value) | 外側半径と内側半径の差を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getRadius{#getRadius}
+
+| 名前 | 説明 |
+| --- | --- |
+| getRadius() | 円の半径を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setRadius{#setRadius}
+
+| 名前 | 説明 |
+| --- | --- |
+| setRadius(value) | 円の半径を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNodes() | すべての親ノードを取得します。エンティティはジオメトリインスタンシングのために複数の親ノードにアタッチできます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExcluded() | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExcluded(value) | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNode() | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setParentNode(value) | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 名前 | 説明 |
+| --- | --- |
+| getScene() | このオブジェクトが属するシーンを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtent{#getExtent}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExtent() | x と y の次元での範囲を取得します |
+
+ **Result:**
+Vector2
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEntityRendererKey() | レンダラーに登録されたエンティティレンダラーのキーを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBoundingBox() | 現在のエンティティのオブジェクト空間座標系におけるバウンディングボックスを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/hollowrectangleshape/_index.md
+++ b/japanese/nodejs-java/aspose.threed/hollowrectangleshape/_index.md
@@ -1,0 +1,411 @@
+---
+title: "HollowRectangleShape"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/hollowrectangleshape/
+---
+## HollowRectangleShape class
+
+IFC 互換の中空長方形形状で、内側と外側の角が丸められています。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getWallThickness{#getWallThickness}
+
+| 名前 | 説明 |
+| --- | --- |
+| getWallThickness() | 矩形の境界と内部の穴との間の厚さです。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setWallThickness{#setWallThickness}
+
+| 名前 | 説明 |
+| --- | --- |
+| setWallThickness(value) | 矩形の境界と内部の穴との間の厚さです。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getInnerFilletRadius{#getInnerFilletRadius}
+
+| 名前 | 説明 |
+| --- | --- |
+| getInnerFilletRadius() | 内部矩形の内側フィレット半径です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setInnerFilletRadius{#setInnerFilletRadius}
+
+| 名前 | 説明 |
+| --- | --- |
+| setInnerFilletRadius(value) | 内部矩形の内側フィレット半径です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getRoundingRadius{#getRoundingRadius}
+
+| 名前 | 説明 |
+| --- | --- |
+| getRoundingRadius() | すべての四隅の円弧の半径を取得または設定します（単位は度）。デフォルト値は 0.0 です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setRoundingRadius{#setRoundingRadius}
+
+| 名前 | 説明 |
+| --- | --- |
+| setRoundingRadius(value) | すべての四隅の円弧の半径を取得または設定します（単位は度）。デフォルト値は 0.0 です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getXDim{#getXDim}
+
+| 名前 | 説明 |
+| --- | --- |
+| getXDim() | 矩形の x 軸方向の広がりを取得または設定します。デフォルト値は 2.0 です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setXDim{#setXDim}
+
+| 名前 | 説明 |
+| --- | --- |
+| setXDim(value) | 矩形の x 軸方向の広がりを取得または設定します。デフォルト値は 2.0 です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getYDim{#getYDim}
+
+| 名前 | 説明 |
+| --- | --- |
+| getYDim() | 矩形の y 軸方向の広がりを取得または設定します。デフォルト値は 2.0 です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setYDim{#setYDim}
+
+| 名前 | 説明 |
+| --- | --- |
+| setYDim(value) | 矩形の y 軸方向の広がりを取得または設定します。デフォルト値は 2.0 です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNodes() | すべての親ノードを取得します。エンティティはジオメトリインスタンシングのために複数の親ノードにアタッチできます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExcluded() | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExcluded(value) | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNode() | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setParentNode(value) | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 名前 | 説明 |
+| --- | --- |
+| getScene() | このオブジェクトが属するシーンを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtent{#getExtent}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExtent() | x と y の次元での範囲を取得します |
+
+ **Result:**
+Vector2
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEntityRendererKey() | レンダラーに登録されたエンティティレンダラーのキーを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBoundingBox() | 現在のエンティティのオブジェクト空間座標系におけるバウンディングボックスを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/hshape/_index.md
+++ b/japanese/nodejs-java/aspose.threed/hshape/_index.md
@@ -1,0 +1,541 @@
+---
+title: "HShape"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/hshape/
+---
+## HShape class
+
+HShape は 'H' または 'I' 形状の定義パラメータを提供します。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | HShape のコンストラクタ |
+
+ **Result:**
+
+
+
+---
+
+
+### getOverallDepth{#getOverallDepth}
+
+| 名前 | 説明 |
+| --- | --- |
+| getOverallDepth() | 深さの範囲を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setOverallDepth{#setOverallDepth}
+
+| 名前 | 説明 |
+| --- | --- |
+| setOverallDepth(value) | 深さの範囲を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getBottomFlangeWidth{#getBottomFlangeWidth}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBottomFlangeWidth() | 幅の範囲を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setBottomFlangeWidth{#setBottomFlangeWidth}
+
+| 名前 | 説明 |
+| --- | --- |
+| setBottomFlangeWidth(value) | 幅の範囲を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getTopFlangeWidth{#getTopFlangeWidth}
+
+| 名前 | 説明 |
+| --- | --- |
+| getTopFlangeWidth() | 上フランジの幅を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setTopFlangeWidth{#setTopFlangeWidth}
+
+| 名前 | 説明 |
+| --- | --- |
+| setTopFlangeWidth(value) | 上フランジの幅を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getTopFlangeThickness{#getTopFlangeThickness}
+
+| 名前 | 説明 |
+| --- | --- |
+| getTopFlangeThickness() | 上フランジの厚さを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setTopFlangeThickness{#setTopFlangeThickness}
+
+| 名前 | 説明 |
+| --- | --- |
+| setTopFlangeThickness(value) | 上フランジの厚さを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getTopFlangeEdgeRadius{#getTopFlangeEdgeRadius}
+
+| 名前 | 説明 |
+| --- | --- |
+| getTopFlangeEdgeRadius() | 上フランジの下部エッジの半径を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setTopFlangeEdgeRadius{#setTopFlangeEdgeRadius}
+
+| 名前 | 説明 |
+| --- | --- |
+| setTopFlangeEdgeRadius(value) | 上フランジの下部エッジの半径を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getTopFlangeFilletRadius{#getTopFlangeFilletRadius}
+
+| 名前 | 説明 |
+| --- | --- |
+| getTopFlangeFilletRadius() | ウェブと上フランジ間のフィレット半径を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setTopFlangeFilletRadius{#setTopFlangeFilletRadius}
+
+| 名前 | 説明 |
+| --- | --- |
+| setTopFlangeFilletRadius(value) | ウェブと上フランジ間のフィレット半径を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getBottomFlangeThickness{#getBottomFlangeThickness}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBottomFlangeThickness() | H字形のフランジ厚さを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setBottomFlangeThickness{#setBottomFlangeThickness}
+
+| 名前 | 説明 |
+| --- | --- |
+| setBottomFlangeThickness(value) | H字形のフランジ厚さを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getWebThickness{#getWebThickness}
+
+| 名前 | 説明 |
+| --- | --- |
+| getWebThickness() | H字形のウェブの厚さを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setWebThickness{#setWebThickness}
+
+| 名前 | 説明 |
+| --- | --- |
+| setWebThickness(value) | H字形のウェブの厚さを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getBottomFlangeFilletRadius{#getBottomFlangeFilletRadius}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBottomFlangeFilletRadius() | ウェブと下フランジ間のフィレット半径を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setBottomFlangeFilletRadius{#setBottomFlangeFilletRadius}
+
+| 名前 | 説明 |
+| --- | --- |
+| setBottomFlangeFilletRadius(value) | ウェブと下フランジ間のフィレット半径を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getBottomFlangeEdgeRadius{#getBottomFlangeEdgeRadius}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBottomFlangeEdgeRadius() | 下フランジの上部エッジの半径を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setBottomFlangeEdgeRadius{#setBottomFlangeEdgeRadius}
+
+| 名前 | 説明 |
+| --- | --- |
+| setBottomFlangeEdgeRadius(value) | 下フランジの上部エッジの半径を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNodes() | すべての親ノードを取得します。エンティティはジオメトリインスタンシングのために複数の親ノードにアタッチできます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExcluded() | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExcluded(value) | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNode() | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setParentNode(value) | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 名前 | 説明 |
+| --- | --- |
+| getScene() | このオブジェクトが属するシーンを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtent{#getExtent}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExtent() | x と y の次元での範囲を取得します |
+
+ **Result:**
+Vector2
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEntityRendererKey() | レンダラーに登録されたエンティティレンダラーのキーを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBoundingBox() | 現在のエンティティのオブジェクト空間座標系におけるバウンディングボックスを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/html5saveoptions/_index.md
+++ b/japanese/nodejs-java/aspose.threed/html5saveoptions/_index.md
@@ -1,0 +1,406 @@
+---
+title: "Html5SaveOptions"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/html5saveoptions/
+---
+## Html5SaveOptions class
+
+HTML5 の保存オプション
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | すべてのデフォルト設定を持つ Html5SaveOptions のコンストラクタです。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getShowGrid{#getShowGrid}
+
+| 名前 | 説明 |
+| --- | --- |
+| getShowGrid() | シーンにグリッドを表示します。デフォルト値は true です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setShowGrid{#setShowGrid}
+
+| 名前 | 説明 |
+| --- | --- |
+| setShowGrid(value) | シーンにグリッドを表示します。デフォルト値は true です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getShowRulers{#getShowRulers}
+
+| 名前 | 説明 |
+| --- | --- |
+| getShowRulers() | シーン内でモデルを測定するために x/y/z 軸の定規を表示します。デフォルト値は false です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setShowRulers{#setShowRulers}
+
+| 名前 | 説明 |
+| --- | --- |
+| setShowRulers(value) | シーン内でモデルを測定するために x/y/z 軸の定規を表示します。デフォルト値は false です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getShowUI{#getShowUI}
+
+| 名前 | 説明 |
+| --- | --- |
+| getShowUI() | シーンにシンプルな UI を表示します。デフォルト値は true です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setShowUI{#setShowUI}
+
+| 名前 | 説明 |
+| --- | --- |
+| setShowUI(value) | シーンにシンプルな UI を表示します。デフォルト値は true です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getOrientationBox{#getOrientationBox}
+
+| 名前 | 説明 |
+| --- | --- |
+| getOrientationBox() | オリエンテーションボックスを表示します。デフォルト値は true です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setOrientationBox{#setOrientationBox}
+
+| 名前 | 説明 |
+| --- | --- |
+| setOrientationBox(value) | オリエンテーションボックスを表示します。デフォルト値は true です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getUpVector{#getUpVector}
+
+| 名前 | 説明 |
+| --- | --- |
+| getUpVector() | 上方向ベクトルを取得または設定します。値は "x"/"y"/"z" のいずれかで、デフォルト値は "y" です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setUpVector{#setUpVector}
+
+| 名前 | 説明 |
+| --- | --- |
+| setUpVector(value) | 上方向ベクトルを取得または設定します。値は "x"/"y"/"z" のいずれかで、デフォルト値は "y" です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFarPlane{#getFarPlane}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFarPlane() | カメラの遠平面を取得または設定します。デフォルト値は1000です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFarPlane{#setFarPlane}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFarPlane(value) | カメラの遠平面を取得または設定します。デフォルト値は1000です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getNearPlane{#getNearPlane}
+
+| 名前 | 説明 |
+| --- | --- |
+| getNearPlane() | カメラの近平面を取得または設定します。デフォルト値は1です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setNearPlane{#setNearPlane}
+
+| 名前 | 説明 |
+| --- | --- |
+| setNearPlane(value) | カメラの近平面を取得または設定します。デフォルト値は1です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookAt{#getLookAt}
+
+| 名前 | 説明 |
+| --- | --- |
+| getLookAt() | デフォルトの注視位置を取得または設定します。デフォルト値は (0, 0, 0) です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setLookAt{#setLookAt}
+
+| 名前 | 説明 |
+| --- | --- |
+| setLookAt(value) | デフォルトの注視位置を取得または設定します。デフォルト値は (0, 0, 0) です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getCameraPosition{#getCameraPosition}
+
+| 名前 | 説明 |
+| --- | --- |
+| getCameraPosition() | カメラの初期位置を取得または設定します。デフォルト値は (10, 10, 10) です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setCameraPosition{#setCameraPosition}
+
+| 名前 | 説明 |
+| --- | --- |
+| setCameraPosition(value) | カメラの初期位置を取得または設定します。デフォルト値は (10, 10, 10) です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFieldOfView{#getFieldOfView}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFieldOfView() | 視野角を取得または設定します。デフォルト値は45で、単位は度です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFieldOfView{#setFieldOfView}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFieldOfView(value) | 視野角を取得または設定します。デフォルト値は45で、単位は度です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportTextures{#getExportTextures}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExportTextures() | シーンで使用されているテクスチャを出力ディレクトリにコピーしようとします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextures{#setExportTextures}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExportTextures(value) | シーンで使用されているテクスチャを出力ディレクトリにコピーしようとします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileFormat() | 現在の保存/読み込みオプションで指定されたファイル形式を取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEncoding() | テキストベースのファイルのデフォルトエンコーディングを取得または設定します。デフォルト値は null で、インポーター/エクスポーターが使用するエンコーディングを決定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileSystem() | ロード/セーブ時に外部依存関係を管理する方法をユーザーが処理できるようにします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFileSystem(value) | ロード/セーブ時に外部依存関係を管理する方法をユーザーが処理できるようにします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| 名前 | 説明 |
+| --- | --- |
+| getLookupPaths() | OBJ のような一部のファイルは外部ファイルに依存しており、検索パスにより Aspose.3D が外部ファイルを探してロードできるようになります。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileName() | エクスポート/インポートシーンのファイル名です。これはオプションですが、OBJ のマテリアルなど外部アセットをシリアライズする際に便利です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFileName(value) | エクスポート/インポートシーンのファイル名です。これはオプションですが、OBJ のマテリアルなど外部アセットをシリアライズする際に便利です。 |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/imagerenderoptions/_index.md
+++ b/japanese/nodejs-java/aspose.threed/imagerenderoptions/_index.md
@@ -1,0 +1,229 @@
+---
+title: "ImageRenderOptions"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/imagerenderoptions/
+---
+## ImageRenderOptions class
+
+Scene.render(com.aspose.threed.Camera, java.lang.String, com.aspose.threed.Vector2, java.lang.String, com.aspose.threed.ImageRenderOptions) および Scene.render(com.aspose.threed.Camera, com.aspose.threed.TextureData, com.aspose.threed.ImageRenderOptions) のオプション
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | ImageRenderOptions のインスタンスを初期化します |
+
+ **Result:**
+
+
+
+---
+
+
+### getBackgroundColor{#getBackgroundColor}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBackgroundColor() | レンダリング結果の背景色です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setBackgroundColor{#setBackgroundColor}
+
+| 名前 | 説明 |
+| --- | --- |
+| setBackgroundColor(value) | レンダリング結果の背景色です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getAssetDirectories{#getAssetDirectories}
+
+| 名前 | 説明 |
+| --- | --- |
+| getAssetDirectories() | 外部アセット（テクスチャなど）を格納するディレクトリ |
+
+ **Result:**
+
+
+
+---
+
+
+### getEnableShadows{#getEnableShadows}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEnableShadows() | シャドウをレンダリングするかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setEnableShadows{#setEnableShadows}
+
+| 名前 | 説明 |
+| --- | --- |
+| setEnableShadows(value) | シャドウをレンダリングするかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/importexception/_index.md
+++ b/japanese/nodejs-java/aspose.threed/importexception/_index.md
@@ -1,0 +1,35 @@
+---
+title: "ImportException"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/importexception/
+---
+## ImportException class
+
+Aspose.3D が指定されたソースのオープンに失敗したときの例外
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor(msg) | 新しいインスタンスを初期化します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| msg | 文字列 | エラーメッセージ |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/indexdatatype/_index.md
+++ b/japanese/nodejs-java/aspose.threed/indexdatatype/_index.md
@@ -1,0 +1,13 @@
+---
+title: "IndexDataType"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/indexdatatype/
+---
+## IndexDataType class
+
+定数を含むユーティリティクラスです。com.aspose.threed.IIndexBuffer の要素のデータ型  @hideconstructor
+
+

--- a/japanese/nodejs-java/aspose.threed/initializationexception/_index.md
+++ b/japanese/nodejs-java/aspose.threed/initializationexception/_index.md
@@ -1,0 +1,42 @@
+---
+title: "InitializationException"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/initializationexception/
+---
+## InitializationException class
+
+レンダーパイプライン初期化時の例外
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | InitializationException のインスタンスを初期化します |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload(msg) | 指定された例外メッセージで InitializationException のインスタンスを初期化します。 |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/ioconfig/_index.md
+++ b/japanese/nodejs-java/aspose.threed/ioconfig/_index.md
@@ -1,0 +1,133 @@
+---
+title: "IOConfig"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/ioconfig/
+---
+## IOConfig class
+
+シリアライズ/デシリアライズ用の IO 設定です。ユーザーは依存関係の検索パスなどの詳細設定や、ここでフォーマット関連の設定を指定できます。  @hideconstructor
+
+
+## メソッド
+
+### getFileSystemFactory{#getFileSystemFactory}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileSystemFactory() | FileSystem のファクトリクラスを取得または設定します。デフォルトのファクトリは LocalFileSystem を作成しますが、サーバー環境には適していません。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystemFactory{#setFileSystemFactory}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFileSystemFactory(value) | FileSystem のファクトリクラスを取得または設定します。デフォルトのファクトリは LocalFileSystem を作成しますが、サーバー環境には適していません。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileFormat() | 現在の保存/読み込みオプションで指定されたファイル形式を取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEncoding() | テキストベースのファイルのデフォルトエンコーディングを取得または設定します。デフォルト値は null で、インポーター/エクスポーターが使用するエンコーディングを決定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileSystem() | ロード/セーブ時に外部依存関係を管理する方法をユーザーが処理できるようにします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFileSystem(value) | ロード/セーブ時に外部依存関係を管理する方法をユーザーが処理できるようにします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| 名前 | 説明 |
+| --- | --- |
+| getLookupPaths() | OBJ のような一部のファイルは外部ファイルに依存しており、検索パスにより Aspose.3D が外部ファイルを探してロードできるようになります。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileName() | エクスポート/インポートシーンのファイル名です。これはオプションですが、OBJ のマテリアルなど外部アセットをシリアライズする際に便利です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFileName(value) | エクスポート/インポートシーンのファイル名です。これはオプションですが、OBJ のマテリアルなど外部アセットをシリアライズする際に便利です。 |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/ioutils/_index.md
+++ b/japanese/nodejs-java/aspose.threed/ioutils/_index.md
@@ -1,0 +1,13 @@
+---
+title: "IOUtils"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/ioutils/
+---
+## IOUtils class
+
+行列/ベクトルを書き込むためのユーティリティ（バイナリライター用）  @hideconstructor
+
+

--- a/japanese/nodejs-java/aspose.threed/keyframe/_index.md
+++ b/japanese/nodejs-java/aspose.threed/keyframe/_index.md
@@ -1,0 +1,439 @@
+---
+title: "KeyFrame"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/keyframe/
+---
+## KeyFrame class
+
+キーフレームは主に時間と値で定義され、いくつかの補間タイプでは接線/テンション/バイアス/連続性が最終的なサンプル値の計算に使用されます。キーフレーム以外の時間位置のサンプル値は、前後のキーフレーム間で補間されます。最初または最後のキーフレームの前後の値は Extrapolation クラスによって計算されます。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor(curve, time) | 指定された曲線上に新しいキーフレームを作成する |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| curve | KeyframeSequence | キー フレームが作成される曲線 |
+| 時間 | 数 | キー フレームの時間位置 |
+
+ **Result:**
+
+
+
+---
+
+
+### getTime{#getTime}
+
+| 名前 | 説明 |
+| --- | --- |
+| getTime() | list.data[index] キー フレームの時間位置を取得または設定します（秒単位で測定）。時間。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setTime{#setTime}
+
+| 名前 | 説明 |
+| --- | --- |
+| setTime(value) | list.data[index] キー フレームの時間位置を取得または設定します（秒単位で測定）。時間。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getValue{#getValue}
+
+| 名前 | 説明 |
+| --- | --- |
+| getValue() | キー フレームの値を取得または設定します。値。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setValue{#setValue}
+
+| 名前 | 説明 |
+| --- | --- |
+| setValue(value) | キー フレームの値を取得または設定します。値。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getInterpolation{#getInterpolation}
+
+| 名前 | 説明 |
+| --- | --- |
+| getInterpolation() | キーの補間タイプを取得または設定します。list.data[index] はサンプリングされた値の計算方法を定義するアルゴリズムです。プロパティの値は Interpolation 整数定数です。補間。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setInterpolation{#setInterpolation}
+
+| 名前 | 説明 |
+| --- | --- |
+| setInterpolation(value) | キーの補間タイプを取得または設定します。list.data[index] はサンプリングされた値の計算方法を定義するアルゴリズムです。プロパティの値は Interpolation 整数定数です。補間。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getTangentWeightMode{#getTangentWeightMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getTangentWeightMode() | キーのタンジェント重みモードを取得または設定します。外部タンジェントまたは次の内部タンジェントは、適切な WeightedMode を選択することでカスタマイズできます。プロパティの値は WeightedMode 整数定数です。タンジェント重みモード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setTangentWeightMode{#setTangentWeightMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setTangentWeightMode(value) | キーのタンジェント重みモードを取得または設定します。外部タンジェントまたは次の内部タンジェントは、適切な WeightedMode を選択することでカスタマイズできます。プロパティの値は WeightedMode 整数定数です。タンジェント重みモード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getStepMode{#getStepMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getStepMode() | キーのステップモードを取得または設定します。補間タイプが Interpolation.CONSTANT の場合、list.data[index] は補間中に使用されるキー フレームの値を決定します。StepMode.PREVIOUS_VALUE は左側のキー フレームの値が使用されることを意味し、StepMode.NEXT_VALUE は右側の次のキー フレームの値が使用されることを意味します。プロパティの値は StepMode 整数定数です。ステップモード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setStepMode{#setStepMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setStepMode(value) | キーのステップモードを取得または設定します。補間タイプが Interpolation.CONSTANT の場合、list.data[index] は補間中に使用されるキー フレームの値を決定します。StepMode.PREVIOUS_VALUE は左側のキー フレームの値が使用されることを意味し、StepMode.NEXT_VALUE は右側の次のキー フレームの値が使用されることを意味します。プロパティの値は StepMode 整数定数です。ステップモード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getNextInTangent{#getNextInTangent}
+
+| 名前 | 説明 |
+| --- | --- |
+| getNextInTangent() | このキー フレームの次の内部（左）タンジェントを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setNextInTangent{#setNextInTangent}
+
+| 名前 | 説明 |
+| --- | --- |
+| setNextInTangent(value) | このキー フレームの次の内部（左）タンジェントを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getOutTangent{#getOutTangent}
+
+| 名前 | 説明 |
+| --- | --- |
+| getOutTangent() | このキー フレームの外部（右）タンジェントを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setOutTangent{#setOutTangent}
+
+| 名前 | 説明 |
+| --- | --- |
+| setOutTangent(value) | このキー フレームの外部（右）タンジェントを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getOutWeight{#getOutWeight}
+
+| 名前 | 説明 |
+| --- | --- |
+| getOutWeight() | このキー フレームの外部（右）ウェイトを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setOutWeight{#setOutWeight}
+
+| 名前 | 説明 |
+| --- | --- |
+| setOutWeight(value) | このキー フレームの外部（右）ウェイトを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getNextInWeight{#getNextInWeight}
+
+| 名前 | 説明 |
+| --- | --- |
+| getNextInWeight() | このキーフレームの次のイン（左）ウェイトを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setNextInWeight{#setNextInWeight}
+
+| 名前 | 説明 |
+| --- | --- |
+| setNextInWeight(value) | このキーフレームの次のイン（左）ウェイトを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getTension{#getTension}
+
+| 名前 | 説明 |
+| --- | --- |
+| getTension() | TCB splineで使用されるテンションを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setTension{#setTension}
+
+| 名前 | 説明 |
+| --- | --- |
+| setTension(value) | TCB splineで使用されるテンションを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getContinuity{#getContinuity}
+
+| 名前 | 説明 |
+| --- | --- |
+| getContinuity() | TCB splineで使用される連続性を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setContinuity{#setContinuity}
+
+| 名前 | 説明 |
+| --- | --- |
+| setContinuity(value) | TCB splineで使用される連続性を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getBias{#getBias}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBias() | TCB splineで使用されるバイアスを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setBias{#setBias}
+
+| 名前 | 説明 |
+| --- | --- |
+| setBias(value) | TCB splineで使用されるバイアスを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndependentTangent{#getIndependentTangent}
+
+| 名前 | 説明 |
+| --- | --- |
+| getIndependentTangent() | 外部および次のインタンジェントが独立しているかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndependentTangent{#setIndependentTangent}
+
+| 名前 | 説明 |
+| --- | --- |
+| setIndependentTangent(value) | 外部および次のインタンジェントが独立しているかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlat{#getFlat}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFlat() | キーフレームがフラットかどうかを取得または設定します。次または前のキーフレームと同じ値の場合、キーフレームはフラットであるべきです。フラットなキーフレームはフラットなタンジェントと固定された補間を持ちます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlat{#setFlat}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFlat(value) | キーフレームがフラットかどうかを取得または設定します。次または前のキーフレームと同じ値の場合、キーフレームはフラットであるべきです。フラットなキーフレームはフラットなタンジェントと固定された補間を持ちます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getTimeIndependentTangent{#getTimeIndependentTangent}
+
+| 名前 | 説明 |
+| --- | --- |
+| getTimeIndependentTangent() | タンジェントが時間に依存しないかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setTimeIndependentTangent{#setTimeIndependentTangent}
+
+| 名前 | 説明 |
+| --- | --- |
+| setTimeIndependentTangent(value) | タンジェントが時間に依存しないかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| 名前 | 説明 |
+| --- | --- |
+| toString() | キーフレームの文字列表現を取得します。 |
+
+ **Result:**
+文字列
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/keyframesequence/_index.md
+++ b/japanese/nodejs-java/aspose.threed/keyframesequence/_index.md
@@ -1,0 +1,302 @@
+---
+title: "KeyframeSequence"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/keyframesequence/
+---
+## KeyframeSequence class
+
+キーフレームのシーケンスで、サンプル値が時間とともに変化する様子を記述します。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor(name) | KeyframeSequence クラスの新しいインスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| name | 文字列 | 名前 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload() | KeyframeSequence クラスの新しいインスタンスを初期化します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getBindPoint{#getBindPoint}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBindPoint() | この曲線を所有するプロパティのバインドポイントを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getKeyFrames{#getKeyFrames}
+
+| 名前 | 説明 |
+| --- | --- |
+| getKeyFrames() | この曲線のキーフレームを取得します。キーです。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getPostBehavior{#getPostBehavior}
+
+| 名前 | 説明 |
+| --- | --- |
+| getPostBehavior() | ポストビヘイビアを取得します。これは、最後のキーフレームの後にサンプル値がどうなるべきかを示します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getPreBehavior{#getPreBehavior}
+
+| 名前 | 説明 |
+| --- | --- |
+| getPreBehavior() | プリビヘイビアを取得します。これは、最初のキーの前にサンプル値がどうなるべきかを示します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### add{#add}
+
+| 名前 | 説明 |
+| --- | --- |
+| add(time, value) | 指定された値で新しいキーフレームを作成します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| 時間 | 数 | 時間位置(秒単位で測定) |
+| 値 | 数 | この時間位置の値 |
+
+ **Result:**
+
+
+
+---
+
+
+### add{#add}
+
+| 名前 | 説明 |
+| --- | --- |
+| add(time, value, interpolation) | 指定された値で新しいキーフレームを作成します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| 時間 | 数 | 時間位置(秒単位で測定) |
+| 値 | 数 | この時間位置の値 |
+| 補間 | 補間 | 補間 |
+
+ **Result:**
+
+
+
+---
+
+
+### reset{#reset}
+
+| 名前 | 説明 |
+| --- | --- |
+| reset() | すべてのキーフレームを削除し、ポスト/プリビヘイビアをリセットします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+### iterator{#iterator}
+
+| 名前 | 説明 |
+| --- | --- |
+| iterator() | 内部使用のために予約されています。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/lambertmaterial/_index.md
+++ b/japanese/nodejs-java/aspose.threed/lambertmaterial/_index.md
@@ -1,0 +1,378 @@
+---
+title: "LambertMaterial"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/lambertmaterial/
+---
+## LambertMaterial class
+
+Lambertシェーディングモデル用のマテリアル
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | LambertMaterial クラスの新しいインスタンスを初期化します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload(name) | LambertMaterial クラスの新しいインスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| name | 文字列 | 名前 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEmissiveColor{#getEmissiveColor}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEmissiveColor() | 放射色を取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setEmissiveColor{#setEmissiveColor}
+
+| 名前 | 説明 |
+| --- | --- |
+| setEmissiveColor(value) | 放射色を取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getAmbientColor{#getAmbientColor}
+
+| 名前 | 説明 |
+| --- | --- |
+| getAmbientColor() | 環境光の色を取得または設定します。例: var mat = new LambertMaterial(); mat.AmbientColor = new Vector3(1, 1, 1); ambient. |
+
+ **Result:**
+
+
+
+---
+
+
+### setAmbientColor{#setAmbientColor}
+
+| 名前 | 説明 |
+| --- | --- |
+| setAmbientColor(value) | 環境光の色を取得または設定します。例: var mat = new LambertMaterial(); mat.AmbientColor = new Vector3(1, 1, 1); ambient. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDiffuseColor{#getDiffuseColor}
+
+| 名前 | 説明 |
+| --- | --- |
+| getDiffuseColor() | 拡散色を取得または設定します。例: var mat = new LambertMaterial(); mat.DiffuseColor = new Vector3(1, 0, 0); 拡散色。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setDiffuseColor{#setDiffuseColor}
+
+| 名前 | 説明 |
+| --- | --- |
+| setDiffuseColor(value) | 拡散色を取得または設定します。例: var mat = new LambertMaterial(); mat.DiffuseColor = new Vector3(1, 0, 0); 拡散色。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getTransparentColor{#getTransparentColor}
+
+| 名前 | 説明 |
+| --- | --- |
+| getTransparentColor() | 透過色を取得または設定します。例: var mat = new LambertMaterial(); mat.TransparentColor = new Vector3(0.3, 0.5, 0.2); 透過色。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setTransparentColor{#setTransparentColor}
+
+| 名前 | 説明 |
+| --- | --- |
+| setTransparentColor(value) | 透過色を取得または設定します。例: var mat = new LambertMaterial(); mat.TransparentColor = new Vector3(0.3, 0.5, 0.2); 透過色。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getTransparency{#getTransparency}
+
+| 名前 | 説明 |
+| --- | --- |
+| getTransparency() | 透明度係数を取得または設定します。係数は0（0%、完全に不透明）から1（100%、完全に透明）の範囲である必要があります。無効な係数値はクランプされます。例: var mat = new LambertMaterial(); mat.Transparency = 0.3; 透明度係数。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setTransparency{#setTransparency}
+
+| 名前 | 説明 |
+| --- | --- |
+| setTransparency(value) | 透明度係数を取得または設定します。係数は0（0%、完全に不透明）から1（100%、完全に透明）の範囲である必要があります。無効な係数値はクランプされます。例: var mat = new LambertMaterial(); mat.Transparency = 0.3; 透明度係数。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getTexture{#getTexture}
+
+| 名前 | 説明 |
+| --- | --- |
+| getTexture(slotName) | 指定されたスロットからテクスチャを取得します。スロットはマテリアルのプロパティ名またはシェーダーのパラメータ名にすることができます。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| slotName | 文字列 | スロット名。 |
+
+ **Result:**
+TextureBase
+
+
+---
+
+
+### setTexture{#setTexture}
+
+| 名前 | 説明 |
+| --- | --- |
+| setTexture(slotName, texture) | テクスチャを指定されたスロットに設定します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| slotName | 文字列 | スロット名。 |
+| texture | TextureBase | テクスチャ。 |
+
+ **Result:**
+TextureBase
+
+
+---
+
+
+### toString{#toString}
+
+| 名前 | 説明 |
+| --- | --- |
+| toString() | オブジェクトを文字列にフォーマットします |
+
+ **Result:**
+文字列
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+### iterator{#iterator}
+
+| 名前 | 説明 |
+| --- | --- |
+| iterator() | 内部使用のために予約されています。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/license/_index.md
+++ b/japanese/nodejs-java/aspose.threed/license/_index.md
@@ -1,0 +1,61 @@
+---
+title: "ライセンス"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/license/
+---
+## License class
+
+コンポーネントのライセンスを取得するためのメソッドを提供します。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | このクラスの新しいインスタンスを初期化します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setLicense{#setLicense}
+
+| 名前 | 説明 |
+| --- | --- |
+| setLicense(licenseName) | コンポーネントにライセンスを適用します。次の場所でライセンスを検索します：1. 明示的なパス。2. Aspose コンポーネントの JAR ファイルが含まれるフォルダー。3. クライアントの呼び出し JAR ファイルが含まれるフォルダー。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setLicense{#setLicense}
+
+| 名前 | 説明 |
+| --- | --- |
+| setLicense(stream) | コンポーネントにライセンスを適用します。このメソッドを使用してストリームからライセンスをロードします。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| stream | InputStream | ライセンスを含むストリーム。 |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/light/_index.md
+++ b/japanese/nodejs-java/aspose.threed/light/_index.md
@@ -1,0 +1,827 @@
+---
+title: "Light"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/light/
+---
+## Light class
+
+光はシーンを照らします。光の総減衰を計算する式は次のとおりです:  A = ConstantAttenuation + (Dist  LinearAttenuation) + ((Dist^2)  QuadraticAttenuation)
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | Light クラスの新しいインスタンスを初期化します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload(name) | Light クラスの新しいインスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| name | 文字列 | 名前 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload2(name, type) | Light クラスの新しいインスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| name | 文字列 | 名前 |
+| type | LightType | LightType |
+
+ **Result:**
+
+
+
+---
+
+
+### getColor{#getColor}
+
+| 名前 | 説明 |
+| --- | --- |
+| getColor() | 光の色を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setColor{#setColor}
+
+| 名前 | 説明 |
+| --- | --- |
+| setColor(value) | 光の色を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getLightType{#getLightType}
+
+| 名前 | 説明 |
+| --- | --- |
+| getLightType() | 光のタイプを取得または設定します。このプロパティの値は LightType の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setLightType{#setLightType}
+
+| 名前 | 説明 |
+| --- | --- |
+| setLightType(value) | 光のタイプを取得または設定します。このプロパティの値は LightType の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastLight{#getCastLight}
+
+| 名前 | 説明 |
+| --- | --- |
+| getCastLight() | 現在の光インスタンスが他のオブジェクトを照らすかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastLight{#setCastLight}
+
+| 名前 | 説明 |
+| --- | --- |
+| setCastLight(value) | 現在の光インスタンスが他のオブジェクトを照らすかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getIntensity{#getIntensity}
+
+| 名前 | 説明 |
+| --- | --- |
+| getIntensity() | 光の強度を取得または設定します。デフォルト値は 100 です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setIntensity{#setIntensity}
+
+| 名前 | 説明 |
+| --- | --- |
+| setIntensity(value) | 光の強度を取得または設定します。デフォルト値は 100 です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getHotSpot{#getHotSpot}
+
+| 名前 | 説明 |
+| --- | --- |
+| getHotSpot() | ホットスポットの円錐角（度）を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setHotSpot{#setHotSpot}
+
+| 名前 | 説明 |
+| --- | --- |
+| setHotSpot(value) | ホットスポットの円錐角（度）を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFalloff{#getFalloff}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFalloff() | 減衰円錐角（度）を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFalloff{#setFalloff}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFalloff(value) | 減衰円錐角（度）を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getConstantAttenuation{#getConstantAttenuation}
+
+| 名前 | 説明 |
+| --- | --- |
+| getConstantAttenuation() | 光の総減衰を計算するための定数減衰を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setConstantAttenuation{#setConstantAttenuation}
+
+| 名前 | 説明 |
+| --- | --- |
+| setConstantAttenuation(value) | 光の総減衰を計算するための定数減衰を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getLinearAttenuation{#getLinearAttenuation}
+
+| 名前 | 説明 |
+| --- | --- |
+| getLinearAttenuation() | 光の総減衰を計算するための線形減衰を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setLinearAttenuation{#setLinearAttenuation}
+
+| 名前 | 説明 |
+| --- | --- |
+| setLinearAttenuation(value) | 光の総減衰を計算するための線形減衰を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getQuadraticAttenuation{#getQuadraticAttenuation}
+
+| 名前 | 説明 |
+| --- | --- |
+| getQuadraticAttenuation() | 光の総減衰を計算するための二次減衰を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setQuadraticAttenuation{#setQuadraticAttenuation}
+
+| 名前 | 説明 |
+| --- | --- |
+| setQuadraticAttenuation(value) | 光の総減衰を計算するための二次減衰を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastShadows{#getCastShadows}
+
+| 名前 | 説明 |
+| --- | --- |
+| getCastShadows() | 光が他のオブジェクトに影を落とすかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastShadows{#setCastShadows}
+
+| 名前 | 説明 |
+| --- | --- |
+| setCastShadows(value) | 光が他のオブジェクトに影を落とすかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getShadowColor{#getShadowColor}
+
+| 名前 | 説明 |
+| --- | --- |
+| getShadowColor() | 影の色を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setShadowColor{#setShadowColor}
+
+| 名前 | 説明 |
+| --- | --- |
+| setShadowColor(value) | 影の色を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getRotationMode{#getRotationMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getRotationMode() | 視錐台の向きモードを取得または設定します。このプロパティは Target が null の場合にのみ機能します。値が RotationMode.FIXED_TARGET の場合、方向は常に LookAt プロパティによって計算されます。それ以外の場合、LookAt は常に Direction によって計算されます。プロパティの値は RotationMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setRotationMode{#setRotationMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setRotationMode(value) | 視錐台の向きモードを取得または設定します。このプロパティは Target が null の場合にのみ機能します。値が RotationMode.FIXED_TARGET の場合、方向は常に LookAt プロパティによって計算されます。それ以外の場合、LookAt は常に Direction によって計算されます。プロパティの値は RotationMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getNearPlane{#getNearPlane}
+
+| 名前 | 説明 |
+| --- | --- |
+| getNearPlane() | 視錐台の近接平面距離を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setNearPlane{#setNearPlane}
+
+| 名前 | 説明 |
+| --- | --- |
+| setNearPlane(value) | 視錐台の近接平面距離を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFarPlane{#getFarPlane}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFarPlane() | フラスタムの遠平面距離を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFarPlane{#setFarPlane}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFarPlane(value) | フラスタムの遠平面距離を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getAspect{#getAspect}
+
+| 名前 | 説明 |
+| --- | --- |
+| getAspect() | フラスタムのアスペクト比を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setAspect{#setAspect}
+
+| 名前 | 説明 |
+| --- | --- |
+| setAspect(value) | フラスタムのアスペクト比を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getOrthoHeight{#getOrthoHeight}
+
+| 名前 | 説明 |
+| --- | --- |
+| getOrthoHeight() | フラスタムが正射影の場合の高さを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setOrthoHeight{#setOrthoHeight}
+
+| 名前 | 説明 |
+| --- | --- |
+| setOrthoHeight(value) | フラスタムが正射影の場合の高さを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getUp{#getUp}
+
+| 名前 | 説明 |
+| --- | --- |
+| getUp() | カメラの上方向ベクトルを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setUp{#setUp}
+
+| 名前 | 説明 |
+| --- | --- |
+| setUp(value) | カメラの上方向ベクトルを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookAt{#getLookAt}
+
+| 名前 | 説明 |
+| --- | --- |
+| getLookAt() | カメラが注目している位置を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setLookAt{#setLookAt}
+
+| 名前 | 説明 |
+| --- | --- |
+| setLookAt(value) | カメラが注目している位置を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getDirection{#getDirection}
+
+| 名前 | 説明 |
+| --- | --- |
+| getDirection() | カメラが向いている方向を取得または設定します。このプロパティの変更は LookAt と Target にも影響します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setDirection{#setDirection}
+
+| 名前 | 説明 |
+| --- | --- |
+| setDirection(value) | カメラが向いている方向を取得または設定します。このプロパティの変更は LookAt と Target にも影響します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getTarget{#getTarget}
+
+| 名前 | 説明 |
+| --- | --- |
+| getTarget() | カメラが向いているターゲットを取得または設定します。ユーザーがこのプロパティをサポートしている場合、LookAt プロパティよりも先に設定すべきです。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setTarget{#setTarget}
+
+| 名前 | 説明 |
+| --- | --- |
+| setTarget(value) | カメラが向いているターゲットを取得または設定します。ユーザーがこのプロパティをサポートしている場合、LookAt プロパティよりも先に設定すべきです。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNodes() | すべての親ノードを取得します。エンティティはジオメトリインスタンシングのために複数の親ノードにアタッチできます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExcluded() | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExcluded(value) | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNode() | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setParentNode(value) | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 名前 | 説明 |
+| --- | --- |
+| getScene() | このオブジェクトが属するシーンを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBoundingBox() | 現在のエンティティのオブジェクト空間座標系におけるバウンディングボックスを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEntityRendererKey() | レンダラーに登録されたエンティティレンダラーのキーを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/line/_index.md
+++ b/japanese/nodejs-java/aspose.threed/line/_index.md
@@ -1,0 +1,397 @@
+---
+title: "Line"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/line/
+---
+## Line class
+
+ポリラインは Geometry.ControlPoints で定義された点の集合で構成され、Segments によって接続されたパスです。つまり、接続された線分の集合とも言えます。ラインは通常線形オブジェクトであり、曲線を表すことはできません。曲線を表現するには NurbsCurve を使用します。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | Line クラスの新しいインスタンスを初期化します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload(name) | Line クラスの新しいインスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| name | 文字列 | 名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getControlPoints{#getControlPoints}
+
+| 名前 | 説明 |
+| --- | --- |
+| getControlPoints() | すべての制御点を取得します |
+
+ **Result:**
+
+
+
+---
+
+
+### getVisible{#getVisible}
+
+| 名前 | 説明 |
+| --- | --- |
+| getVisible() | ジオメトリが表示されているかどうかを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setVisible{#setVisible}
+
+| 名前 | 説明 |
+| --- | --- |
+| setVisible(value) | ジオメトリが表示されているかどうかを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getSegments{#getSegments}
+
+| 名前 | 説明 |
+| --- | --- |
+| getSegments() | ラインのセグメントを取得します |
+
+ **Result:**
+
+
+
+---
+
+
+### getColor{#getColor}
+
+| 名前 | 説明 |
+| --- | --- |
+| getColor() | 線の色を取得または設定します。デフォルト値は白 (1, 1, 1) です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setColor{#setColor}
+
+| 名前 | 説明 |
+| --- | --- |
+| setColor(value) | 線の色を取得または設定します。デフォルト値は白 (1, 1, 1) です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNodes() | すべての親ノードを取得します。エンティティはジオメトリインスタンシングのために複数の親ノードにアタッチできます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExcluded() | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExcluded(value) | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNode() | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setParentNode(value) | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 名前 | 説明 |
+| --- | --- |
+| getScene() | このオブジェクトが属するシーンを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### fromPoints{#fromPoints}
+
+| 名前 | 説明 |
+| --- | --- |
+| fromPoints(points) | ポイントの集合から Line インスタンスを構築します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| ポイント | Vector3[] | null |
+
+ **Result:**
+Line
+
+
+---
+
+
+### makeDefaultIndices{#makeDefaultIndices}
+
+| 名前 | 説明 |
+| --- | --- |
+| makeDefaultIndices() | 0,1,2,3....Geometry.ControlPoints.Length-1 のシーケンスを Segments に生成し、ControlPoints を単一のラインとして使用できるようにします |
+
+ **Result:**
+Line
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEntityRendererKey() | レンダラーに登録されたエンティティレンダラーのキーを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBoundingBox() | 現在のエンティティのオブジェクト空間座標系におけるバウンディングボックスを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/linearextrusion/_index.md
+++ b/japanese/nodejs-java/aspose.threed/linearextrusion/_index.md
@@ -1,0 +1,476 @@
+---
+title: "LinearExtrusion"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/linearextrusion/
+---
+## LinearExtrusion class
+
+線形押し出しは 2D 形状を入力として受け取り、形状を第3次元に拡張します。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | LinearExtrusion インスタンスのコンストラクタ。 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload(shape, height) | LinearExtrusion インスタンスのコンストラクタ。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getShape{#getShape}
+
+| 名前 | 説明 |
+| --- | --- |
+| getShape() | 押し出される基本形状。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setShape{#setShape}
+
+| 名前 | 説明 |
+| --- | --- |
+| setShape(value) | 押し出される基本形状。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getDirection{#getDirection}
+
+| 名前 | 説明 |
+| --- | --- |
+| getDirection() | 押し出し方向、デフォルト値は (0, 0, 1) です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setDirection{#setDirection}
+
+| 名前 | 説明 |
+| --- | --- |
+| setDirection(value) | 押し出し方向、デフォルト値は (0, 0, 1) です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getHeight{#getHeight}
+
+| 名前 | 説明 |
+| --- | --- |
+| getHeight() | 押し出されたジオメトリの高さ、デフォルト値は 1.0 です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setHeight{#setHeight}
+
+| 名前 | 説明 |
+| --- | --- |
+| setHeight(value) | 押し出されたジオメトリの高さ、デフォルト値は 1.0 です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getSlices{#getSlices}
+
+| 名前 | 説明 |
+| --- | --- |
+| getSlices() | ねじれた押し出しジオメトリのスライス数、デフォルト値は 1 です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setSlices{#setSlices}
+
+| 名前 | 説明 |
+| --- | --- |
+| setSlices(value) | ねじれた押し出しジオメトリのスライス数、デフォルト値は 1 です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getCenter{#getCenter}
+
+| 名前 | 説明 |
+| --- | --- |
+| getCenter() | この値が false の場合、線形押し出しの Z 範囲は 0 から高さまでになります。false でない場合、範囲は -height/2 から height/2 になります。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setCenter{#setCenter}
+
+| 名前 | 説明 |
+| --- | --- |
+| setCenter(value) | この値が false の場合、線形押し出しの Z 範囲は 0 から高さまでになります。false でない場合、範囲は -height/2 から height/2 になります。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getTwistOffset{#getTwistOffset}
+
+| 名前 | 説明 |
+| --- | --- |
+| getTwistOffset() | ねじりに使用されるオフセット、デフォルト値は (0, 0, 0) です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setTwistOffset{#setTwistOffset}
+
+| 名前 | 説明 |
+| --- | --- |
+| setTwistOffset(value) | ねじりに使用されるオフセット、デフォルト値は (0, 0, 0) です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getTwist{#getTwist}
+
+| 名前 | 説明 |
+| --- | --- |
+| getTwist() | 形状が押し出される角度（度）です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setTwist{#setTwist}
+
+| 名前 | 説明 |
+| --- | --- |
+| setTwist(value) | 形状が押し出される角度（度）です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNodes() | すべての親ノードを取得します。エンティティはジオメトリインスタンシングのために複数の親ノードにアタッチできます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExcluded() | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExcluded(value) | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNode() | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setParentNode(value) | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 名前 | 説明 |
+| --- | --- |
+| getScene() | このオブジェクトが属するシーンを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### toMesh{#toMesh}
+
+| 名前 | 説明 |
+| --- | --- |
+| toMesh() | 押し出しをメッシュに変換します。 |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBoundingBox() | 現在のエンティティのオブジェクト空間座標系におけるバウンディングボックスを取得します。 |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEntityRendererKey() | レンダラーに登録されたエンティティレンダラーのキーを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/loadoptions/_index.md
+++ b/japanese/nodejs-java/aspose.threed/loadoptions/_index.md
@@ -1,0 +1,107 @@
+---
+title: "LoadOptions"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/loadoptions/
+---
+## LoadOptions class
+
+さまざまなタイプのファイル読み込みオプションを構成するための基底クラスです @hideconstructor
+
+
+## メソッド
+
+### getFileFormat{#getFileFormat}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileFormat() | 現在の保存/読み込みオプションで指定されたファイル形式を取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEncoding() | テキストベースのファイルのデフォルトエンコーディングを取得または設定します。デフォルト値は null で、インポーター/エクスポーターが使用するエンコーディングを決定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileSystem() | ロード/セーブ時に外部依存関係を管理する方法をユーザーが処理できるようにします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFileSystem(value) | ロード/セーブ時に外部依存関係を管理する方法をユーザーが処理できるようにします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| 名前 | 説明 |
+| --- | --- |
+| getLookupPaths() | OBJ のような一部のファイルは外部ファイルに依存しており、検索パスにより Aspose.3D が外部ファイルを探してロードできるようになります。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileName() | エクスポート/インポートシーンのファイル名です。これはオプションですが、OBJ のマテリアルなど外部アセットをシリアライズする際に便利です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFileName(value) | エクスポート/インポートシーンのファイル名です。これはオプションですが、OBJ のマテリアルなど外部アセットをシリアライズする際に便利です。 |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/localfilesystem/_index.md
+++ b/japanese/nodejs-java/aspose.threed/localfilesystem/_index.md
@@ -1,0 +1,75 @@
+---
+title: "LocalFileSystem"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/localfilesystem/
+---
+## LocalFileSystem class
+
+LocalFileSystem は読み書き操作をローカルディレクトリにマップします。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor(directory) | 指定されたベースディレクトリで新しい LocalFileSystem を初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| ディレクター | 文字列 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### readFile{#readFile}
+
+| 名前 | 説明 |
+| --- | --- |
+| readFile(fileName, options) | 依存関係を読み取るためのストリームを作成します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| fileNam | 文字列 | null |
+| オプション | IOConfig | null |
+
+ **Result:**
+Stream
+
+
+---
+
+
+### writeFile{#writeFile}
+
+| 名前 | 説明 |
+| --- | --- |
+| writeFile(fileName, options) | 依存関係を書き込むためのストリームを作成します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| fileNam | 文字列 | null |
+| オプション | IOConfig | null |
+
+ **Result:**
+Stream
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/lshape/_index.md
+++ b/japanese/nodejs-java/aspose.threed/lshape/_index.md
@@ -1,0 +1,411 @@
+---
+title: "LShape"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/lshape/
+---
+## LShape class
+
+パラメータで定義された IFC 互換の L 形プロファイルです。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | LShape のコンストラクタ |
+
+ **Result:**
+
+
+
+---
+
+
+### getDepth{#getDepth}
+
+| 名前 | 説明 |
+| --- | --- |
+| getDepth() | プロファイルの深さを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setDepth{#setDepth}
+
+| 名前 | 説明 |
+| --- | --- |
+| setDepth(value) | プロファイルの深さを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getWidth{#getWidth}
+
+| 名前 | 説明 |
+| --- | --- |
+| getWidth() | プロファイルの幅を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setWidth{#setWidth}
+
+| 名前 | 説明 |
+| --- | --- |
+| setWidth(value) | プロファイルの幅を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getThickness{#getThickness}
+
+| 名前 | 説明 |
+| --- | --- |
+| getThickness() | 定常壁の厚さを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setThickness{#setThickness}
+
+| 名前 | 説明 |
+| --- | --- |
+| setThickness(value) | 定常壁の厚さを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFilletRadius{#getFilletRadius}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFilletRadius() | フィレットの半径を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFilletRadius{#setFilletRadius}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFilletRadius(value) | フィレットの半径を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEdgeRadius{#getEdgeRadius}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEdgeRadius() | エッジの半径を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setEdgeRadius{#setEdgeRadius}
+
+| 名前 | 説明 |
+| --- | --- |
+| setEdgeRadius(value) | エッジの半径を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNodes() | すべての親ノードを取得します。エンティティはジオメトリインスタンシングのために複数の親ノードにアタッチできます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExcluded() | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExcluded(value) | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNode() | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setParentNode(value) | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 名前 | 説明 |
+| --- | --- |
+| getScene() | このオブジェクトが属するシーンを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtent{#getExtent}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExtent() | x と y の次元での範囲を取得します |
+
+ **Result:**
+Vector2
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEntityRendererKey() | レンダラーに登録されたエンティティレンダラーのキーを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBoundingBox() | 現在のエンティティのオブジェクト空間座標系におけるバウンディングボックスを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/material/_index.md
+++ b/japanese/nodejs-java/aspose.threed/material/_index.md
@@ -1,0 +1,226 @@
+---
+title: "マテリアル"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/material/
+---
+## Material class
+
+Material はジオメトリの視覚的外観に必要なパラメータを定義します。Aspose.3D は LambertMaterial、PhongMaterial、ShaderMaterial のシェーディングモデルを提供します @hideconstructor
+
+
+## プロパティ
+
+| 名前 | 説明 |
+| --- | --- |
+| MAP_SPECULAR | setTexture(java.lang.String, com.aspose.threed.TextureBase) で使用され、スペキュラテクスチャマッピングを割り当てます。 |
+| MAP_DIFFUSE | setTexture(java.lang.String, com.aspose.threed.TextureBase) で使用され、ディフューズテクスチャマッピングを割り当てます。 |
+| MAP_EMISSIVE | setTexture(java.lang.String, com.aspose.threed.TextureBase) で使用され、エミッシブテクスチャマッピングを割り当てます。 |
+| MAP_AMBIENT | setTexture(java.lang.String, com.aspose.threed.TextureBase) で使用され、アンビエントテクスチャマッピングを割り当てます。 |
+| MAP_NORMAL | setTexture(java.lang.String, com.aspose.threed.TextureBase) で使用され、ノーマルテクスチャマッピングを割り当てます。 |
+
+## メソッド
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getTexture{#getTexture}
+
+| 名前 | 説明 |
+| --- | --- |
+| getTexture(slotName) | 指定されたスロットからテクスチャを取得します。スロットはマテリアルのプロパティ名またはシェーダーのパラメータ名にすることができます。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| slotName | 文字列 | スロット名。 |
+
+ **Result:**
+TextureBase
+
+
+---
+
+
+### setTexture{#setTexture}
+
+| 名前 | 説明 |
+| --- | --- |
+| setTexture(slotName, texture) | テクスチャを指定されたスロットに設定します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| slotName | 文字列 | スロット名。 |
+| texture | TextureBase | テクスチャ。 |
+
+ **Result:**
+TextureBase
+
+
+---
+
+
+### toString{#toString}
+
+| 名前 | 説明 |
+| --- | --- |
+| toString() | オブジェクトを文字列にフォーマットします |
+
+ **Result:**
+文字列
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+### iterator{#iterator}
+
+| 名前 | 説明 |
+| --- | --- |
+| iterator() | 内部使用のために予約されています。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/mathutils/_index.md
+++ b/japanese/nodejs-java/aspose.threed/mathutils/_index.md
@@ -1,0 +1,193 @@
+---
+title: "MathUtils"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/mathutils/
+---
+## MathUtils class
+
+便利な数学ユーティリティのセットです @hideconstructor
+
+
+## メソッド
+
+### clamp{#clamp}
+
+| 名前 | 説明 |
+| --- | --- |
+| clamp(val, min, max) | 範囲 [min, max] に値をクランプします。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| val | 数 | クランプする値。 |
+| min | 数 | 最小値。 |
+| max | 数 | 最大値。 |
+
+ **Result:**
+数
+
+
+---
+
+
+### toDegree{#toDegree}
+
+| 名前 | 説明 |
+| --- | --- |
+| toDegree(radian) | Vector3 をラジアンから度に変換します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| radian | Vector3 | ラジアンの値。 |
+
+ **Result:**
+Vector3
+
+
+---
+
+
+### toRadian{#toRadian}
+
+| 名前 | 説明 |
+| --- | --- |
+| toRadian(degree) | Vector3 を度からラジアンに変換します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| degree | Vector3 | 度の値。 |
+
+ **Result:**
+Vector3
+
+
+---
+
+
+### toDegree{#toDegree}
+
+| 名前 | 説明 |
+| --- | --- |
+| toDegree(radian) | 数値をラジアンから度に変換します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| radian | 数 | ラジアンの値。 |
+
+ **Result:**
+数
+
+
+---
+
+
+### toDegree{#toDegree}
+
+| 名前 | 説明 |
+| --- | --- |
+| toDegree(radian) | 数値をラジアンから度に変換します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| radian | 数 | ラジアンの値。 |
+
+ **Result:**
+数
+
+
+---
+
+
+### toDegree{#toDegree}
+
+| 名前 | 説明 |
+| --- | --- |
+| toDegree(x, y, z) | 数値をラジアンから度に変換します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| x | 数 | ラジアン値の x 成分。 |
+| y | 数 | ラジアン値の y 成分。 |
+| z | 数 | ラジアン値の z 成分。 |
+
+ **Result:**
+Vector3
+
+
+---
+
+
+### toRadian{#toRadian}
+
+| 名前 | 説明 |
+| --- | --- |
+| toRadian(degree) | 数値を度からラジアンに変換します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| degree | 数 | 度の値。 |
+
+ **Result:**
+数
+
+
+---
+
+
+### toRadian{#toRadian}
+
+| 名前 | 説明 |
+| --- | --- |
+| toRadian(degree) | 数値を度からラジアンに変換します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| degree | 数 | 度の値。 |
+
+ **Result:**
+数
+
+
+---
+
+
+### toRadian{#toRadian}
+
+| 名前 | 説明 |
+| --- | --- |
+| toRadian(x, y, z) | ベクトルを度からラジアンに変換する |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| x | 数 | 度単位の x 成分です。 |
+| y | 数 | 度単位の y 成分です。 |
+| z | 数 | 度単位の z 成分です。 |
+
+ **Result:**
+Vector3
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/matrix4/_index.md
+++ b/japanese/nodejs-java/aspose.threed/matrix4/_index.md
@@ -1,0 +1,453 @@
+---
+title: "Matrix4"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/matrix4/
+---
+## Matrix4 class
+
+4x4 行列の実装です。
+
+
+## プロパティ
+
+| 名前 | 説明 |
+| --- | --- |
+| m00 | m00です。 |
+| m01 | m01です。 |
+| m02 | m02です。 |
+| m03 | m03です。 |
+| m10 | m10です。 |
+| m11 | m11です。 |
+| m12 | m12です。 |
+| m13 | m13です。 |
+| m20 | m20です。 |
+| m21 | m21です。 |
+| m22 | m22です。 |
+| m23 | m23です。 |
+| m30 | m30です。 |
+| m31 | m31です。 |
+| m32 | m32です。 |
+| m33 | m33です。 |
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload(r0, r1, r2, r3) | 4 行から行列を構築します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| r0 | Vector4 | R0. |
+| r1 | Vector4 | R1. |
+| r2 | Vector4 | R2. |
+| r3 | Vector4 | R3. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload2(m00, m01, m02, m03, m10, m11, m12, m13, m20, m21, m22, m23, m30, m31, m32, m33) | Matrix4 構造体の新しいインスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| m00 | 数 | M00. |
+| m01 | 数 | M01. |
+| m02 | 数 | M02. |
+| m03 | 数 | M03. |
+| m10 | 数 | M10. |
+| m11 | 数 | M11. |
+| m12 | 数 | M12. |
+| m13 | 数 | M13. |
+| m20 | 数 | M20. |
+| m21 | 数 | M21. |
+| m22 | 数 | M22. |
+| m23 | 数 | M23. |
+| m30 | 数 | M30. |
+| m31 | 数 | M31. |
+| m32 | 数 | M32. |
+| m33 | 数 | M33. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload3{#constructor_overload3}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload3(m) | FMatrix4 インスタンスから Matrix4 を構築します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+|  | FMatrix4 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload4{#constructor_overload4}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload4(m) | Matrix4 構造体の新しいインスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| m | Number[] | M. |
+
+ **Result:**
+
+
+
+---
+
+
+### getIdentity{#getIdentity}
+
+| 名前 | 説明 |
+| --- | --- |
+| getIdentity() | 単位行列を取得します。単位行列です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getDeterminant{#getDeterminant}
+
+| 名前 | 説明 |
+| --- | --- |
+| getDeterminant() | 行列の行列式を取得します。行列式です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### concatenate{#concatenate}
+
+| 名前 | 説明 |
+| --- | --- |
+| concatenate(m2) | 2 つの行列を連結します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| m2 | Matrix4 | M2. |
+
+ **Result:**
+Matrix4
+
+
+---
+
+
+### transpose{#transpose}
+
+| 名前 | 説明 |
+| --- | --- |
+| transpose() | このインスタンスを転置します。 |
+
+ **Result:**
+Matrix4
+
+
+---
+
+
+### normalize{#normalize}
+
+| 名前 | 説明 |
+| --- | --- |
+| normalize() | このインスタンスを正規化します。 |
+
+ **Result:**
+Matrix4
+
+
+---
+
+
+### inverse{#inverse}
+
+| 名前 | 説明 |
+| --- | --- |
+| inverse() | このインスタンスを逆行列にします。 |
+
+ **Result:**
+Matrix4
+
+
+---
+
+
+### setTRS{#setTRS}
+
+| 名前 | 説明 |
+| --- | --- |
+| setTRS(translation, rotation, scale) | 平行移動/回転/スケールで行列を初期化します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| 平行移動 | Vector3 | 平行移動。 |
+| 回転 | Vector3 | 回転のオイラー角、フィールドは度単位です。 |
+| スケール | Vector3 | スケール。 |
+
+ **Result:**
+Matrix4
+
+
+---
+
+
+### toArray{#toArray}
+
+| 名前 | 説明 |
+| --- | --- |
+| toArray() | 行列を配列に変換します。 |
+
+ **Result:**
+Number[]
+
+
+---
+
+
+### toString{#toString}
+
+| 名前 | 説明 |
+| --- | --- |
+| toString() | 現在の Matrix4 を表す java.lang.String を返します。 |
+
+ **Result:**
+文字列
+
+
+---
+
+
+### translate{#translate}
+
+| 名前 | 説明 |
+| --- | --- |
+| translate(t) | x 軸、y 軸、z 軸に沿って平行移動する行列を作成します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| t | Vector3 | 平行移動オフセット |
+
+ **Result:**
+Matrix4
+
+
+---
+
+
+### translate{#translate}
+
+| 名前 | 説明 |
+| --- | --- |
+| translate(tx, ty, tz) | x 軸、y 軸、z 軸に沿って平行移動する行列を作成します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| tx | 数 | X 座標オフセット |
+| ty | 数 | Y座標オフセット |
+| tz | 数 | Z座標オフセット |
+
+ **Result:**
+Matrix4
+
+
+---
+
+
+### scale{#scale}
+
+| 名前 | 説明 |
+| --- | --- |
+| scale(s) | x軸、y軸、z軸に沿って拡大する行列を作成します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| s | Vector3 | スケーリングファクトリはx軸、y軸、z軸に適用されます |
+
+ **Result:**
+Matrix4
+
+
+---
+
+
+### scale{#scale}
+
+| 名前 | 説明 |
+| --- | --- |
+| scale(s) | x軸、y軸、z軸に沿って拡大する行列を作成します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| s | 数 | スケーリングファクトリはすべての軸に適用されます |
+
+ **Result:**
+Matrix4
+
+
+---
+
+
+### scale{#scale}
+
+| 名前 | 説明 |
+| --- | --- |
+| scale(sx, sy, sz) | x軸、y軸、z軸に沿って拡大する行列を作成します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| sx | 数 | スケーリングファクトリはx軸に適用されます |
+| sy | 数 | スケーリングファクトリはy軸に適用されます |
+| sz | 数 | スケーリングファクトリはz軸に適用されます |
+
+ **Result:**
+Matrix4
+
+
+---
+
+
+### rotateFromEuler{#rotateFromEuler}
+
+| 名前 | 説明 |
+| --- | --- |
+| rotateFromEuler(eul) | Euler角から回転行列を作成します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| eul | Vector3 | ラジアンでの回転 |
+
+ **Result:**
+Matrix4
+
+
+---
+
+
+### rotateFromEuler{#rotateFromEuler}
+
+| 名前 | 説明 |
+| --- | --- |
+| rotateFromEuler(rx, ry, rz) | Euler角から回転行列を作成します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| rx | 数 | x軸のラジアンでの回転 |
+| ry | 数 | y軸のラジアンでの回転 |
+| rz | 数 | z 軸の回転（ラジアン） |
+
+ **Result:**
+Matrix4
+
+
+---
+
+
+### rotate{#rotate}
+
+| 名前 | 説明 |
+| --- | --- |
+| rotate(angle, axis) | 回転角と軸で回転行列を作成する |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| angle | 数 | ラジアン単位の回転角 |
+| axis | Vector3 | 回転軸 |
+
+ **Result:**
+Matrix4
+
+
+---
+
+
+### rotate{#rotate}
+
+| 名前 | 説明 |
+| --- | --- |
+| rotate(q) | クォータニオンから回転行列を作成する |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| q | クォータニオン | 回転クォータニオン |
+
+ **Result:**
+Matrix4
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/memoryfilesystem/_index.md
+++ b/japanese/nodejs-java/aspose.threed/memoryfilesystem/_index.md
@@ -1,0 +1,101 @@
+---
+title: "MemoryFileSystem"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/memoryfilesystem/
+---
+## MemoryFileSystem class
+
+MemoryFileSystem は読み書き操作をメモリにマップします。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileNames{#getFileNames}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileNames() | このメモリファイルシステムに含まれるファイル名。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileContent{#getFileContent}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileContent(fileName) | 指定されたファイルの生データを返します。指定されたファイルが存在しない場合は System.IO.FileNotFoundException をスローします。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| fileNam | 文字列 | null |
+
+ **Result:**
+byte[]
+
+
+---
+
+
+### readFile{#readFile}
+
+| 名前 | 説明 |
+| --- | --- |
+| readFile(fileName, options) | 依存関係を読み取るためのストリームを作成します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| fileNam | 文字列 | null |
+| オプション | IOConfig | null |
+
+ **Result:**
+Stream
+
+
+---
+
+
+### writeFile{#writeFile}
+
+| 名前 | 説明 |
+| --- | --- |
+| writeFile(fileName, options) | 依存関係を書き込むためのストリームを作成します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| fileNam | 文字列 | null |
+| オプション | IOConfig | null |
+
+ **Result:**
+Stream
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/mesh/_index.md
+++ b/japanese/nodejs-java/aspose.threed/mesh/_index.md
@@ -1,0 +1,708 @@
+---
+title: "Mesh"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/mesh/
+---
+## Mesh class
+
+メッシュは多数の n 辺ポリゴンで構成されています。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | Mesh クラスの新しいインスタンスを初期化します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload(name) | Mesh クラスの新しいインスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| name | 文字列 | 名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEdges{#getEdges}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEdges() | Mesh のエッジを取得します。エッジはメッシュでオプションなので、空になることがあります。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getPolygonCount{#getPolygonCount}
+
+| 名前 | 説明 |
+| --- | --- |
+| getPolygonCount() | ポリゴンの数を取得します。ポリゴン数。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getPolygons{#getPolygons}
+
+| 名前 | 説明 |
+| --- | --- |
+| getPolygons() | メッシュのポリゴン定義を取得します |
+
+ **Result:**
+
+
+
+---
+
+
+### getVisible{#getVisible}
+
+| 名前 | 説明 |
+| --- | --- |
+| getVisible() | ジオメトリが表示されているかどうかを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setVisible{#setVisible}
+
+| 名前 | 説明 |
+| --- | --- |
+| setVisible(value) | ジオメトリが表示されているかどうかを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getDeformers{#getDeformers}
+
+| 名前 | 説明 |
+| --- | --- |
+| getDeformers() | このジオメトリに関連付けられたすべてのデフォーマーを取得します。デフォーマー。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getControlPoints{#getControlPoints}
+
+| 名前 | 説明 |
+| --- | --- |
+| getControlPoints() | すべての制御点を取得します |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastShadows{#getCastShadows}
+
+| 名前 | 説明 |
+| --- | --- |
+| getCastShadows() | このジオメトリが影を落とすかどうかを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastShadows{#setCastShadows}
+
+| 名前 | 説明 |
+| --- | --- |
+| setCastShadows(value) | このジオメトリが影を落とすかどうかを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getReceiveShadows{#getReceiveShadows}
+
+| 名前 | 説明 |
+| --- | --- |
+| getReceiveShadows() | このジオメトリが影を受け取るかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setReceiveShadows{#setReceiveShadows}
+
+| 名前 | 説明 |
+| --- | --- |
+| setReceiveShadows(value) | このジオメトリが影を受け取るかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElements{#getVertexElements}
+
+| 名前 | 説明 |
+| --- | --- |
+| getVertexElements() | すべての頂点要素を取得します |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNodes() | すべての親ノードを取得します。エンティティはジオメトリインスタンシングのために複数の親ノードにアタッチできます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExcluded() | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExcluded(value) | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNode() | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setParentNode(value) | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 名前 | 説明 |
+| --- | --- |
+| getScene() | このオブジェクトが属するシーンを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getPolygonSize{#getPolygonSize}
+
+| 名前 | 説明 |
+| --- | --- |
+| getPolygonSize(index) | 指定されたポリゴンの頂点数を取得します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| index | 数 | インデックス。 |
+
+ **Result:**
+数
+
+
+---
+
+
+### createPolygon{#createPolygon}
+
+| 名前 | 説明 |
+| --- | --- |
+| createPolygon(indices, offset, length) | indices で定義されたすべての頂点を持つ新しいポリゴンを作成します。頂点ごとにポリゴンを作成する場合は、PolygonBuilder を使用してください。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| indices | Number[] | ポリゴンのインデックスの配列です。各インデックスはポリゴンを構成する制御点を指します。 |
+| offset | 数 | 最初のポリゴンインデックスのオフセット |
+| length | 数 | インデックスの長さ |
+
+ **Result:**
+数
+
+
+---
+
+
+### createPolygon{#createPolygon}
+
+| 名前 | 説明 |
+| --- | --- |
+| createPolygon(indices) | indices で定義されたすべての頂点を持つ新しいポリゴンを作成します。頂点ごとにポリゴンを作成する場合は、PolygonBuilder を使用してください。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| indices | Number[] | ポリゴンのインデックスの配列です。各インデックスはポリゴンを構成する制御点を指します。 |
+
+ **Result:**
+数
+
+
+---
+
+
+### createPolygon{#createPolygon}
+
+| 名前 | 説明 |
+| --- | --- |
+| createPolygon(v1, v2, v3, v4) | 4つの頂点（クアッド）を持つポリゴンを作成します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| v1 | 数 | 最初の頂点のインデックス |
+| v2 | 数 | 2番目の頂点のインデックス |
+| v3 | 数 | 3番目の頂点のインデックス |
+| v4 | 数 | 4番目の頂点のインデックス |
+
+ **Result:**
+数
+
+
+---
+
+
+### createPolygon{#createPolygon}
+
+| 名前 | 説明 |
+| --- | --- |
+| createPolygon(v1, v2, v3) | 3つの頂点（三角形）でポリゴンを作成 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| v1 | 数 | 最初の頂点のインデックス |
+| v2 | 数 | 2番目の頂点のインデックス |
+| v3 | 数 | 3番目の頂点のインデックス |
+
+ **Result:**
+数
+
+
+---
+
+
+### toMesh{#toMesh}
+
+| 名前 | 説明 |
+| --- | --- |
+| toMesh() | 現在のエンティティから Mesh インスタンスを取得します。 |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getElement{#getElement}
+
+| 名前 | 説明 |
+| --- | --- |
+| getElement(type) | 指定されたタイプの頂点要素を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| type | VertexElementType | VertexElementType |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### getVertexElementOfUV{#getVertexElementOfUV}
+
+| 名前 | 説明 |
+| --- | --- |
+| getVertexElementOfUV(textureMapping) | 指定されたテクスチャマッピングタイプの VertexElementUV インスタンスを取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| textureMapping | TextureMapping | TextureMapping |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### createElement{#createElement}
+
+| 名前 | 説明 |
+| --- | --- |
+| createElement(type) | 指定されたタイプの頂点要素を作成し、ジオメトリに追加します。type が VertexElementType.UV の場合、テクスチャマッピングタイプが TextureMapping.DIFFUSE の VertexElementUV が作成されます。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| type | VertexElementType | VertexElementType |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### addElement{#addElement}
+
+| 名前 | 説明 |
+| --- | --- |
+| addElement(element) | 既存の頂点要素を現在のジオメトリに追加します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| element | VertexElement | 追加する頂点要素 |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### createElement{#createElement}
+
+| 名前 | 説明 |
+| --- | --- |
+| createElement(type, mappingMode, referenceMode) | 指定されたタイプの頂点要素を作成し、ジオメトリに追加します。type が VertexElementType.UV の場合、テクスチャマッピングタイプが TextureMapping.DIFFUSE の VertexElementUV が作成されます。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| type | VertexElementType | VertexElementType |
+| mappingMode | MappingMode | MappingMode |
+| referenceMode | ReferenceMode | ReferenceMode |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### createElementUV{#createElementUV}
+
+| 名前 | 説明 |
+| --- | --- |
+| createElementUV(uvMapping) | 指定されたテクスチャマッピングタイプで VertexElementUV を作成します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| uvMapping | TextureMapping | TextureMapping |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### createElementUV{#createElementUV}
+
+| 名前 | 説明 |
+| --- | --- |
+| createElementUV(uvMapping, mappingMode, referenceMode) | 指定されたテクスチャマッピングタイプで VertexElementUV を作成します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| uvMapping | TextureMapping | TextureMapping |
+| mappingMode | MappingMode | MappingMode |
+| referenceMode | ReferenceMode | ReferenceMode |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBoundingBox() | 現在のエンティティのオブジェクト空間座標系におけるバウンディングボックスを取得します。 |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEntityRendererKey() | レンダラーに登録されたエンティティレンダラーのキーを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+### iterator{#iterator}
+
+| 名前 | 説明 |
+| --- | --- |
+| iterator() | 内部使用のために予約されています。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/metered/_index.md
+++ b/japanese/nodejs-java/aspose.threed/metered/_index.md
@@ -1,0 +1,75 @@
+---
+title: "Metered"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/metered/
+---
+## Metered class
+
+メータ付きキーを設定するためのメソッドを提供します。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | このクラスの新しいインスタンスを初期化します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setMeteredKey{#setMeteredKey}
+
+| 名前 | 説明 |
+| --- | --- |
+| setMeteredKey(publicKey, privateKey) | メーター付きの公開キーと秘密キーを設定します。メーター付きライセンスを購入した場合、アプリケーション起動時にこの API を呼び出す必要があります。通常はこれだけで十分です。ただし、消費データのアップロードが常に失敗し、24 時間を超えると、ライセンスは評価ステータスに設定されます。そのような事態を回避するために、ライセンスステータスを定期的に確認し、評価ステータスの場合は再度この API を呼び出してください。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| publicKey | 文字列 | 公開キー |
+| privateKey | 文字列 | プライベートキー |
+
+ **Result:**
+
+
+
+---
+
+
+### getConsumptionQuantity{#getConsumptionQuantity}
+
+| 名前 | 説明 |
+| --- | --- |
+| getConsumptionQuantity() | 消費ファイルサイズを取得します |
+
+ **Result:**
+BigDecimal
+
+
+---
+
+
+### getConsumptionCredit{#getConsumptionCredit}
+
+| 名前 | 説明 |
+| --- | --- |
+| getConsumptionCredit() | 消費クレジットを取得します |
+
+ **Result:**
+BigDecimal
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/mirroredprofile/_index.md
+++ b/japanese/nodejs-java/aspose.threed/mirroredprofile/_index.md
@@ -1,0 +1,287 @@
+---
+title: "MirroredProfile"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/mirroredprofile/
+---
+## MirroredProfile class
+
+IFC 互換のミラープロファイルです。このプロファイルは、ベースプロファイルを y 軸で鏡像化することで新しいプロファイルを定義します。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor(baseProfile) | 既存のプロファイルから新しい MirroredProfile を構築します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| baseProfile | プロファイル | 鏡像化される基礎プロファイルです。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getBaseProfile{#getBaseProfile}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBaseProfile() | 鏡像化される基礎プロファイルです。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNodes() | すべての親ノードを取得します。エンティティはジオメトリインスタンシングのために複数の親ノードにアタッチできます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExcluded() | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExcluded(value) | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNode() | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setParentNode(value) | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 名前 | 説明 |
+| --- | --- |
+| getScene() | このオブジェクトが属するシーンを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEntityRendererKey() | レンダラーに登録されたエンティティレンダラーのキーを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBoundingBox() | 現在のエンティティのオブジェクト空間座標系におけるバウンディングボックスを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/morphtargetchannel/_index.md
+++ b/japanese/nodejs-java/aspose.threed/morphtargetchannel/_index.md
@@ -1,0 +1,306 @@
+---
+title: "MorphTargetChannel"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/morphtargetchannel/
+---
+## MorphTargetChannel class
+
+MorphTargetChannel は MorphTargetDeformer によってターゲットジオメトリを整理するために使用されます。FBX のような一部のファイル形式は複数のチャネルを同時にサポートします。ウェイトは 0 から 1.0 の範囲で、ターゲットのデフォルトウェイトは 0.0 です；
+
+
+## プロパティ
+
+| 名前 | 説明 |
+| --- | --- |
+| DEFAULT_WEIGHT | モーフターゲットのデフォルトウェイトです。 |
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor(name) | MorphTargetChannel クラスの新しいインスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| name | 文字列 | 名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload() | MorphTargetChannel クラスの新しいインスタンスを初期化します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getWeights{#getWeights}
+
+| 名前 | 説明 |
+| --- | --- |
+| getWeights() | ターゲットジオメトリの完全なウェイト値を取得します。完全なウェイトです。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getChannelWeight{#getChannelWeight}
+
+| 名前 | 説明 |
+| --- | --- |
+| getChannelWeight() | このチャネルのデフォーマーウェイトを取得または設定します。ウェイトは 0.0 から 1.0 の間です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setChannelWeight{#setChannelWeight}
+
+| 名前 | 説明 |
+| --- | --- |
+| setChannelWeight(value) | このチャネルのデフォーマーウェイトを取得または設定します。ウェイトは 0.0 から 1.0 の間です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getTargets{#getTargets}
+
+| 名前 | 説明 |
+| --- | --- |
+| getTargets() | チャネルに関連付けられたすべてのターゲットを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### get{#get}
+
+| 名前 | 説明 |
+| --- | --- |
+| get(target) |  |
+
+ **Result:**
+
+
+
+---
+
+
+### set{#set}
+
+| 名前 | 説明 |
+| --- | --- |
+| set(target, value) |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getWeight{#getWeight}
+
+| 名前 | 説明 |
+| --- | --- |
+| getWeight(target) | 指定されたターゲットの重みを取得します。ターゲットがこのチャネルに属さない場合、デフォルト値の0が返されます。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| targe | シェイプ | null |
+
+ **Result:**
+数
+
+
+---
+
+
+### setWeight{#setWeight}
+
+| 名前 | 説明 |
+| --- | --- |
+| setWeight(target, weight) | 指定されたターゲットの重みを設定します。デフォルト値は1で、範囲は0〜1の間である必要があります。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| targe | シェイプ | null |
+| 重み付け | 数 | null |
+
+ **Result:**
+数
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/morphtargetdeformer/_index.md
+++ b/japanese/nodejs-java/aspose.threed/morphtargetdeformer/_index.md
@@ -1,0 +1,235 @@
+---
+title: "MorphTargetDeformer"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/morphtargetdeformer/
+---
+## MorphTargetDeformer class
+
+MorphTargetDeformer は頂点単位のアニメーションを提供します。MorphTargetDeformer はすべてのターゲットを MorphTargetChannel を介して整理し、各チャネルは複数のターゲットを管理できます。モーフターゲットデフォーマーの一般的な使用例は、キャラクターに表情を適用することです。詳細は https://en.wikipedia.org/wiki/Morph_target_animation にあります。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor(name) | MorphTargetDeformer クラスの新しいインスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| name | 文字列 | 名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload() | MorphTargetDeformer クラスの新しいインスタンスを初期化します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getChannels{#getChannels}
+
+| 名前 | 説明 |
+| --- | --- |
+| getChannels() | このデフォーマーに含まれるすべてのチャンネルを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getOwner{#getOwner}
+
+| 名前 | 説明 |
+| --- | --- |
+| getOwner() | このデフォーマーを所有するジオメトリを取得します |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### get{#get}
+
+| 名前 | 説明 |
+| --- | --- |
+| get(target) |  |
+
+ **Result:**
+
+
+
+---
+
+
+### set{#set}
+
+| 名前 | 説明 |
+| --- | --- |
+| set(target, value) |  |
+
+ **Result:**
+
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/node/_index.md
+++ b/japanese/nodejs-java/aspose.threed/node/_index.md
@@ -1,0 +1,739 @@
+---
+title: "ノード"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/node/
+---
+## Node class
+
+シーングラフ内の要素を表します。シーングラフは Node オブジェクトのツリーです。ツリー管理サービスはこのクラスに自己完結しています。Aspose.3D SDK は構築されたシーングラフの有効性を検証しないことに注意してください。呼び出し側の責任で、ノード階層に循環グラフが生成されないようにする必要があります。ツリー管理に加えて、このクラスはシーン内のオブジェクトの位置を記述するために必要なすべてのプロパティを定義します。この情報には基本的な Translation、Rotation、Scaling プロパティと、ピボット、リミット、IK ジョイント属性（剛性や減衰など）の高度なオプションが含まれます。最初に作成されたとき、Node オブジェクトは "empty"（つまり、位置情報のみを保持し、グラフィカルな表現を持たないオブジェクト）です。この状態では、ノードツリー構造の親を表すために使用できますが、それ以上の用途はほとんどありません。この種のオブジェクトの通常の使用方法は、ノードを専門化するエンティティ（"Entity"参照）を追加することです。エンティティはそれ自体がオブジェクトであり、Node に接続されます。これは、同じエンティティを複数のノードで共有できることも意味します。Camera、Light、Mesh などはすべてエンティティであり、すべて基底クラス Entity から派生しています。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | Node クラスの新しいインスタンスを初期化します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload(name, entity) | Node クラスの新しいインスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| name | 文字列 | 名前。 |
+| エンティティ | エンティティ | デフォルトエンティティ。 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload2(name) | Node クラスの新しいインスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| name | 文字列 | 名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getAssetInfo{#getAssetInfo}
+
+| 名前 | 説明 |
+| --- | --- |
+| getAssetInfo() | ノードごとのアセット情報 |
+
+ **Result:**
+
+
+
+---
+
+
+### setAssetInfo{#setAssetInfo}
+
+| 名前 | 説明 |
+| --- | --- |
+| setAssetInfo(value) | ノードごとのアセット情報 |
+
+ **Result:**
+
+
+
+---
+
+
+### getVisible{#getVisible}
+
+| 名前 | 説明 |
+| --- | --- |
+| getVisible() | ノードの表示を取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setVisible{#setVisible}
+
+| 名前 | 説明 |
+| --- | --- |
+| setVisible(value) | ノードの表示を取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getChildNodes{#getChildNodes}
+
+| 名前 | 説明 |
+| --- | --- |
+| getChildNodes() | 子ノードを取得します。ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntity{#getEntity}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEntity() | このノードに添付された最初のエンティティを取得または設定します。設定した場合、他のエンティティはクリアされます。ノードエンティティ。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setEntity{#setEntity}
+
+| 名前 | 説明 |
+| --- | --- |
+| setEntity(value) | このノードに添付された最初のエンティティを取得または設定します。設定した場合、他のエンティティはクリアされます。ノードエンティティ。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExcluded() | エクスポート時にこのノードとすべての子ノード/エンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExcluded(value) | エクスポート時にこのノードとすべての子ノード/エンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntities{#getEntities}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEntities() | すべてのノードエンティティを取得します。ノードエンティティ。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getMetaDatas{#getMetaDatas}
+
+| 名前 | 説明 |
+| --- | --- |
+| getMetaDatas() | このノードで定義されたメタデータを取得します。メタデータ。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getMaterials{#getMaterials}
+
+| 名前 | 説明 |
+| --- | --- |
+| getMaterials() | このノードに関連付けられたマテリアルを取得します。マテリアル。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getMaterial{#getMaterial}
+
+| 名前 | 説明 |
+| --- | --- |
+| getMaterial() | このノードに関連付けられた最初のマテリアルを取得または設定します。設定した場合、他のマテリアルはクリアされます。マテリアル。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setMaterial{#setMaterial}
+
+| 名前 | 説明 |
+| --- | --- |
+| setMaterial(value) | このノードに関連付けられた最初のマテリアルを取得または設定します。設定した場合、他のマテリアルはクリアされます。マテリアル。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNode() | 親ノードを取得または設定します。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setParentNode(value) | 親ノードを取得または設定します。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getTransform{#getTransform}
+
+| 名前 | 説明 |
+| --- | --- |
+| getTransform() | ローカル変換を取得します。変換。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getGlobalTransform{#getGlobalTransform}
+
+| 名前 | 説明 |
+| --- | --- |
+| getGlobalTransform() | グローバル変換を取得します。グローバル変換。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 名前 | 説明 |
+| --- | --- |
+| getScene() | このオブジェクトが属するシーンを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### createChildNode{#createChildNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| createChildNode() | 子ノードを作成します |
+
+ **Result:**
+ノード
+
+
+---
+
+
+### merge{#merge}
+
+| 名前 | 説明 |
+| --- | --- |
+| merge(node) | ノード以下のすべてを切り離し、現在のノードに添付します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| nod | ノード | null |
+
+ **Result:**
+ノード
+
+
+---
+
+
+### createChildNode{#createChildNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| createChildNode(nodeName) | 指定されたノード名で新しい子ノードを作成します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| nodeName | 文字列 | 新しい子ノードの名前 |
+
+ **Result:**
+ノード
+
+
+---
+
+
+### createChildNode{#createChildNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| createChildNode(entity) | 指定されたエンティティが添付された新しい子ノードを作成します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| エンティティ | エンティティ | ノードに添付されたデフォルトエンティティ |
+
+ **Result:**
+ノード
+
+
+---
+
+
+### createChildNode{#createChildNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| createChildNode(nodeName, entity) | 指定されたノード名で新しい子ノードを作成します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| nodeName | 文字列 | 新しい子ノードの名前 |
+| エンティティ | エンティティ | ノードに添付されたデフォルトエンティティ |
+
+ **Result:**
+ノード
+
+
+---
+
+
+### createChildNode{#createChildNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| createChildNode(nodeName, entity, material) | 指定されたノード名で新しい子ノードを作成し、指定されたエンティティとマテリアルを添付します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| nodeName | 文字列 | 新しい子ノードの名前 |
+| エンティティ | エンティティ | ノードに添付されたデフォルトエンティティ |
+| material | マテリアル | ノードに添付されたマテリアル |
+
+ **Result:**
+ノード
+
+
+---
+
+
+### evaluateGlobalTransform{#evaluateGlobalTransform}
+
+| 名前 | 説明 |
+| --- | --- |
+| evaluateGlobalTransform(withGeometricTransform) | グローバル変換を評価します。幾何変換を含めるかどうか。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| withGeometricTransform | boolean | 幾何変換が必要かどうか。 |
+
+ **Result:**
+Matrix4
+
+
+---
+
+
+### getChild{#getChild}
+
+| 名前 | 説明 |
+| --- | --- |
+| getChild(index) | 指定されたインデックスの子ノードを取得します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| index | 数 | インデックス。 |
+
+ **Result:**
+ノード
+
+
+---
+
+
+### getChild{#getChild}
+
+| 名前 | 説明 |
+| --- | --- |
+| getChild(nodeName) | 指定された名前の子ノードを取得します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| nodeName | 文字列 | 検索する子ノードの名前。 |
+
+ **Result:**
+ノード
+
+
+---
+
+
+### accept{#accept}
+
+| 名前 | 説明 |
+| --- | --- |
+| accept(visitor) | 現在のノードを含むすべての子孫ノードを走査し、ノードを visitor に渡して呼び出します。visitor は false を返すことで走査を中止できます。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| visitor | NodeVisitor | ノードを訪問するための Visitor コールバック |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### toString{#toString}
+
+| 名前 | 説明 |
+| --- | --- |
+| toString() | このノードの文字列表現を取得します。 |
+
+ **Result:**
+文字列
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBoundingBox() | ノードのバウンディングボックスを計算します。 |
+
+ **Result:**
+BoundingBox
+
+
+---
+
+
+### addEntity{#addEntity}
+
+| 名前 | 説明 |
+| --- | --- |
+| addEntity(entity) | エンティティをノードに追加します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| エンティティ | エンティティ | ノードに添付するエンティティ |
+
+ **Result:**
+BoundingBox
+
+
+---
+
+
+### addChildNode{#addChildNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| addChildNode(node) | このノードに子ノードを追加します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| ノード | ノード | 添付する子ノード |
+
+ **Result:**
+BoundingBox
+
+
+---
+
+
+### selectSingleObject{#selectSingleObject}
+
+| 名前 | 説明 |
+| --- | --- |
+| selectSingleObject(path) | XPath ライクなクエリ構文を使用して、現在のノード以下の単一オブジェクトを選択します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| pat | 文字列 | null |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### selectObjects{#selectObjects}
+
+| 名前 | 説明 |
+| --- | --- |
+| selectObjects(path) | XPath ライクなクエリ構文を使用して、現在のノード以下の複数オブジェクトを選択します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| pat | 文字列 | null |
+
+ **Result:**
+0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/nurbscurve/_index.md
+++ b/japanese/nodejs-java/aspose.threed/nurbscurve/_index.md
@@ -1,0 +1,494 @@
+---
+title: "NurbsCurve"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/nurbscurve/
+---
+## NurbsCurve class
+
+NURBS 曲線は NURBS（Non-uniform rational basis spline）で表現される曲線です。NURBS 曲線はその Order、重み付き Geometry.ControlPoints の集合、そして KnotVectors によって定義されます。制御点の w 成分は制御点の重みとして使用され、CurveDimension.TWO_DIMENSIONAL であろうと CurveDimension.THREE_DIMENSIONAL であろうと同様です。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | NurbsCurve クラスの新しいインスタンスを初期化します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload(name) | NurbsCurve クラスの新しいインスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| name | 文字列 | 名前 |
+
+ **Result:**
+
+
+
+---
+
+
+### getControlPoints{#getControlPoints}
+
+| 名前 | 説明 |
+| --- | --- |
+| getControlPoints() | すべての制御点を取得します |
+
+ **Result:**
+
+
+
+---
+
+
+### getMultiplicity{#getMultiplicity}
+
+| 名前 | 説明 |
+| --- | --- |
+| getMultiplicity() | 多重度を取得します。多重度。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getOrder{#getOrder}
+
+| 名前 | 説明 |
+| --- | --- |
+| getOrder() | NURBS 曲線の次数を取得または設定します。次数は、曲線上の任意の点に影響を与える近傍の制御点の数を定義します。次数。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setOrder{#setOrder}
+
+| 名前 | 説明 |
+| --- | --- |
+| setOrder(value) | NURBS 曲線の次数を取得または設定します。次数は、曲線上の任意の点に影響を与える近傍の制御点の数を定義します。次数。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getDimension{#getDimension}
+
+| 名前 | 説明 |
+| --- | --- |
+| getDimension() | 曲線の次元を取得または設定します。プロパティの値は CurveDimension 整数定数です。CurveDimension.TWO_DIMENSIONAL 曲線の場合、制御点の z 成分は使用されません。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setDimension{#setDimension}
+
+| 名前 | 説明 |
+| --- | --- |
+| setDimension(value) | 曲線の次元を取得または設定します。プロパティの値は CurveDimension 整数定数です。CurveDimension.TWO_DIMENSIONAL 曲線の場合、制御点の z 成分は使用されません。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getCurveType{#getCurveType}
+
+| 名前 | 説明 |
+| --- | --- |
+| getCurveType() | 曲線のタイプを取得または設定します。プロパティの値は NurbsType 整数定数です。曲線のタイプ。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setCurveType{#setCurveType}
+
+| 名前 | 説明 |
+| --- | --- |
+| setCurveType(value) | 曲線のタイプを取得または設定します。プロパティの値は NurbsType 整数定数です。曲線のタイプ。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getKnotVectors{#getKnotVectors}
+
+| 名前 | 説明 |
+| --- | --- |
+| getKnotVectors() | ノットベクトルを取得します。これはパラメータ値のシーケンスで、制御点が NURBS 曲線にどのように影響するかを決定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getRational{#getRational}
+
+| 名前 | 説明 |
+| --- | --- |
+| getRational() | 有理かどうかを取得または設定します。この値は、この NurbsCurve が有理スプラインか非有理スプラインかを示します。非有理 B スプラインは有理 B スプラインの特別なケースです。有理スプラインの場合は true、そうでない場合は非有理スプラインとして false です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setRational{#setRational}
+
+| 名前 | 説明 |
+| --- | --- |
+| setRational(value) | 有理かどうかを取得または設定します。この値は、この NurbsCurve が有理スプラインか非有理スプラインかを示します。非有理 B スプラインは有理 B スプラインの特別なケースです。有理スプラインの場合は true、そうでない場合は非有理スプラインとして false です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getColor{#getColor}
+
+| 名前 | 説明 |
+| --- | --- |
+| getColor() | 線の色を取得または設定します。デフォルト値は白 (1, 1, 1) です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setColor{#setColor}
+
+| 名前 | 説明 |
+| --- | --- |
+| setColor(value) | 線の色を取得または設定します。デフォルト値は白 (1, 1, 1) です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNodes() | すべての親ノードを取得します。エンティティはジオメトリインスタンシングのために複数の親ノードにアタッチできます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExcluded() | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExcluded(value) | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNode() | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setParentNode(value) | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 名前 | 説明 |
+| --- | --- |
+| getScene() | このオブジェクトが属するシーンを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### evaluate{#evaluate}
+
+| 名前 | 説明 |
+| --- | --- |
+| evaluate(steps) | NURBS 曲線を評価します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| steps | 数 | 隣接する2つのノット間の評価頻度です。デフォルト値は 20 です。 |
+
+ **Result:**
+Vector4[]
+
+
+---
+
+
+### evaluateAt{#evaluateAt}
+
+| 名前 | 説明 |
+| --- | --- |
+| evaluateAt(u) | 指定された位置で曲線の点を評価します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| u | 数 | 曲線上の位置で、0 から 1 の間です |
+
+ **Result:**
+Vector4
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEntityRendererKey() | レンダラーに登録されたエンティティレンダラーのキーを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBoundingBox() | 現在のエンティティのオブジェクト空間座標系におけるバウンディングボックスを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/nurbsdirection/_index.md
+++ b/japanese/nodejs-java/aspose.threed/nurbsdirection/_index.md
@@ -1,0 +1,159 @@
+---
+title: "NurbsDirection"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/nurbsdirection/
+---
+## NurbsDirection class
+
+3D NurbsSurface には 2 つの方向、NurbsSurface.U と NurbsSurface.V があり、NurbsDirection は各方向のデータを定義します。方向は実際には NURBS 曲線であり、Order、KnotVectors、そして NurbsSurface で定義された重み付き制御点の集合によっても定義されます。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getKnotVectors{#getKnotVectors}
+
+| 名前 | 説明 |
+| --- | --- |
+| getKnotVectors() | ノットベクトルを取得します。これはパラメータ値のシーケンスで、制御点が NURBS 曲線にどのように影響するかを決定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getMultiplicity{#getMultiplicity}
+
+| 名前 | 説明 |
+| --- | --- |
+| getMultiplicity() | 多重度を取得します。多重度。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getOrder{#getOrder}
+
+| 名前 | 説明 |
+| --- | --- |
+| getOrder() | NURBS 曲線の次数を取得または設定します。これは、曲線上の任意の点に影響を与える近傍の制御点の数を定義します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setOrder{#setOrder}
+
+| 名前 | 説明 |
+| --- | --- |
+| setOrder(value) | NURBS 曲線の次数を取得または設定します。これは、曲線上の任意の点に影響を与える近傍の制御点の数を定義します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getDivisions{#getDivisions}
+
+| 名前 | 説明 |
+| --- | --- |
+| getDivisions() | 現在の方向における隣接する制御点間の分割数を取得または設定します。ステップです。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setDivisions{#setDivisions}
+
+| 名前 | 説明 |
+| --- | --- |
+| setDivisions(value) | 現在の方向における隣接する制御点間の分割数を取得または設定します。ステップです。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getType{#getType}
+
+| 名前 | 説明 |
+| --- | --- |
+| getType() | 現在の方向のタイプを取得または設定します。プロパティの値は NurbsType 整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setType{#setType}
+
+| 名前 | 説明 |
+| --- | --- |
+| setType(value) | 現在の方向のタイプを取得または設定します。プロパティの値は NurbsType 整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getCount{#getCount}
+
+| 名前 | 説明 |
+| --- | --- |
+| getCount() | 現在の方向における制御点の数を取得または設定します。カウント。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setCount{#setCount}
+
+| 名前 | 説明 |
+| --- | --- |
+| setCount(value) | 現在の方向における制御点の数を取得または設定します。カウント。 |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/nurbssurface/_index.md
+++ b/japanese/nodejs-java/aspose.threed/nurbssurface/_index.md
@@ -1,0 +1,580 @@
+---
+title: "NurbsSurface"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/nurbssurface/
+---
+## NurbsSurface class
+
+NurbsSurface は NURBS（Non-uniform rational basis spline）で表現されるサーフェスです。NurbsSurface は 2 つの NurbsDirectionU と V によって定義されます。制御点の w 成分は、方向のタイプが CurveDimension.TWO_DIMENSIONAL であろうと CurveDimension.THREE_DIMENSIONAL であろうと、制御点の重みとして使用されます。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | NurbsSurface クラスの新しいインスタンスを初期化します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload(name) | NurbsSurface クラスの新しいインスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| name | 文字列 | 名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getU{#getU}
+
+| 名前 | 説明 |
+| --- | --- |
+| getU() | NURBS サーフェスの U 方向を取得します |
+
+ **Result:**
+
+
+
+---
+
+
+### getV{#getV}
+
+| 名前 | 説明 |
+| --- | --- |
+| getV() | NURBS サーフェスの V 方向を取得します |
+
+ **Result:**
+
+
+
+---
+
+
+### getVisible{#getVisible}
+
+| 名前 | 説明 |
+| --- | --- |
+| getVisible() | ジオメトリが表示されているかどうかを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setVisible{#setVisible}
+
+| 名前 | 説明 |
+| --- | --- |
+| setVisible(value) | ジオメトリが表示されているかどうかを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getDeformers{#getDeformers}
+
+| 名前 | 説明 |
+| --- | --- |
+| getDeformers() | このジオメトリに関連付けられたすべてのデフォーマーを取得します。デフォーマー。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getControlPoints{#getControlPoints}
+
+| 名前 | 説明 |
+| --- | --- |
+| getControlPoints() | すべての制御点を取得します |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastShadows{#getCastShadows}
+
+| 名前 | 説明 |
+| --- | --- |
+| getCastShadows() | このジオメトリが影を落とすかどうかを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastShadows{#setCastShadows}
+
+| 名前 | 説明 |
+| --- | --- |
+| setCastShadows(value) | このジオメトリが影を落とすかどうかを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getReceiveShadows{#getReceiveShadows}
+
+| 名前 | 説明 |
+| --- | --- |
+| getReceiveShadows() | このジオメトリが影を受け取るかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setReceiveShadows{#setReceiveShadows}
+
+| 名前 | 説明 |
+| --- | --- |
+| setReceiveShadows(value) | このジオメトリが影を受け取るかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElements{#getVertexElements}
+
+| 名前 | 説明 |
+| --- | --- |
+| getVertexElements() | すべての頂点要素を取得します |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNodes() | すべての親ノードを取得します。エンティティはジオメトリインスタンシングのために複数の親ノードにアタッチできます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExcluded() | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExcluded(value) | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNode() | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setParentNode(value) | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 名前 | 説明 |
+| --- | --- |
+| getScene() | このオブジェクトが属するシーンを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### toMesh{#toMesh}
+
+| 名前 | 説明 |
+| --- | --- |
+| toMesh() | NURBS サーフェスをメッシュに変換します |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getElement{#getElement}
+
+| 名前 | 説明 |
+| --- | --- |
+| getElement(type) | 指定されたタイプの頂点要素を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| type | VertexElementType | VertexElementType |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### getVertexElementOfUV{#getVertexElementOfUV}
+
+| 名前 | 説明 |
+| --- | --- |
+| getVertexElementOfUV(textureMapping) | 指定されたテクスチャマッピングタイプの VertexElementUV インスタンスを取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| textureMapping | TextureMapping | TextureMapping |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### createElement{#createElement}
+
+| 名前 | 説明 |
+| --- | --- |
+| createElement(type) | 指定されたタイプの頂点要素を作成し、ジオメトリに追加します。type が VertexElementType.UV の場合、テクスチャマッピングタイプが TextureMapping.DIFFUSE の VertexElementUV が作成されます。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| type | VertexElementType | VertexElementType |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### addElement{#addElement}
+
+| 名前 | 説明 |
+| --- | --- |
+| addElement(element) | 既存の頂点要素を現在のジオメトリに追加します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| element | VertexElement | 追加する頂点要素 |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### createElement{#createElement}
+
+| 名前 | 説明 |
+| --- | --- |
+| createElement(type, mappingMode, referenceMode) | 指定されたタイプの頂点要素を作成し、ジオメトリに追加します。type が VertexElementType.UV の場合、テクスチャマッピングタイプが TextureMapping.DIFFUSE の VertexElementUV が作成されます。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| type | VertexElementType | VertexElementType |
+| mappingMode | MappingMode | MappingMode |
+| referenceMode | ReferenceMode | ReferenceMode |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### createElementUV{#createElementUV}
+
+| 名前 | 説明 |
+| --- | --- |
+| createElementUV(uvMapping) | 指定されたテクスチャマッピングタイプで VertexElementUV を作成します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| uvMapping | TextureMapping | TextureMapping |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### createElementUV{#createElementUV}
+
+| 名前 | 説明 |
+| --- | --- |
+| createElementUV(uvMapping, mappingMode, referenceMode) | 指定されたテクスチャマッピングタイプで VertexElementUV を作成します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| uvMapping | TextureMapping | TextureMapping |
+| mappingMode | MappingMode | MappingMode |
+| referenceMode | ReferenceMode | ReferenceMode |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBoundingBox() | 現在のエンティティのオブジェクト空間座標系におけるバウンディングボックスを取得します。 |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEntityRendererKey() | レンダラーに登録されたエンティティレンダラーのキーを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/objloadoptions/_index.md
+++ b/japanese/nodejs-java/aspose.threed/objloadoptions/_index.md
@@ -1,0 +1,224 @@
+---
+title: "ObjLoadOptions"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/objloadoptions/
+---
+## ObjLoadOptions class
+
+Wavefront OBJ のロードオプション
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | ObjLoadOptions のコンストラクタ |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlipCoordinateSystem{#getFlipCoordinateSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFlipCoordinateSystem() | インポート時に制御点/法線の座標系を反転させるかどうかを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlipCoordinateSystem{#setFlipCoordinateSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFlipCoordinateSystem(value) | インポート時に制御点/法線の座標系を反転させるかどうかを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getEnableMaterials{#getEnableMaterials}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEnableMaterials() | 各オブジェクトのマテリアルをインポートするかどうかを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setEnableMaterials{#setEnableMaterials}
+
+| 名前 | 説明 |
+| --- | --- |
+| setEnableMaterials(value) | 各オブジェクトのマテリアルをインポートするかどうかを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getScale{#getScale}
+
+| 名前 | 説明 |
+| --- | --- |
+| getScale() | x/y/z 軸上のスケール、デフォルト値は 1.0 です |
+
+ **Result:**
+
+
+
+---
+
+
+### setScale{#setScale}
+
+| 名前 | 説明 |
+| --- | --- |
+| setScale(value) | x/y/z 軸上のスケール、デフォルト値は 1.0 です |
+
+ **Result:**
+
+
+
+---
+
+
+### getNormalizeNormal{#getNormalizeNormal}
+
+| 名前 | 説明 |
+| --- | --- |
+| getNormalizeNormal() | ロード中に法線ベクトルを正規化するかどうかを取得または設定します。デフォルト値は true です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setNormalizeNormal{#setNormalizeNormal}
+
+| 名前 | 説明 |
+| --- | --- |
+| setNormalizeNormal(value) | ロード中に法線ベクトルを正規化するかどうかを取得または設定します。デフォルト値は true です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileFormat() | 現在の保存/読み込みオプションで指定されたファイル形式を取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEncoding() | テキストベースのファイルのデフォルトエンコーディングを取得または設定します。デフォルト値は null で、インポーター/エクスポーターが使用するエンコーディングを決定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileSystem() | ロード/セーブ時に外部依存関係を管理する方法をユーザーが処理できるようにします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFileSystem(value) | ロード/セーブ時に外部依存関係を管理する方法をユーザーが処理できるようにします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| 名前 | 説明 |
+| --- | --- |
+| getLookupPaths() | OBJ のような一部のファイルは外部ファイルに依存しており、検索パスにより Aspose.3D が外部ファイルを探してロードできるようになります。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileName() | エクスポート/インポートシーンのファイル名です。これはオプションですが、OBJ のマテリアルなど外部アセットをシリアライズする際に便利です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFileName(value) | エクスポート/インポートシーンのファイル名です。これはオプションですが、OBJ のマテリアルなど外部アセットをシリアライズする際に便利です。 |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/objsaveoptions/_index.md
+++ b/japanese/nodejs-java/aspose.threed/objsaveoptions/_index.md
@@ -1,0 +1,302 @@
+---
+title: "ObjSaveOptions"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/objsaveoptions/
+---
+## ObjSaveOptions class
+
+Wavefront OBJ ファイルの保存オプション
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | ObjSaveOptions のコンストラクタ |
+
+ **Result:**
+
+
+
+---
+
+
+### getApplyUnitScale{#getApplyUnitScale}
+
+| 名前 | 説明 |
+| --- | --- |
+| getApplyUnitScale() | AssetInfo.UnitScaleFactor をメッシュに適用します。デフォルト値は false です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setApplyUnitScale{#setApplyUnitScale}
+
+| 名前 | 説明 |
+| --- | --- |
+| setApplyUnitScale(value) | AssetInfo.UnitScaleFactor をメッシュに適用します。デフォルト値は false です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getPointCloud{#getPointCloud}
+
+| 名前 | 説明 |
+| --- | --- |
+| getPointCloud() | エクスポーターがシーンをトポロジー構造なしのポイントクラウドとしてエクスポートすべきかどうかのフラグを取得または設定します。デフォルト値は false です |
+
+ **Result:**
+
+
+
+---
+
+
+### setPointCloud{#setPointCloud}
+
+| 名前 | 説明 |
+| --- | --- |
+| setPointCloud(value) | エクスポーターがシーンをトポロジー構造なしのポイントクラウドとしてエクスポートすべきかどうかのフラグを取得または設定します。デフォルト値は false です |
+
+ **Result:**
+
+
+
+---
+
+
+### getVerbose{#getVerbose}
+
+| 名前 | 説明 |
+| --- | --- |
+| getVerbose() | 各セクションのコメントを生成するかどうかを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setVerbose{#setVerbose}
+
+| 名前 | 説明 |
+| --- | --- |
+| setVerbose(value) | 各セクションのコメントを生成するかどうかを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getSerializeW{#getSerializeW}
+
+| 名前 | 説明 |
+| --- | --- |
+| getSerializeW() | モデルの頂点位置における W 成分をシリアライズするかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setSerializeW{#setSerializeW}
+
+| 名前 | 説明 |
+| --- | --- |
+| setSerializeW(value) | モデルの頂点位置における W 成分をシリアライズするかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEnableMaterials{#getEnableMaterials}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEnableMaterials() | 各オブジェクトのマテリアルのインポート/エクスポートを行うかどうかを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setEnableMaterials{#setEnableMaterials}
+
+| 名前 | 説明 |
+| --- | --- |
+| setEnableMaterials(value) | 各オブジェクトのマテリアルのインポート/エクスポートを行うかどうかを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlipCoordinateSystem{#getFlipCoordinateSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFlipCoordinateSystem() | インポート/エクスポート時に制御点/法線の座標系を反転させるかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlipCoordinateSystem{#setFlipCoordinateSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFlipCoordinateSystem(value) | インポート/エクスポート時に制御点/法線の座標系を反転させるかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportTextures{#getExportTextures}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExportTextures() | シーンで使用されているテクスチャを出力ディレクトリにコピーしようとします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextures{#setExportTextures}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExportTextures(value) | シーンで使用されているテクスチャを出力ディレクトリにコピーしようとします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileFormat() | 現在の保存/読み込みオプションで指定されたファイル形式を取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEncoding() | テキストベースのファイルのデフォルトエンコーディングを取得または設定します。デフォルト値は null で、インポーター/エクスポーターが使用するエンコーディングを決定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileSystem() | ロード/セーブ時に外部依存関係を管理する方法をユーザーが処理できるようにします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFileSystem(value) | ロード/セーブ時に外部依存関係を管理する方法をユーザーが処理できるようにします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| 名前 | 説明 |
+| --- | --- |
+| getLookupPaths() | OBJ のような一部のファイルは外部ファイルに依存しており、検索パスにより Aspose.3D が外部ファイルを探してロードできるようになります。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileName() | エクスポート/インポートシーンのファイル名です。これはオプションですが、OBJ のマテリアルなど外部アセットをシリアライズする際に便利です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFileName(value) | エクスポート/インポートシーンのファイル名です。これはオプションですが、OBJ のマテリアルなど外部アセットをシリアライズする際に便利です。 |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/parameterizedprofile/_index.md
+++ b/japanese/nodejs-java/aspose.threed/parameterizedprofile/_index.md
@@ -1,0 +1,268 @@
+---
+title: "ParameterizedProfile"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/parameterizedprofile/
+---
+## ParameterizedProfile class
+
+すべてのパラメトリックプロファイルの基底クラスです @hideconstructor
+
+
+## メソッド
+
+### getParentNodes{#getParentNodes}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNodes() | すべての親ノードを取得します。エンティティはジオメトリインスタンシングのために複数の親ノードにアタッチできます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExcluded() | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExcluded(value) | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNode() | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setParentNode(value) | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 名前 | 説明 |
+| --- | --- |
+| getScene() | このオブジェクトが属するシーンを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtent{#getExtent}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExtent() | x と y の次元での範囲を取得します |
+
+ **Result:**
+Vector2
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEntityRendererKey() | レンダラーに登録されたエンティティレンダラーのキーを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBoundingBox() | 現在のエンティティのオブジェクト空間座標系におけるバウンディングボックスを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/parseexception/_index.md
+++ b/japanese/nodejs-java/aspose.threed/parseexception/_index.md
@@ -1,0 +1,35 @@
+---
+title: "ParseException"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/parseexception/
+---
+## ParseException class
+
+Aspose.3D が入力の解析に失敗したときの例外です。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor(msg) | ParseException のコンストラクタ |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| ms | 文字列 | null |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/patch/_index.md
+++ b/japanese/nodejs-java/aspose.threed/patch/_index.md
@@ -1,0 +1,567 @@
+---
+title: "Patch"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/patch/
+---
+## Patch class
+
+Patchはパラメトリックモデリングサーフェスで、NurbsSurfaceに似ており、UとVという2つのPatchDirectionで定義されます。ただし、PatchとNurbsSurfaceの違いは、PatchDirection曲線がPatchDirectionType.BEZIER、PatchDirectionType.QUADRATIC_BEZIER、PatchDirectionType.BASIS_SPLINE、PatchDirectionType.CARDINAL_SPLINE、PatchDirectionType.LINEARのいずれかになり得ることです。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | Patch クラスの新しいインスタンスを初期化します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload(name) | Patch クラスの新しいインスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| name | 文字列 | 名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getU{#getU}
+
+| 名前 | 説明 |
+| --- | --- |
+| getU() | u 方向を取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getV{#getV}
+
+| 名前 | 説明 |
+| --- | --- |
+| getV() | v 方向を取得します。v。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getVisible{#getVisible}
+
+| 名前 | 説明 |
+| --- | --- |
+| getVisible() | ジオメトリが表示されているかどうかを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setVisible{#setVisible}
+
+| 名前 | 説明 |
+| --- | --- |
+| setVisible(value) | ジオメトリが表示されているかどうかを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getDeformers{#getDeformers}
+
+| 名前 | 説明 |
+| --- | --- |
+| getDeformers() | このジオメトリに関連付けられたすべてのデフォーマーを取得します。デフォーマー。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getControlPoints{#getControlPoints}
+
+| 名前 | 説明 |
+| --- | --- |
+| getControlPoints() | すべての制御点を取得します |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastShadows{#getCastShadows}
+
+| 名前 | 説明 |
+| --- | --- |
+| getCastShadows() | このジオメトリが影を落とすかどうかを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastShadows{#setCastShadows}
+
+| 名前 | 説明 |
+| --- | --- |
+| setCastShadows(value) | このジオメトリが影を落とすかどうかを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getReceiveShadows{#getReceiveShadows}
+
+| 名前 | 説明 |
+| --- | --- |
+| getReceiveShadows() | このジオメトリが影を受け取るかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setReceiveShadows{#setReceiveShadows}
+
+| 名前 | 説明 |
+| --- | --- |
+| setReceiveShadows(value) | このジオメトリが影を受け取るかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElements{#getVertexElements}
+
+| 名前 | 説明 |
+| --- | --- |
+| getVertexElements() | すべての頂点要素を取得します |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNodes() | すべての親ノードを取得します。エンティティはジオメトリインスタンシングのために複数の親ノードにアタッチできます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExcluded() | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExcluded(value) | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNode() | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setParentNode(value) | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 名前 | 説明 |
+| --- | --- |
+| getScene() | このオブジェクトが属するシーンを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getElement{#getElement}
+
+| 名前 | 説明 |
+| --- | --- |
+| getElement(type) | 指定されたタイプの頂点要素を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| type | VertexElementType | VertexElementType |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### getVertexElementOfUV{#getVertexElementOfUV}
+
+| 名前 | 説明 |
+| --- | --- |
+| getVertexElementOfUV(textureMapping) | 指定されたテクスチャマッピングタイプの VertexElementUV インスタンスを取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| textureMapping | TextureMapping | TextureMapping |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### createElement{#createElement}
+
+| 名前 | 説明 |
+| --- | --- |
+| createElement(type) | 指定されたタイプの頂点要素を作成し、ジオメトリに追加します。type が VertexElementType.UV の場合、テクスチャマッピングタイプが TextureMapping.DIFFUSE の VertexElementUV が作成されます。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| type | VertexElementType | VertexElementType |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### addElement{#addElement}
+
+| 名前 | 説明 |
+| --- | --- |
+| addElement(element) | 既存の頂点要素を現在のジオメトリに追加します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| element | VertexElement | 追加する頂点要素 |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### createElement{#createElement}
+
+| 名前 | 説明 |
+| --- | --- |
+| createElement(type, mappingMode, referenceMode) | 指定されたタイプの頂点要素を作成し、ジオメトリに追加します。type が VertexElementType.UV の場合、テクスチャマッピングタイプが TextureMapping.DIFFUSE の VertexElementUV が作成されます。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| type | VertexElementType | VertexElementType |
+| mappingMode | MappingMode | MappingMode |
+| referenceMode | ReferenceMode | ReferenceMode |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### createElementUV{#createElementUV}
+
+| 名前 | 説明 |
+| --- | --- |
+| createElementUV(uvMapping) | 指定されたテクスチャマッピングタイプで VertexElementUV を作成します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| uvMapping | TextureMapping | TextureMapping |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### createElementUV{#createElementUV}
+
+| 名前 | 説明 |
+| --- | --- |
+| createElementUV(uvMapping, mappingMode, referenceMode) | 指定されたテクスチャマッピングタイプで VertexElementUV を作成します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| uvMapping | TextureMapping | TextureMapping |
+| mappingMode | MappingMode | MappingMode |
+| referenceMode | ReferenceMode | ReferenceMode |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBoundingBox() | 現在のエンティティのオブジェクト空間座標系におけるバウンディングボックスを取得します。 |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEntityRendererKey() | レンダラーに登録されたエンティティレンダラーのキーを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/patchdirection/_index.md
+++ b/japanese/nodejs-java/aspose.threed/patchdirection/_index.md
@@ -1,0 +1,133 @@
+---
+title: "PatchDirection"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/patchdirection/
+---
+## PatchDirection class
+
+PatchのU方向とV方向。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getType{#getType}
+
+| 名前 | 説明 |
+| --- | --- |
+| getType() | パッチのタイプを取得または設定します。プロパティの値は PatchDirectionType の整数定数です。タイプ。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setType{#setType}
+
+| 名前 | 説明 |
+| --- | --- |
+| setType(value) | パッチのタイプを取得または設定します。プロパティの値は PatchDirectionType の整数定数です。タイプ。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getDivisions{#getDivisions}
+
+| 名前 | 説明 |
+| --- | --- |
+| getDivisions() | 隣接する制御点間の分割数を取得または設定します。ステップ。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setDivisions{#setDivisions}
+
+| 名前 | 説明 |
+| --- | --- |
+| setDivisions(value) | 隣接する制御点間の分割数を取得または設定します。ステップ。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getControlPoints{#getControlPoints}
+
+| 名前 | 説明 |
+| --- | --- |
+| getControlPoints() | 現在の方向における制御点の数を取得または設定します。カウント。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setControlPoints{#setControlPoints}
+
+| 名前 | 説明 |
+| --- | --- |
+| setControlPoints(value) | 現在の方向における制御点の数を取得または設定します。カウント。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getClosed{#getClosed}
+
+| 名前 | 説明 |
+| --- | --- |
+| getClosed() | この PatchDirection が閉曲線かどうかを示す値を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setClosed{#setClosed}
+
+| 名前 | 説明 |
+| --- | --- |
+| setClosed(value) | この PatchDirection が閉曲線かどうかを示す値を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/pbrmaterial/_index.md
+++ b/japanese/nodejs-java/aspose.threed/pbrmaterial/_index.md
@@ -1,0 +1,579 @@
+---
+title: "PbrMaterial"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/pbrmaterial/
+---
+## PbrMaterial class
+
+アルベドカラー/メタリック/ラフネスに基づく物理ベースレンダリング用マテリアル
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | デフォルトの PBR マテリアル インスタンスを作成します |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload(albedo) | 指定されたアルベドカラー値でデフォルトの PBR マテリアルを作成します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| albedo | Vector3 | デフォルトのアルベドカラー値 |
+
+ **Result:**
+
+
+
+---
+
+
+### getTransparency{#getTransparency}
+
+| 名前 | 説明 |
+| --- | --- |
+| getTransparency() | 透明度係数を取得または設定します。係数は 0（0%、完全に不透明）から 1（100%、完全に透明）までの範囲である必要があります。無効な係数値はクランプされます。透明度係数。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setTransparency{#setTransparency}
+
+| 名前 | 説明 |
+| --- | --- |
+| setTransparency(value) | 透明度係数を取得または設定します。係数は 0（0%、完全に不透明）から 1（100%、完全に透明）までの範囲である必要があります。無効な係数値はクランプされます。透明度係数。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getNormalTexture{#getNormalTexture}
+
+| 名前 | 説明 |
+| --- | --- |
+| getNormalTexture() | 法線マッピングのテクスチャを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setNormalTexture{#setNormalTexture}
+
+| 名前 | 説明 |
+| --- | --- |
+| setNormalTexture(value) | 法線マッピングのテクスチャを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getSpecularTexture{#getSpecularTexture}
+
+| 名前 | 説明 |
+| --- | --- |
+| getSpecularTexture() | 鏡面反射色のテクスチャを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setSpecularTexture{#setSpecularTexture}
+
+| 名前 | 説明 |
+| --- | --- |
+| setSpecularTexture(value) | 鏡面反射色のテクスチャを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getAlbedoTexture{#getAlbedoTexture}
+
+| 名前 | 説明 |
+| --- | --- |
+| getAlbedoTexture() | アルベドのテクスチャを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setAlbedoTexture{#setAlbedoTexture}
+
+| 名前 | 説明 |
+| --- | --- |
+| setAlbedoTexture(value) | アルベドのテクスチャを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getAlbedo{#getAlbedo}
+
+| 名前 | 説明 |
+| --- | --- |
+| getAlbedo() | マテリアルの基本色を取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setAlbedo{#setAlbedo}
+
+| 名前 | 説明 |
+| --- | --- |
+| setAlbedo(value) | マテリアルの基本色を取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getOcclusionTexture{#getOcclusionTexture}
+
+| 名前 | 説明 |
+| --- | --- |
+| getOcclusionTexture() | アンビエントオクルージョンのテクスチャを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setOcclusionTexture{#setOcclusionTexture}
+
+| 名前 | 説明 |
+| --- | --- |
+| setOcclusionTexture(value) | アンビエントオクルージョンのテクスチャを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getOcclusionFactor{#getOcclusionFactor}
+
+| 名前 | 説明 |
+| --- | --- |
+| getOcclusionFactor() | 環境遮蔽の係数を取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setOcclusionFactor{#setOcclusionFactor}
+
+| 名前 | 説明 |
+| --- | --- |
+| setOcclusionFactor(value) | 環境遮蔽の係数を取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getMetallicFactor{#getMetallicFactor}
+
+| 名前 | 説明 |
+| --- | --- |
+| getMetallicFactor() | マテリアルの金属性を取得または設定します。値が 1 の場合はマテリアルが金属であり、値が 0 の場合は誘電体です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setMetallicFactor{#setMetallicFactor}
+
+| 名前 | 説明 |
+| --- | --- |
+| setMetallicFactor(value) | マテリアルの金属性を取得または設定します。値が 1 の場合はマテリアルが金属であり、値が 0 の場合は誘電体です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getRoughnessFactor{#getRoughnessFactor}
+
+| 名前 | 説明 |
+| --- | --- |
+| getRoughnessFactor() | マテリアルの粗さを取得または設定します。値が 1 の場合は完全に粗く、値が 0 の場合は完全に滑らかです。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setRoughnessFactor{#setRoughnessFactor}
+
+| 名前 | 説明 |
+| --- | --- |
+| setRoughnessFactor(value) | マテリアルの粗さを取得または設定します。値が 1 の場合は完全に粗く、値が 0 の場合は完全に滑らかです。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getMetallicRoughness{#getMetallicRoughness}
+
+| 名前 | 説明 |
+| --- | --- |
+| getMetallicRoughness() | 金属性（R チャンネル）と粗さ（G チャンネル）のテクスチャを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setMetallicRoughness{#setMetallicRoughness}
+
+| 名前 | 説明 |
+| --- | --- |
+| setMetallicRoughness(value) | 金属性（R チャンネル）と粗さ（G チャンネル）のテクスチャを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getEmissiveTexture{#getEmissiveTexture}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEmissiveTexture() | 放射用のテクスチャを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setEmissiveTexture{#setEmissiveTexture}
+
+| 名前 | 説明 |
+| --- | --- |
+| setEmissiveTexture(value) | 放射用のテクスチャを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getEmissiveColor{#getEmissiveColor}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEmissiveColor() | 放射色を取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setEmissiveColor{#setEmissiveColor}
+
+| 名前 | 説明 |
+| --- | --- |
+| setEmissiveColor(value) | 放射色を取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### fromMaterial{#fromMaterial}
+
+| 名前 | 説明 |
+| --- | --- |
+| fromMaterial(material) | 他のマテリアルを PbrMaterial に変換できるようにします |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| マテリア | マテリアル | null |
+
+ **Result:**
+PbrMaterial
+
+
+---
+
+
+### getTexture{#getTexture}
+
+| 名前 | 説明 |
+| --- | --- |
+| getTexture(slotName) | 指定されたスロットからテクスチャを取得します。スロットはマテリアルのプロパティ名またはシェーダーのパラメータ名にすることができます。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| slotName | 文字列 | スロット名。 |
+
+ **Result:**
+TextureBase
+
+
+---
+
+
+### setTexture{#setTexture}
+
+| 名前 | 説明 |
+| --- | --- |
+| setTexture(slotName, texture) | テクスチャを指定されたスロットに設定します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| slotName | 文字列 | スロット名。 |
+| texture | TextureBase | テクスチャ。 |
+
+ **Result:**
+TextureBase
+
+
+---
+
+
+### toString{#toString}
+
+| 名前 | 説明 |
+| --- | --- |
+| toString() | オブジェクトを文字列にフォーマットします |
+
+ **Result:**
+文字列
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+### iterator{#iterator}
+
+| 名前 | 説明 |
+| --- | --- |
+| iterator() | 内部使用のために予約されています。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/pbrspecularmaterial/_index.md
+++ b/japanese/nodejs-java/aspose.threed/pbrspecularmaterial/_index.md
@@ -1,0 +1,469 @@
+---
+title: "PbrSpecularMaterial"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/pbrspecularmaterial/
+---
+## PbrSpecularMaterial class
+
+拡散カラー/スペキュラ/光沢に基づく物理ベースレンダリング用マテリアル
+
+
+## プロパティ
+
+| 名前 | 説明 |
+| --- | --- |
+| MAP_SPECULAR_GLOSSINESS | 鏡面光沢のテクスチャマップ |
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | PbrSpecularMaterial のコンストラクタ |
+
+ **Result:**
+
+
+
+---
+
+
+### getTransparency{#getTransparency}
+
+| 名前 | 説明 |
+| --- | --- |
+| getTransparency() | 透明度係数を取得または設定します。係数は 0（0%、完全に不透明）から 1（100%、完全に透明）までの範囲である必要があります。無効な係数値はクランプされます。透明度係数。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setTransparency{#setTransparency}
+
+| 名前 | 説明 |
+| --- | --- |
+| setTransparency(value) | 透明度係数を取得または設定します。係数は 0（0%、完全に不透明）から 1（100%、完全に透明）までの範囲である必要があります。無効な係数値はクランプされます。透明度係数。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getNormalTexture{#getNormalTexture}
+
+| 名前 | 説明 |
+| --- | --- |
+| getNormalTexture() | 法線マッピングのテクスチャを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setNormalTexture{#setNormalTexture}
+
+| 名前 | 説明 |
+| --- | --- |
+| setNormalTexture(value) | 法線マッピングのテクスチャを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getSpecularGlossinessTexture{#getSpecularGlossinessTexture}
+
+| 名前 | 説明 |
+| --- | --- |
+| getSpecularGlossinessTexture() | 鏡面色用のテクスチャを取得または設定します。RGB チャンネルは鏡面色を、A チャンネルは光沢度を格納します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setSpecularGlossinessTexture{#setSpecularGlossinessTexture}
+
+| 名前 | 説明 |
+| --- | --- |
+| setSpecularGlossinessTexture(value) | 鏡面色用のテクスチャを取得または設定します。RGB チャンネルは鏡面色を、A チャンネルは光沢度を格納します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getGlossinessFactor{#getGlossinessFactor}
+
+| 名前 | 説明 |
+| --- | --- |
+| getGlossinessFactor() | 材質の光沢度（滑らかさ）を取得または設定します。1 は完全に滑らか、0 は完全に粗いことを意味します。デフォルト値は 1 で、範囲は [0, 1] です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setGlossinessFactor{#setGlossinessFactor}
+
+| 名前 | 説明 |
+| --- | --- |
+| setGlossinessFactor(value) | 材質の光沢度（滑らかさ）を取得または設定します。1 は完全に滑らか、0 は完全に粗いことを意味します。デフォルト値は 1 で、範囲は [0, 1] です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getSpecular{#getSpecular}
+
+| 名前 | 説明 |
+| --- | --- |
+| getSpecular() | 材質の鏡面色を取得または設定します。デフォルト値は (1, 1, 1) です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setSpecular{#setSpecular}
+
+| 名前 | 説明 |
+| --- | --- |
+| setSpecular(value) | 材質の鏡面色を取得または設定します。デフォルト値は (1, 1, 1) です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getDiffuseTexture{#getDiffuseTexture}
+
+| 名前 | 説明 |
+| --- | --- |
+| getDiffuseTexture() | 拡散用のテクスチャを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setDiffuseTexture{#setDiffuseTexture}
+
+| 名前 | 説明 |
+| --- | --- |
+| setDiffuseTexture(value) | 拡散用のテクスチャを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getDiffuse{#getDiffuse}
+
+| 名前 | 説明 |
+| --- | --- |
+| getDiffuse() | 材質の拡散色を取得または設定します。デフォルト値は (1, 1, 1) です |
+
+ **Result:**
+
+
+
+---
+
+
+### setDiffuse{#setDiffuse}
+
+| 名前 | 説明 |
+| --- | --- |
+| setDiffuse(value) | 材質の拡散色を取得または設定します。デフォルト値は (1, 1, 1) です |
+
+ **Result:**
+
+
+
+---
+
+
+### getEmissiveTexture{#getEmissiveTexture}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEmissiveTexture() | 放射用のテクスチャを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setEmissiveTexture{#setEmissiveTexture}
+
+| 名前 | 説明 |
+| --- | --- |
+| setEmissiveTexture(value) | 放射用のテクスチャを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getEmissiveColor{#getEmissiveColor}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEmissiveColor() | 放射色を取得または設定します。デフォルト値は (0, 0, 0) です |
+
+ **Result:**
+
+
+
+---
+
+
+### setEmissiveColor{#setEmissiveColor}
+
+| 名前 | 説明 |
+| --- | --- |
+| setEmissiveColor(value) | 放射色を取得または設定します。デフォルト値は (0, 0, 0) です |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getTexture{#getTexture}
+
+| 名前 | 説明 |
+| --- | --- |
+| getTexture(slotName) | 指定されたスロットからテクスチャを取得します。スロットはマテリアルのプロパティ名またはシェーダーのパラメータ名にすることができます。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| slotName | 文字列 | スロット名。 |
+
+ **Result:**
+TextureBase
+
+
+---
+
+
+### setTexture{#setTexture}
+
+| 名前 | 説明 |
+| --- | --- |
+| setTexture(slotName, texture) | テクスチャを指定されたスロットに設定します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| slotName | 文字列 | スロット名。 |
+| texture | TextureBase | テクスチャ。 |
+
+ **Result:**
+TextureBase
+
+
+---
+
+
+### toString{#toString}
+
+| 名前 | 説明 |
+| --- | --- |
+| toString() | オブジェクトを文字列にフォーマットします |
+
+ **Result:**
+文字列
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+### iterator{#iterator}
+
+| 名前 | 説明 |
+| --- | --- |
+| iterator() | 内部使用のために予約されています。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/pdfformat/_index.md
+++ b/japanese/nodejs-java/aspose.threed/pdfformat/_index.md
@@ -1,0 +1,179 @@
+---
+title: "PdfFormat"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/pdfformat/
+---
+## PdfFormat class
+
+AdobeのPortable Document Format  @hideconstructor
+
+
+## メソッド
+
+### getVersion{#getVersion}
+
+| 名前 | 説明 |
+| --- | --- |
+| getVersion() | ファイル形式のバージョンを取得します |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtension{#getExtension}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExtension() | このタイプの拡張子名を取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtensions{#getExtensions}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExtensions() | このタイプの拡張子名を取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getContentType{#getContentType}
+
+| 名前 | 説明 |
+| --- | --- |
+| getContentType() | ファイル形式のコンテンツタイプを取得します。このプロパティの値は FileContentType 整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormatType{#getFileFormatType}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileFormatType() | ファイル形式のタイプを取得します |
+
+ **Result:**
+
+
+
+---
+
+
+### extract{#extract}
+
+| 名前 | 説明 |
+| --- | --- |
+| extract(fileName, password) | PDF ファイルから生の 3D コンテンツを抽出します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| fileNam | 文字列 | null |
+| パスワード | byte[] | null |
+
+ **Result:**
+0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]
+
+
+---
+
+
+### extractScene{#extractScene}
+
+| 名前 | 説明 |
+| --- | --- |
+| extractScene(fileName) | PDF ファイルから 3D シーンを抽出します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| fileNam | 文字列 | null |
+
+ **Result:**
+0, Culture=neutral, PublicKeyToken=f071c641d0b4582b]]
+
+
+---
+
+
+### extractScene{#extractScene}
+
+| 名前 | 説明 |
+| --- | --- |
+| extractScene(fileName, password) | PDF ファイルから 3D シーンを抽出します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| fileNam | 文字列 | null |
+| パスワード | byte[] | null |
+
+ **Result:**
+0, Culture=neutral, PublicKeyToken=f071c641d0b4582b]]
+
+
+---
+
+
+### createLoadOptions{#createLoadOptions}
+
+| 名前 | 説明 |
+| --- | --- |
+| createLoadOptions() | このファイル形式のデフォルトのロードオプションを作成します |
+
+ **Result:**
+LoadOptions
+
+
+---
+
+
+### createSaveOptions{#createSaveOptions}
+
+| 名前 | 説明 |
+| --- | --- |
+| createSaveOptions() | このファイル形式のデフォルトの保存オプションを作成します |
+
+ **Result:**
+SaveOptions
+
+
+---
+
+
+### toString{#toString}
+
+| 名前 | 説明 |
+| --- | --- |
+| toString() | フォーマットを文字列に変換 |
+
+ **Result:**
+文字列
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/pdfloadoptions/_index.md
+++ b/japanese/nodejs-java/aspose.threed/pdfloadoptions/_index.md
@@ -1,0 +1,146 @@
+---
+title: "PdfLoadOptions"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/pdfloadoptions/
+---
+## PdfLoadOptions class
+
+PDF読み込み用オプション
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | PdfLoadOptions のコンストラクタ |
+
+ **Result:**
+
+
+
+---
+
+
+### getPassword{#getPassword}
+
+| 名前 | 説明 |
+| --- | --- |
+| getPassword() | 暗号化された PDF ファイルのロックを解除するためのパスワード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setPassword{#setPassword}
+
+| 名前 | 説明 |
+| --- | --- |
+| setPassword(value) | 暗号化された PDF ファイルのロックを解除するためのパスワード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileFormat() | 現在の保存/読み込みオプションで指定されたファイル形式を取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEncoding() | テキストベースのファイルのデフォルトエンコーディングを取得または設定します。デフォルト値は null で、インポーター/エクスポーターが使用するエンコーディングを決定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileSystem() | ロード/セーブ時に外部依存関係を管理する方法をユーザーが処理できるようにします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFileSystem(value) | ロード/セーブ時に外部依存関係を管理する方法をユーザーが処理できるようにします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| 名前 | 説明 |
+| --- | --- |
+| getLookupPaths() | OBJ のような一部のファイルは外部ファイルに依存しており、検索パスにより Aspose.3D が外部ファイルを探してロードできるようになります。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileName() | エクスポート/インポートシーンのファイル名です。これはオプションですが、OBJ のマテリアルなど外部アセットをシリアライズする際に便利です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFileName(value) | エクスポート/インポートシーンのファイル名です。これはオプションですが、OBJ のマテリアルなど外部アセットをシリアライズする際に便利です。 |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/pdfsaveoptions/_index.md
+++ b/japanese/nodejs-java/aspose.threed/pdfsaveoptions/_index.md
@@ -1,0 +1,328 @@
+---
+title: "PdfSaveOptions"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/pdfsaveoptions/
+---
+## PdfSaveOptions class
+
+PDFエクスポート時の保存オプション。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | PdfSaveOptions のコンストラクタ |
+
+ **Result:**
+
+
+
+---
+
+
+### getRenderMode{#getRenderMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getRenderMode() | レンダーモードは3Dアートワークがレンダリングされるスタイルを指定します。プロパティの値は PdfRenderMode 整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setRenderMode{#setRenderMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setRenderMode(value) | レンダーモードは3Dアートワークがレンダリングされるスタイルを指定します。プロパティの値は PdfRenderMode 整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getLightingScheme{#getLightingScheme}
+
+| 名前 | 説明 |
+| --- | --- |
+| getLightingScheme() | LightingScheme は3Dアートワークに適用する照明を指定します。プロパティの値は PdfLightingScheme 整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setLightingScheme{#setLightingScheme}
+
+| 名前 | 説明 |
+| --- | --- |
+| setLightingScheme(value) | LightingScheme は3Dアートワークに適用する照明を指定します。プロパティの値は PdfLightingScheme 整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getBackgroundColor{#getBackgroundColor}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBackgroundColor() | PDFファイル内の3Dビューの背景色。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setBackgroundColor{#setBackgroundColor}
+
+| 名前 | 説明 |
+| --- | --- |
+| setBackgroundColor(value) | PDFファイル内の3Dビューの背景色。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFaceColor{#getFaceColor}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFaceColor() | 3Dコンテンツをレンダリングする際に使用されるフェイスカラーを取得または設定します。これは RenderMode が Illustration の値を持つ場合にのみ関連します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFaceColor{#setFaceColor}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFaceColor(value) | 3Dコンテンツをレンダリングする際に使用されるフェイスカラーを取得または設定します。これは RenderMode が Illustration の値を持つ場合にのみ関連します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getAuxiliaryColor{#getAuxiliaryColor}
+
+| 名前 | 説明 |
+| --- | --- |
+| getAuxiliaryColor() | 3Dコンテンツをレンダリングする際に使用される補助カラーを取得または設定します。このカラーの解釈は RenderMode に依存します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setAuxiliaryColor{#setAuxiliaryColor}
+
+| 名前 | 説明 |
+| --- | --- |
+| setAuxiliaryColor(value) | 3Dコンテンツをレンダリングする際に使用される補助カラーを取得または設定します。このカラーの解釈は RenderMode に依存します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlipCoordinateSystem{#getFlipCoordinateSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFlipCoordinateSystem() | エクスポート中にシーンの座標系を反転させるかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlipCoordinateSystem{#setFlipCoordinateSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFlipCoordinateSystem(value) | エクスポート中にシーンの座標系を反転させるかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEmbedTextures{#getEmbedTextures}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEmbedTextures() | 外部テクスチャをPDFファイルに埋め込みます。デフォルト値は false です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setEmbedTextures{#setEmbedTextures}
+
+| 名前 | 説明 |
+| --- | --- |
+| setEmbedTextures(value) | 外部テクスチャをPDFファイルに埋め込みます。デフォルト値は false です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportTextures{#getExportTextures}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExportTextures() | シーンで使用されているテクスチャを出力ディレクトリにコピーしようとします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextures{#setExportTextures}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExportTextures(value) | シーンで使用されているテクスチャを出力ディレクトリにコピーしようとします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileFormat() | 現在の保存/読み込みオプションで指定されたファイル形式を取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEncoding() | テキストベースのファイルのデフォルトエンコーディングを取得または設定します。デフォルト値は null で、インポーター/エクスポーターが使用するエンコーディングを決定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileSystem() | ロード/セーブ時に外部依存関係を管理する方法をユーザーが処理できるようにします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFileSystem(value) | ロード/セーブ時に外部依存関係を管理する方法をユーザーが処理できるようにします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| 名前 | 説明 |
+| --- | --- |
+| getLookupPaths() | OBJ のような一部のファイルは外部ファイルに依存しており、検索パスにより Aspose.3D が外部ファイルを探してロードできるようになります。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileName() | エクスポート/インポートシーンのファイル名です。これはオプションですが、OBJ のマテリアルなど外部アセットをシリアライズする際に便利です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFileName(value) | エクスポート/インポートシーンのファイル名です。これはオプションですが、OBJ のマテリアルなど外部アセットをシリアライズする際に便利です。 |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/phongmaterial/_index.md
+++ b/japanese/nodejs-java/aspose.threed/phongmaterial/_index.md
@@ -1,0 +1,508 @@
+---
+title: "PhongMaterial"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/phongmaterial/
+---
+## PhongMaterial class
+
+Blinn-Phongシェーディングモデル用マテリアル。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | PhongMaterial クラスの新しいインスタンスを初期化します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload(name) | PhongMaterial クラスの新しいインスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| name | 文字列 | 名前 |
+
+ **Result:**
+
+
+
+---
+
+
+### getSpecularColor{#getSpecularColor}
+
+| 名前 | 説明 |
+| --- | --- |
+| getSpecularColor() | 鏡面色を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setSpecularColor{#setSpecularColor}
+
+| 名前 | 説明 |
+| --- | --- |
+| setSpecularColor(value) | 鏡面色を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getSpecularFactor{#getSpecularFactor}
+
+| 名前 | 説明 |
+| --- | --- |
+| getSpecularFactor() | 鏡面係数を取得または設定します。鏡面の式: SpecularColor SpecularFactor (N dot H) ^ Shininess |
+
+ **Result:**
+
+
+
+---
+
+
+### setSpecularFactor{#setSpecularFactor}
+
+| 名前 | 説明 |
+| --- | --- |
+| setSpecularFactor(value) | 鏡面係数を取得または設定します。鏡面の式: SpecularColor SpecularFactor (N dot H) ^ Shininess |
+
+ **Result:**
+
+
+
+---
+
+
+### getShininess{#getShininess}
+
+| 名前 | 説明 |
+| --- | --- |
+| getShininess() | 光沢度を取得または設定します。これにより鏡面ハイライトのサイズが制御されます。鏡面の式: SpecularColor SpecularFactor (N dot H) ^ Shininess 光沢度。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setShininess{#setShininess}
+
+| 名前 | 説明 |
+| --- | --- |
+| setShininess(value) | 光沢度を取得または設定します。これにより鏡面ハイライトのサイズが制御されます。鏡面の式: SpecularColor SpecularFactor (N dot H) ^ Shininess 光沢度。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getReflectionColor{#getReflectionColor}
+
+| 名前 | 説明 |
+| --- | --- |
+| getReflectionColor() | 反射色を取得または設定します。反射。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setReflectionColor{#setReflectionColor}
+
+| 名前 | 説明 |
+| --- | --- |
+| setReflectionColor(value) | 反射色を取得または設定します。反射。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getReflectionFactor{#getReflectionFactor}
+
+| 名前 | 説明 |
+| --- | --- |
+| getReflectionFactor() | 反射色の減衰を取得または設定します。反射係数。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setReflectionFactor{#setReflectionFactor}
+
+| 名前 | 説明 |
+| --- | --- |
+| setReflectionFactor(value) | 反射色の減衰を取得または設定します。反射係数。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEmissiveColor{#getEmissiveColor}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEmissiveColor() | 放射色を取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setEmissiveColor{#setEmissiveColor}
+
+| 名前 | 説明 |
+| --- | --- |
+| setEmissiveColor(value) | 放射色を取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getAmbientColor{#getAmbientColor}
+
+| 名前 | 説明 |
+| --- | --- |
+| getAmbientColor() | 環境光の色を取得または設定します。例: var mat = new LambertMaterial(); mat.AmbientColor = new Vector3(1, 1, 1); ambient. |
+
+ **Result:**
+
+
+
+---
+
+
+### setAmbientColor{#setAmbientColor}
+
+| 名前 | 説明 |
+| --- | --- |
+| setAmbientColor(value) | 環境光の色を取得または設定します。例: var mat = new LambertMaterial(); mat.AmbientColor = new Vector3(1, 1, 1); ambient. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDiffuseColor{#getDiffuseColor}
+
+| 名前 | 説明 |
+| --- | --- |
+| getDiffuseColor() | 拡散色を取得または設定します。例: var mat = new LambertMaterial(); mat.DiffuseColor = new Vector3(1, 0, 0); 拡散色。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setDiffuseColor{#setDiffuseColor}
+
+| 名前 | 説明 |
+| --- | --- |
+| setDiffuseColor(value) | 拡散色を取得または設定します。例: var mat = new LambertMaterial(); mat.DiffuseColor = new Vector3(1, 0, 0); 拡散色。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getTransparentColor{#getTransparentColor}
+
+| 名前 | 説明 |
+| --- | --- |
+| getTransparentColor() | 透過色を取得または設定します。例: var mat = new LambertMaterial(); mat.TransparentColor = new Vector3(0.3, 0.5, 0.2); 透過色。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setTransparentColor{#setTransparentColor}
+
+| 名前 | 説明 |
+| --- | --- |
+| setTransparentColor(value) | 透過色を取得または設定します。例: var mat = new LambertMaterial(); mat.TransparentColor = new Vector3(0.3, 0.5, 0.2); 透過色。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getTransparency{#getTransparency}
+
+| 名前 | 説明 |
+| --- | --- |
+| getTransparency() | 透明度係数を取得または設定します。係数は0（0%、完全に不透明）から1（100%、完全に透明）の範囲である必要があります。無効な係数値はクランプされます。例: var mat = new LambertMaterial(); mat.Transparency = 0.3; 透明度係数。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setTransparency{#setTransparency}
+
+| 名前 | 説明 |
+| --- | --- |
+| setTransparency(value) | 透明度係数を取得または設定します。係数は0（0%、完全に不透明）から1（100%、完全に透明）の範囲である必要があります。無効な係数値はクランプされます。例: var mat = new LambertMaterial(); mat.Transparency = 0.3; 透明度係数。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getTexture{#getTexture}
+
+| 名前 | 説明 |
+| --- | --- |
+| getTexture(slotName) | 指定されたスロットからテクスチャを取得します。スロットはマテリアルのプロパティ名またはシェーダーのパラメータ名にすることができます。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| slotName | 文字列 | スロット名。 |
+
+ **Result:**
+TextureBase
+
+
+---
+
+
+### setTexture{#setTexture}
+
+| 名前 | 説明 |
+| --- | --- |
+| setTexture(slotName, texture) | テクスチャを指定されたスロットに設定します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| slotName | 文字列 | スロット名。 |
+| texture | TextureBase | テクスチャ。 |
+
+ **Result:**
+TextureBase
+
+
+---
+
+
+### toString{#toString}
+
+| 名前 | 説明 |
+| --- | --- |
+| toString() | オブジェクトを文字列にフォーマットします |
+
+ **Result:**
+文字列
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+### iterator{#iterator}
+
+| 名前 | 説明 |
+| --- | --- |
+| iterator() | 内部使用のために予約されています。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/pixelmapping/_index.md
+++ b/japanese/nodejs-java/aspose.threed/pixelmapping/_index.md
@@ -1,0 +1,68 @@
+---
+title: "PixelMapping"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/pixelmapping/
+---
+## PixelMapping class
+
+@hideconstructor
+
+
+## メソッド
+
+### getStride{#getStride}
+
+| 名前 | 説明 |
+| --- | --- |
+| getStride() | 1 行あたりのピクセルバイト数。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getHeight{#getHeight}
+
+| 名前 | 説明 |
+| --- | --- |
+| getHeight() | ピクセルの行数 |
+
+ **Result:**
+
+
+
+---
+
+
+### getWidth{#getWidth}
+
+| 名前 | 説明 |
+| --- | --- |
+| getWidth() | ピクセルの列数 |
+
+ **Result:**
+
+
+
+---
+
+
+### getData{#getData}
+
+| 名前 | 説明 |
+| --- | --- |
+| getData() | マッピングされたピクセルバイトです。 |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/plane/_index.md
+++ b/japanese/nodejs-java/aspose.threed/plane/_index.md
@@ -1,0 +1,506 @@
+---
+title: "Plane"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/plane/
+---
+## Plane class
+
+パラメトリック平面。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | Plane の新しいインスタンスを初期化します（デフォルトサイズ 1x1）。 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload(length, width) | Plane の新しいインスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| length | 数 | 平面の長さ。 |
+| 幅 | 数 | 平面の幅。 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload2(name, length, width, lengthSegments, widthSegments) | Plane の新しいインスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| name | 文字列 | 名前。 |
+| length | 数 | 平面の長さ。 |
+| 幅 | 数 | 平面の幅。 |
+| lengthSegments | 数 | 長さのセグメント。 |
+| widthSegments | 数 | 幅のセグメント。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getUp{#getUp}
+
+| 名前 | 説明 |
+| --- | --- |
+| getUp() | 平面の上方向ベクトルを取得または設定します。デフォルト値は (0, 1, 0) で、平面の生成に影響します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setUp{#setUp}
+
+| 名前 | 説明 |
+| --- | --- |
+| setUp(value) | 平面の上方向ベクトルを取得または設定します。デフォルト値は (0, 1, 0) で、平面の生成に影響します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getLength{#getLength}
+
+| 名前 | 説明 |
+| --- | --- |
+| getLength() | 平面の長さを取得または設定します。長さ。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setLength{#setLength}
+
+| 名前 | 説明 |
+| --- | --- |
+| setLength(value) | 平面の長さを取得または設定します。長さ。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getWidth{#getWidth}
+
+| 名前 | 説明 |
+| --- | --- |
+| getWidth() | 平面の幅を取得または設定します。幅。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setWidth{#setWidth}
+
+| 名前 | 説明 |
+| --- | --- |
+| setWidth(value) | 平面の幅を取得または設定します。幅。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getLengthSegments{#getLengthSegments}
+
+| 名前 | 説明 |
+| --- | --- |
+| getLengthSegments() | 長さのセグメントを取得または設定します。長さのセグメント。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setLengthSegments{#setLengthSegments}
+
+| 名前 | 説明 |
+| --- | --- |
+| setLengthSegments(value) | 長さのセグメントを取得または設定します。長さのセグメント。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getWidthSegments{#getWidthSegments}
+
+| 名前 | 説明 |
+| --- | --- |
+| getWidthSegments() | 幅のセグメントを取得または設定します。幅のセグメント。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setWidthSegments{#setWidthSegments}
+
+| 名前 | 説明 |
+| --- | --- |
+| setWidthSegments(value) | 幅のセグメントを取得または設定します。幅のセグメント。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastShadows{#getCastShadows}
+
+| 名前 | 説明 |
+| --- | --- |
+| getCastShadows() | このジオメトリが影を落とすかどうかを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastShadows{#setCastShadows}
+
+| 名前 | 説明 |
+| --- | --- |
+| setCastShadows(value) | このジオメトリが影を落とすかどうかを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getReceiveShadows{#getReceiveShadows}
+
+| 名前 | 説明 |
+| --- | --- |
+| getReceiveShadows() | このジオメトリが影を受け取るかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setReceiveShadows{#setReceiveShadows}
+
+| 名前 | 説明 |
+| --- | --- |
+| setReceiveShadows(value) | このジオメトリが影を受け取るかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNodes() | すべての親ノードを取得します。エンティティはジオメトリインスタンシングのために複数の親ノードにアタッチできます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExcluded() | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExcluded(value) | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNode() | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setParentNode(value) | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 名前 | 説明 |
+| --- | --- |
+| getScene() | このオブジェクトが属するシーンを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### toMesh{#toMesh}
+
+| 名前 | 説明 |
+| --- | --- |
+| toMesh() | 現在のオブジェクトをメッシュに変換します |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBoundingBox() | 現在のエンティティのオブジェクト空間座標系におけるバウンディングボックスを取得します。 |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEntityRendererKey() | レンダラーに登録されたエンティティレンダラーのキーを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/plyformat/_index.md
+++ b/japanese/nodejs-java/aspose.threed/plyformat/_index.md
@@ -1,0 +1,200 @@
+---
+title: "PlyFormat"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/plyformat/
+---
+## PlyFormat class
+
+PLY形式。  @hideconstructor
+
+
+## メソッド
+
+### getVersion{#getVersion}
+
+| 名前 | 説明 |
+| --- | --- |
+| getVersion() | ファイル形式のバージョンを取得します |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtension{#getExtension}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExtension() | このタイプの拡張子名を取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtensions{#getExtensions}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExtensions() | このタイプの拡張子名を取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getContentType{#getContentType}
+
+| 名前 | 説明 |
+| --- | --- |
+| getContentType() | ファイル形式のコンテンツタイプを取得します。このプロパティの値は FileContentType 整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormatType{#getFileFormatType}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileFormatType() | ファイル形式のタイプを取得します |
+
+ **Result:**
+
+
+
+---
+
+
+### encode{#encode}
+
+| 名前 | 説明 |
+| --- | --- |
+| encode(entity, fileName) | エンティティをエンコードし、結果を外部ファイルに保存します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| エンティティ | エンティティ | エンコードするエンティティ |
+| fileName | 文字列 | 書き込むファイル |
+
+ **Result:**
+
+
+
+---
+
+
+### encode{#encode}
+
+| 名前 | 説明 |
+| --- | --- |
+| encode(entity, fileName, opt) | エンティティをエンコードし、結果を外部ファイルに保存します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| エンティティ | エンティティ | エンコードするエンティティ |
+| fileName | 文字列 | 書き込むファイル |
+| opt | PlySaveOptions | 保存オプション |
+
+ **Result:**
+
+
+
+---
+
+
+### decode{#decode}
+
+| 名前 | 説明 |
+| --- | --- |
+| decode(fileName) | 指定されたストリームから点群またはメッシュをデコードします。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| fileName | 文字列 | 入力ストリーム |
+
+ **Result:**
+ジオメトリ
+
+
+---
+
+
+### decode{#decode}
+
+| 名前 | 説明 |
+| --- | --- |
+| decode(fileName, opt) | 指定されたストリームから点群またはメッシュをデコードします。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| fileName | 文字列 | 入力ストリーム |
+| opt | PlyLoadOptions | PLY形式のロードオプション |
+
+ **Result:**
+ジオメトリ
+
+
+---
+
+
+### createLoadOptions{#createLoadOptions}
+
+| 名前 | 説明 |
+| --- | --- |
+| createLoadOptions() | このファイル形式のデフォルトのロードオプションを作成します |
+
+ **Result:**
+LoadOptions
+
+
+---
+
+
+### createSaveOptions{#createSaveOptions}
+
+| 名前 | 説明 |
+| --- | --- |
+| createSaveOptions() | このファイル形式のデフォルトの保存オプションを作成します |
+
+ **Result:**
+SaveOptions
+
+
+---
+
+
+### toString{#toString}
+
+| 名前 | 説明 |
+| --- | --- |
+| toString() | フォーマットを文字列に変換 |
+
+ **Result:**
+文字列
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/plyloadoptions/_index.md
+++ b/japanese/nodejs-java/aspose.threed/plyloadoptions/_index.md
@@ -1,0 +1,146 @@
+---
+title: "PlyLoadOptions"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/plyloadoptions/
+---
+## PlyLoadOptions class
+
+PLYファイルの読み込みオプション
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | PlyLoadOptions のコンストラクタ |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlipCoordinateSystem{#getFlipCoordinateSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFlipCoordinateSystem() | インポート/エクスポート時にコントロールポイント/法線のフリップ座標系を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlipCoordinateSystem{#setFlipCoordinateSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFlipCoordinateSystem(value) | インポート/エクスポート時にコントロールポイント/法線のフリップ座標系を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileFormat() | 現在の保存/読み込みオプションで指定されたファイル形式を取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEncoding() | テキストベースのファイルのデフォルトエンコーディングを取得または設定します。デフォルト値は null で、インポーター/エクスポーターが使用するエンコーディングを決定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileSystem() | ロード/セーブ時に外部依存関係を管理する方法をユーザーが処理できるようにします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFileSystem(value) | ロード/セーブ時に外部依存関係を管理する方法をユーザーが処理できるようにします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| 名前 | 説明 |
+| --- | --- |
+| getLookupPaths() | OBJ のような一部のファイルは外部ファイルに依存しており、検索パスにより Aspose.3D が外部ファイルを探してロードできるようになります。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileName() | エクスポート/インポートシーンのファイル名です。これはオプションですが、OBJ のマテリアルなど外部アセットをシリアライズする際に便利です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFileName(value) | エクスポート/インポートシーンのファイル名です。これはオプションですが、OBJ のマテリアルなど外部アセットをシリアライズする際に便利です。 |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/plysaveoptions/_index.md
+++ b/japanese/nodejs-java/aspose.threed/plysaveoptions/_index.md
@@ -1,0 +1,347 @@
+---
+title: "PlySaveOptions"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/plysaveoptions/
+---
+## PlySaveOptions class
+
+シーンをPLYファイルとしてエクスポートする際の保存オプション。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | PlySaveOptions のコンストラクタ |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload(contentType) | PlySaveOptions のコンストラクタ |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| contentType | FileContentType | FileContentType |
+
+ **Result:**
+
+
+
+---
+
+
+### getPointCloud{#getPointCloud}
+
+| 名前 | 説明 |
+| --- | --- |
+| getPointCloud() | シーンを点群としてエクスポートします。デフォルト値は false です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setPointCloud{#setPointCloud}
+
+| 名前 | 説明 |
+| --- | --- |
+| setPointCloud(value) | シーンを点群としてエクスポートします。デフォルト値は false です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlipCoordinate{#getFlipCoordinate}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFlipCoordinate() | シーンを保存する際に座標を反転させます。デフォルト値は true です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlipCoordinate{#setFlipCoordinate}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFlipCoordinate(value) | シーンを保存する際に座標を反転させます。デフォルト値は true です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElement{#getVertexElement}
+
+| 名前 | 説明 |
+| --- | --- |
+| getVertexElement() | 頂点データの要素名で、デフォルト値は "vertex" です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setVertexElement{#setVertexElement}
+
+| 名前 | 説明 |
+| --- | --- |
+| setVertexElement(value) | 頂点データの要素名で、デフォルト値は "vertex" です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getPositionComponents{#getPositionComponents}
+
+| 名前 | 説明 |
+| --- | --- |
+| getPositionComponents() | 位置データのコンポーネント名で、デフォルト値は ("x", "y", "z") です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getNormalComponents{#getNormalComponents}
+
+| 名前 | 説明 |
+| --- | --- |
+| getNormalComponents() | 法線データのコンポーネント名で、デフォルト値は ("nx", "ny", "nz") です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getTextureCoordinateComponents{#getTextureCoordinateComponents}
+
+| 名前 | 説明 |
+| --- | --- |
+| getTextureCoordinateComponents() | テクスチャ座標データのコンポーネント名で、デフォルト値は ("u", "v") です |
+
+ **Result:**
+
+
+
+---
+
+
+### getColorComponents{#getColorComponents}
+
+| 名前 | 説明 |
+| --- | --- |
+| getColorComponents() | 頂点カラーのコンポーネント名で、デフォルト値は ("red", "green", "blue") です |
+
+ **Result:**
+
+
+
+---
+
+
+### getFaceElement{#getFaceElement}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFaceElement() | 面データの要素名で、デフォルト値は "face" です |
+
+ **Result:**
+
+
+
+---
+
+
+### setFaceElement{#setFaceElement}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFaceElement(value) | 面データの要素名で、デフォルト値は "face" です |
+
+ **Result:**
+
+
+
+---
+
+
+### getFaceProperty{#getFaceProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFaceProperty() | 面データのプロパティ名で、デフォルト値は "vertex_index" です |
+
+ **Result:**
+
+
+
+---
+
+
+### setFaceProperty{#setFaceProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFaceProperty(value) | 面データのプロパティ名で、デフォルト値は "vertex_index" です |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportTextures{#getExportTextures}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExportTextures() | シーンで使用されているテクスチャを出力ディレクトリにコピーしようとします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextures{#setExportTextures}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExportTextures(value) | シーンで使用されているテクスチャを出力ディレクトリにコピーしようとします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileFormat() | 現在の保存/読み込みオプションで指定されたファイル形式を取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEncoding() | テキストベースのファイルのデフォルトエンコーディングを取得または設定します。デフォルト値は null で、インポーター/エクスポーターが使用するエンコーディングを決定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileSystem() | ロード/セーブ時に外部依存関係を管理する方法をユーザーが処理できるようにします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFileSystem(value) | ロード/セーブ時に外部依存関係を管理する方法をユーザーが処理できるようにします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| 名前 | 説明 |
+| --- | --- |
+| getLookupPaths() | OBJ のような一部のファイルは外部ファイルに依存しており、検索パスにより Aspose.3D が外部ファイルを探してロードできるようになります。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileName() | エクスポート/インポートシーンのファイル名です。これはオプションですが、OBJ のマテリアルなど外部アセットをシリアライズする際に便利です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFileName(value) | エクスポート/インポートシーンのファイル名です。これはオプションですが、OBJ のマテリアルなど外部アセットをシリアライズする際に便利です。 |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/pointcloud/_index.md
+++ b/japanese/nodejs-java/aspose.threed/pointcloud/_index.md
@@ -1,0 +1,580 @@
+---
+title: "PointCloud"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/pointcloud/
+---
+## PointCloud class
+
+ポイントクラウドはトポロジ情報を持たず、制御点と頂点要素のみを含みます。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor(name) | PointCloud のコンストラクタ |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| name | 文字列 | このエンティティの名前 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload() | PointCloud のコンストラクタ |
+
+ **Result:**
+
+
+
+---
+
+
+### getVisible{#getVisible}
+
+| 名前 | 説明 |
+| --- | --- |
+| getVisible() | ジオメトリが表示されているかどうかを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setVisible{#setVisible}
+
+| 名前 | 説明 |
+| --- | --- |
+| setVisible(value) | ジオメトリが表示されているかどうかを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getDeformers{#getDeformers}
+
+| 名前 | 説明 |
+| --- | --- |
+| getDeformers() | このジオメトリに関連付けられたすべてのデフォーマーを取得します。デフォーマー。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getControlPoints{#getControlPoints}
+
+| 名前 | 説明 |
+| --- | --- |
+| getControlPoints() | すべての制御点を取得します |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastShadows{#getCastShadows}
+
+| 名前 | 説明 |
+| --- | --- |
+| getCastShadows() | このジオメトリが影を落とすかどうかを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastShadows{#setCastShadows}
+
+| 名前 | 説明 |
+| --- | --- |
+| setCastShadows(value) | このジオメトリが影を落とすかどうかを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getReceiveShadows{#getReceiveShadows}
+
+| 名前 | 説明 |
+| --- | --- |
+| getReceiveShadows() | このジオメトリが影を受け取るかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setReceiveShadows{#setReceiveShadows}
+
+| 名前 | 説明 |
+| --- | --- |
+| setReceiveShadows(value) | このジオメトリが影を受け取るかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElements{#getVertexElements}
+
+| 名前 | 説明 |
+| --- | --- |
+| getVertexElements() | すべての頂点要素を取得します |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNodes() | すべての親ノードを取得します。エンティティはジオメトリインスタンシングのために複数の親ノードにアタッチできます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExcluded() | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExcluded(value) | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNode() | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setParentNode(value) | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 名前 | 説明 |
+| --- | --- |
+| getScene() | このオブジェクトが属するシーンを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEntityRendererKey() | レンダラーに登録されたエンティティレンダラーのキーを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### fromGeometry{#fromGeometry}
+
+| 名前 | 説明 |
+| --- | --- |
+| fromGeometry(g) | ジオメトリオブジェクトから新しい PointCloud インスタンスを作成します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+|  | ジオメトリ | null |
+
+ **Result:**
+PointCloud
+
+
+---
+
+
+### fromGeometry{#fromGeometry}
+
+| 名前 | 説明 |
+| --- | --- |
+| fromGeometry(g, density) | ジオメトリオブジェクトから新しいポイントクラウドインスタンスを作成します。Density は単位三角形あたりのポイント数です（単位三角形はメッシュから最大表面積を持つ三角形です）。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| g | ジオメトリ | メッシュまたはその他のジオメトリインスタンス |
+| 密度 | 数 | 単位三角形あたりのポイント数 |
+
+ **Result:**
+PointCloud
+
+
+---
+
+
+### getElement{#getElement}
+
+| 名前 | 説明 |
+| --- | --- |
+| getElement(type) | 指定されたタイプの頂点要素を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| type | VertexElementType | VertexElementType |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### getVertexElementOfUV{#getVertexElementOfUV}
+
+| 名前 | 説明 |
+| --- | --- |
+| getVertexElementOfUV(textureMapping) | 指定されたテクスチャマッピングタイプの VertexElementUV インスタンスを取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| textureMapping | TextureMapping | TextureMapping |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### createElement{#createElement}
+
+| 名前 | 説明 |
+| --- | --- |
+| createElement(type) | 指定されたタイプの頂点要素を作成し、ジオメトリに追加します。type が VertexElementType.UV の場合、テクスチャマッピングタイプが TextureMapping.DIFFUSE の VertexElementUV が作成されます。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| type | VertexElementType | VertexElementType |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### addElement{#addElement}
+
+| 名前 | 説明 |
+| --- | --- |
+| addElement(element) | 既存の頂点要素を現在のジオメトリに追加します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| element | VertexElement | 追加する頂点要素 |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### createElement{#createElement}
+
+| 名前 | 説明 |
+| --- | --- |
+| createElement(type, mappingMode, referenceMode) | 指定されたタイプの頂点要素を作成し、ジオメトリに追加します。type が VertexElementType.UV の場合、テクスチャマッピングタイプが TextureMapping.DIFFUSE の VertexElementUV が作成されます。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| type | VertexElementType | VertexElementType |
+| mappingMode | MappingMode | MappingMode |
+| referenceMode | ReferenceMode | ReferenceMode |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### createElementUV{#createElementUV}
+
+| 名前 | 説明 |
+| --- | --- |
+| createElementUV(uvMapping) | 指定されたテクスチャマッピングタイプで VertexElementUV を作成します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| uvMapping | TextureMapping | TextureMapping |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### createElementUV{#createElementUV}
+
+| 名前 | 説明 |
+| --- | --- |
+| createElementUV(uvMapping, mappingMode, referenceMode) | 指定されたテクスチャマッピングタイプで VertexElementUV を作成します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| uvMapping | TextureMapping | TextureMapping |
+| mappingMode | MappingMode | MappingMode |
+| referenceMode | ReferenceMode | ReferenceMode |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBoundingBox() | 現在のエンティティのオブジェクト空間座標系におけるバウンディングボックスを取得します。 |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/polygonbuilder/_index.md
+++ b/japanese/nodejs-java/aspose.threed/polygonbuilder/_index.md
@@ -1,0 +1,80 @@
+---
+title: "PolygonBuilder"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/polygonbuilder/
+---
+## PolygonBuilder class
+
+Mesh用ポリゴンを構築するヘルパークラス
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| コンストラクタ(mesh) | PolygonBuilder クラスの新しいインスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| メッシュ | Mesh | どのメッシュ上にポリゴンを構築するか。 |
+
+ **Result:**
+
+
+
+---
+
+
+### begin{#begin}
+
+| 名前 | 説明 |
+| --- | --- |
+| begin() | 新しいポリゴンの追加を開始します |
+
+ **Result:**
+
+
+
+---
+
+
+### addVertex{#addVertex}
+
+| 名前 | 説明 |
+| --- | --- |
+| addVertex(index) | ポリゴンに頂点インデックスを追加します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| inde | 数 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### end{#end}
+
+| 名前 | 説明 |
+| --- | --- |
+| end() | ポリゴンの作成を完了します |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/polygonmodifier/_index.md
+++ b/japanese/nodejs-java/aspose.threed/polygonmodifier/_index.md
@@ -1,0 +1,266 @@
+---
+title: "PolygonModifier"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/polygonmodifier/
+---
+## PolygonModifier class
+
+ポリゴンを変更するユーティリティ  @hideconstructor
+
+
+## メソッド
+
+### triangulate{#triangulate}
+
+| 名前 | 説明 |
+| --- | --- |
+| triangulate(scene) | すべてのポリゴンベースのメッシュを完全な三角形メッシュに変換します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| シーン | Scene | 処理対象のシーン |
+
+ **Result:**
+
+
+
+---
+
+
+### triangulate{#triangulate}
+
+| 名前 | 説明 |
+| --- | --- |
+| triangulate(mesh) | ポリゴンベースのメッシュを完全な三角形メッシュに変換します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| メッシュ | Mesh | 元の非三角形メッシュ |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### mergeMesh{#mergeMesh}
+
+| 名前 | 説明 |
+| --- | --- |
+| mergeMesh(scene) | シーン全体を単一の変換済みメッシュに変換します。法線やテクスチャ座標などの頂点要素はまだサポートされていません |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| シーン | Scene | マージ対象のシーン |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### mergeMesh{#mergeMesh}
+
+| 名前 | 説明 |
+| --- | --- |
+| mergeMesh(node) | ノード全体を単一の変換済みメッシュに変換します。法線やテクスチャ座標などの頂点要素はまだサポートされていません |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| ノード | ノード | マージ対象のノード |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### scale{#scale}
+
+| 名前 | 説明 |
+| --- | --- |
+| scale(scene, scale) | このシーン内のすべてのジオメトリをスケールします（変換行列ではなく制御点をスケールします） |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| シーン | Scene | スケール対象のシーン |
+| スケール | Vector3 | スケール係数 |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### scale{#scale}
+
+| 名前 | 説明 |
+| --- | --- |
+| scale(node, scale) | このノード内のすべてのジオメトリをスケールします（変換行列ではなく制御点をスケールします） |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| ノード | ノード | スケール対象のノード |
+| スケール | Vector3 | スケール係数 |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### generateNormal{#generateNormal}
+
+| 名前 | 説明 |
+| --- | --- |
+| generateNormal(mesh) | Mesh 定義から法線データを生成する |
+
+ **Result:**
+VertexElementNormal
+
+
+---
+
+
+### generateUV{#generateUV}
+
+| 名前 | 説明 |
+| --- | --- |
+| generateUV(mesh, normals) | 指定された入力メッシュと指定された法線データから UV データを生成します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| メッシュ | Mesh | 入力メッシュ |
+| 法線 | VertexElementNormal | 法線データ |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### generateUV{#generateUV}
+
+| 名前 | 説明 |
+| --- | --- |
+| generateUV(mesh) | 指定された入力メッシュから UV データを生成します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| メッシュ | Mesh | 入力メッシュ |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### splitMesh{#splitMesh}
+
+| 名前 | 説明 |
+| --- | --- |
+| splitMesh(node, policy, createChildNodes, removeOldMesh) | VertexElementMaterial によってメッシュをサブメッシュに分割します。各サブメッシュは 1 つのマテリアルのみを使用します。ノード上でメッシュ分割を実行します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| nod | ノード | null |
+| ポリシー | SplitMeshPolicy | SplitMeshPolicy |
+| createChildNodes | boolean | 各サブメッシュに対して子ノードを作成します。 |
+| removeOldMesh | boolean | 分割後に古いメッシュを削除します。このパラメーターが false の場合、古いメッシュと新しいメッシュが共存します。 |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### splitMesh{#splitMesh}
+
+| 名前 | 説明 |
+| --- | --- |
+| splitMesh(scene, policy, removeOldMesh) | VertexElementMaterial によってメッシュをサブメッシュに分割します。各サブメッシュは 1 つのマテリアルのみを使用します。シーン内のすべてのノードでメッシュ分割を実行します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| シーン | Scene | null |
+| ポリシー | SplitMeshPolicy | SplitMeshPolicy |
+| removeOldMes | boolean | null |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### splitMesh{#splitMesh}
+
+| 名前 | 説明 |
+| --- | --- |
+| splitMesh(mesh, policy) | VertexElementMaterial によってメッシュをサブメッシュに分割します。各サブメッシュは 1 つのマテリアルのみを使用します。元のメッシュは変更されません。 |
+
+ **Result:**
+Mesh[]
+
+
+---
+
+
+### buildTangentBinormal{#buildTangentBinormal}
+
+| 名前 | 説明 |
+| --- | --- |
+| buildTangentBinormal(scene) | シーン内のすべてのメッシュにタンジェントとバイノーマルを作成します。法線が必要で、メッシュに法線が存在しない場合は、位置情報から法線データも作成します。UV も必要で、UV が定義されていないメッシュは無視されます。 |
+
+ **Result:**
+Mesh[]
+
+
+---
+
+
+### buildTangentBinormal{#buildTangentBinormal}
+
+| 名前 | 説明 |
+| --- | --- |
+| buildTangentBinormal(mesh) | これにより、メッシュ上にタンジェントとバイノーマルが作成されます。法線が必要で、メッシュに法線が存在しない場合は、位置から法線データも作成されます。UVも必要で、UVが見つからない場合は例外がスローされます。 |
+
+ **Result:**
+Mesh[]
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/pose/_index.md
+++ b/japanese/nodejs-java/aspose.threed/pose/_index.md
@@ -1,0 +1,263 @@
+---
+title: "ポーズ"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/pose/
+---
+## Pose class
+
+ジオメトリがスキンされているときに変換行列を保存するために使用されるポーズです。ポーズはBonePoseの集合で、各BonePoseはボーンノードの具体的な変換情報を保存します。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor(name) | Pose クラスの新しいインスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| name | 文字列 | 名前 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload() | Pose クラスの新しいインスタンスを初期化します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getPoseType{#getPoseType}
+
+| 名前 | 説明 |
+| --- | --- |
+| getPoseType() | ポーズのタイプを取得または設定します。プロパティの値は PoseType 整数定数です。ポーズのタイプ。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setPoseType{#setPoseType}
+
+| 名前 | 説明 |
+| --- | --- |
+| setPoseType(value) | ポーズのタイプを取得または設定します。プロパティの値は PoseType 整数定数です。ポーズのタイプ。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getBonePoses{#getBonePoses}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBonePoses() | すべての BonePose を取得します。ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### addBonePose{#addBonePose}
+
+| 名前 | 説明 |
+| --- | --- |
+| addBonePose(node, matrix, localMatrix) | 指定されたボーンノードのポーズ変換行列を保存します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| ノード | ノード | ボーンノード。 |
+| matrix | Matrix4 | 変換行列。 |
+| localMatrix | boolean | 設定する場合は |
+
+ **Result:**
+
+
+
+---
+
+
+### addBonePose{#addBonePose}
+
+| 名前 | 説明 |
+| --- | --- |
+| addBonePose(node, matrix) | 指定されたボーンノードのポーズ変換行列を保存します。グローバル変換行列が暗黙的に使用されます。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| ノード | ノード | ボーンノード。 |
+| matrix | Matrix4 | 変換行列。 |
+
+ **Result:**
+
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/postprocessing/_index.md
+++ b/japanese/nodejs-java/aspose.threed/postprocessing/_index.md
@@ -1,0 +1,177 @@
+---
+title: "ポストプロセッシング"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/postprocessing/
+---
+## PostProcessing class
+
+ポストプロセッシングエフェクト  @hideconstructor
+
+
+## メソッド
+
+### getInput{#getInput}
+
+| 名前 | 説明 |
+| --- | --- |
+| getInput() | このポストプロセッシングの入力 |
+
+ **Result:**
+
+
+
+---
+
+
+### setInput{#setInput}
+
+| 名前 | 説明 |
+| --- | --- |
+| setInput(value) | このポストプロセッシングの入力 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/primitive/_index.md
+++ b/japanese/nodejs-java/aspose.threed/primitive/_index.md
@@ -1,0 +1,339 @@
+---
+title: "プリミティブ"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/primitive/
+---
+## Primitive class
+
+すべてのプリミティブの基底クラス
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor(name) | Primitive クラスの新しいインスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| name | 文字列 | 名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastShadows{#getCastShadows}
+
+| 名前 | 説明 |
+| --- | --- |
+| getCastShadows() | このジオメトリが影を落とすかどうかを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastShadows{#setCastShadows}
+
+| 名前 | 説明 |
+| --- | --- |
+| setCastShadows(value) | このジオメトリが影を落とすかどうかを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getReceiveShadows{#getReceiveShadows}
+
+| 名前 | 説明 |
+| --- | --- |
+| getReceiveShadows() | このジオメトリが影を受け取るかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setReceiveShadows{#setReceiveShadows}
+
+| 名前 | 説明 |
+| --- | --- |
+| setReceiveShadows(value) | このジオメトリが影を受け取るかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNodes() | すべての親ノードを取得します。エンティティはジオメトリインスタンシングのために複数の親ノードにアタッチできます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExcluded() | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExcluded(value) | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNode() | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setParentNode(value) | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 名前 | 説明 |
+| --- | --- |
+| getScene() | このオブジェクトが属するシーンを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### toMesh{#toMesh}
+
+| 名前 | 説明 |
+| --- | --- |
+| toMesh() | 現在のオブジェクトをメッシュに変換します |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBoundingBox() | 現在のエンティティのオブジェクト空間座標系におけるバウンディングボックスを取得します。 |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEntityRendererKey() | レンダラーに登録されたエンティティレンダラーのキーを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/profile/_index.md
+++ b/japanese/nodejs-java/aspose.threed/profile/_index.md
@@ -1,0 +1,255 @@
+---
+title: "プロファイル"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/profile/
+---
+## Profile class
+
+xy平面上の2Dプロファイル  @hideconstructor
+
+
+## メソッド
+
+### getParentNodes{#getParentNodes}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNodes() | すべての親ノードを取得します。エンティティはジオメトリインスタンシングのために複数の親ノードにアタッチできます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExcluded() | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExcluded(value) | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNode() | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setParentNode(value) | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 名前 | 説明 |
+| --- | --- |
+| getScene() | このオブジェクトが属するシーンを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEntityRendererKey() | レンダラーに登録されたエンティティレンダラーのキーを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBoundingBox() | 現在のエンティティのオブジェクト空間座標系におけるバウンディングボックスを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/property/_index.md
+++ b/japanese/nodejs-java/aspose.threed/property/_index.md
@@ -1,0 +1,230 @@
+---
+title: "Property"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/property/
+---
+## Property class
+
+ユーザー定義プロパティを保持するクラス。  @hideconstructor
+
+
+## メソッド
+
+### getValue{#getValue}
+
+| 名前 | 説明 |
+| --- | --- |
+| getValue() | 値を取得または設定します。値。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setValue{#setValue}
+
+| 名前 | 説明 |
+| --- | --- |
+| setValue(value) | 値を取得または設定します。値。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getValueType{#getValueType}
+
+| 名前 | 説明 |
+| --- | --- |
+| getValueType() | プロパティ値の型を取得します。値の型。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getBindPoint{#getBindPoint}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBindPoint(anim, create) | 指定されたアニメーションインスタンス上のプロパティバインドポイントを取得します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| anim | AnimationNode | どのアニメーションでバインドポイントを作成するか。 |
+| 作成 | boolean | プロパティバインドポイントが見つからない場合は作成してください。 |
+
+ **Result:**
+BindPoint
+
+
+---
+
+
+### getKeyframeSequence{#getKeyframeSequence}
+
+| 名前 | 説明 |
+| --- | --- |
+| getKeyframeSequence(anim, create) | 指定されたアニメーションインスタンスのキーフレームシーケンスを取得します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| anim | AnimationNode | どのアニメーションでキーフレームシーケンスを作成するか。 |
+| 作成 | boolean | キーフレームシーケンスが見つからない場合は作成してください。 |
+
+ **Result:**
+KeyframeSequence
+
+
+---
+
+
+### toString{#toString}
+
+| 名前 | 説明 |
+| --- | --- |
+| toString() | 現在のプロパティを表す文字列を返します。 |
+
+ **Result:**
+文字列
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/propertycollection/_index.md
+++ b/japanese/nodejs-java/aspose.threed/propertycollection/_index.md
@@ -1,0 +1,125 @@
+---
+title: "PropertyCollection"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/propertycollection/
+---
+## PropertyCollection class
+
+プロパティのコレクション  @hideconstructor
+
+
+## メソッド
+
+### get{#get}
+
+| 名前 | 説明 |
+| --- | --- |
+| get(idx) |  |
+
+ **Result:**
+
+
+
+---
+
+
+### get{#get}
+
+| 名前 | 説明 |
+| --- | --- |
+| get(property) |  |
+
+ **Result:**
+
+
+
+---
+
+
+### set{#set}
+
+| 名前 | 説明 |
+| --- | --- |
+| set(property, value) |  |
+
+ **Result:**
+
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(property) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### iterator{#iterator}
+
+| 名前 | 説明 |
+| --- | --- |
+| iterator() | 内部使用のために予約されています。 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/pushconstant/_index.md
+++ b/japanese/nodejs-java/aspose.threed/pushconstant/_index.md
@@ -1,0 +1,166 @@
+---
+title: "PushConstant"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/pushconstant/
+---
+## PushConstant class
+
+プッシュ定数を介してシェーダーにデータを提供するユーティリティ。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | PushConstant のコンストラクタ |
+
+ **Result:**
+
+
+
+---
+
+
+### write{#write}
+
+| 名前 | 説明 |
+| --- | --- |
+| write(mat) | 行列を定数に書き込む |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| mat | FMatrix4 | 書き込む行列 |
+
+ **Result:**
+
+
+
+---
+
+
+### write{#write}
+
+| 名前 | 説明 |
+| --- | --- |
+| write(n) | int 値を定数に書き込む |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+|  | 数 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### write{#write}
+
+| 名前 | 説明 |
+| --- | --- |
+| write(f) | float 値を定数に書き込む |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+|  | 数 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### write{#write}
+
+| 名前 | 説明 |
+| --- | --- |
+| write(vec) | 4 成分ベクトルを定数に書き込む |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| ve | FVector4 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### write{#write}
+
+| 名前 | 説明 |
+| --- | --- |
+| write(vec) | 3 成分ベクトルを定数に書き込む |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| ve | FVector3 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### write{#write}
+
+| 名前 | 説明 |
+| --- | --- |
+| write(x, y, z, w) | 4 成分ベクトルを定数に書き込む |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+|  | 数 | null |
+|  | 数 | null |
+|  | 数 | null |
+|  | 数 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### commit{#commit}
+
+| 名前 | 説明 |
+| --- | --- |
+| commit(stage, commandList) | 準備されたデータをグラフィックス パイプラインにコミットする。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| stage | 数 | ShaderStage |
+| commandLis | ICommandList | null |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/pyramid/_index.md
+++ b/japanese/nodejs-java/aspose.threed/pyramid/_index.md
@@ -1,0 +1,505 @@
+---
+title: "Pyramid"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/pyramid/
+---
+## Pyramid class
+
+パラメトリックピラミッド。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | デフォルトの底面領域(10, 10)とデフォルトの高さ(5)で新しい Pyramid インスタンスを構築します |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload(xbottom, ybottom, height) | 指定された底面領域で新しい Pyramid インスタンスを構築します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| xbottom | 数 | 底面の x 方向の長さ |
+| ybottom | 数 | 底面の y 方向の長さ |
+| height | 数 | Pyramid の高さ |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload2(xbottom, ybottom, xtop, ytop, height) | 指定された底面領域、上面領域、および高さで新しい Pyramid インスタンスを構築します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| xbottom | 数 | 底面領域の x 方向の長さ |
+| ybottom | 数 | 底面領域の y 方向の長さ |
+| xtop | 数 | 上面領域の x 方向の長さ |
+| ytop | 数 | 上面領域の y 方向の長さ |
+| height | 数 | Pyramid の高さ |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload3{#constructor_overload3}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload3(name, xbottom, ybottom, xtop, ytop, height) | 指定された底面領域、上面領域、および高さで新しい Pyramid インスタンスを構築します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| name | 文字列 | ピラミッドの名前 |
+| xbottom | 数 | 底面領域の x 方向の長さ |
+| ybottom | 数 | 底面領域の y 方向の長さ |
+| xtop | 数 | 上面領域の x 方向の長さ |
+| ytop | 数 | 上面領域の y 方向の長さ |
+| height | 数 | Pyramid の高さ |
+
+ **Result:**
+
+
+
+---
+
+
+### getBottomArea{#getBottomArea}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBottomArea() | 底部キャップの面積 |
+
+ **Result:**
+
+
+
+---
+
+
+### setBottomArea{#setBottomArea}
+
+| 名前 | 説明 |
+| --- | --- |
+| setBottomArea(value) | 底部キャップの面積 |
+
+ **Result:**
+
+
+
+---
+
+
+### getTopArea{#getTopArea}
+
+| 名前 | 説明 |
+| --- | --- |
+| getTopArea() | 上部キャップの面積 |
+
+ **Result:**
+
+
+
+---
+
+
+### setTopArea{#setTopArea}
+
+| 名前 | 説明 |
+| --- | --- |
+| setTopArea(value) | 上部キャップの面積 |
+
+ **Result:**
+
+
+
+---
+
+
+### getBottomOffset{#getBottomOffset}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBottomOffset() | 底部頂点のオフセット |
+
+ **Result:**
+
+
+
+---
+
+
+### setBottomOffset{#setBottomOffset}
+
+| 名前 | 説明 |
+| --- | --- |
+| setBottomOffset(value) | 底部頂点のオフセット |
+
+ **Result:**
+
+
+
+---
+
+
+### getHeight{#getHeight}
+
+| 名前 | 説明 |
+| --- | --- |
+| getHeight() | ピラミッドの高さ |
+
+ **Result:**
+
+
+
+---
+
+
+### setHeight{#setHeight}
+
+| 名前 | 説明 |
+| --- | --- |
+| setHeight(value) | ピラミッドの高さ |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastShadows{#getCastShadows}
+
+| 名前 | 説明 |
+| --- | --- |
+| getCastShadows() | このジオメトリが影を落とすかどうかを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastShadows{#setCastShadows}
+
+| 名前 | 説明 |
+| --- | --- |
+| setCastShadows(value) | このジオメトリが影を落とすかどうかを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getReceiveShadows{#getReceiveShadows}
+
+| 名前 | 説明 |
+| --- | --- |
+| getReceiveShadows() | このジオメトリが影を受け取るかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setReceiveShadows{#setReceiveShadows}
+
+| 名前 | 説明 |
+| --- | --- |
+| setReceiveShadows(value) | このジオメトリが影を受け取るかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNodes() | すべての親ノードを取得します。エンティティはジオメトリインスタンシングのために複数の親ノードにアタッチできます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExcluded() | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExcluded(value) | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNode() | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setParentNode(value) | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 名前 | 説明 |
+| --- | --- |
+| getScene() | このオブジェクトが属するシーンを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### toMesh{#toMesh}
+
+| 名前 | 説明 |
+| --- | --- |
+| toMesh() | 現在のオブジェクトをメッシュに変換します |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBoundingBox() | 現在のエンティティのオブジェクト空間座標系におけるバウンディングボックスを取得します。 |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEntityRendererKey() | レンダラーに登録されたエンティティレンダラーのキーを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/quaternion/_index.md
+++ b/japanese/nodejs-java/aspose.threed/quaternion/_index.md
@@ -1,0 +1,323 @@
+---
+title: "クォータニオン"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/quaternion/
+---
+## Quaternion class
+
+Quaternionはコンピュータグラフィックスで回転を実行するために通常使用されます。
+
+
+## プロパティ
+
+| 名前 | 説明 |
+| --- | --- |
+| w | w コンポーネントです。 |
+| x | x 成分。 |
+| y | y 成分。 |
+| z | z 成分。 |
+| IDENTITY | 単位四元数。 |
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload(w, x, y, z) | Quaternion クラスの新しいインスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| w | 数 | 四元数の w 成分 |
+| x | 数 | 四元数の x 成分 |
+| y | 数 | 四元数の y 成分 |
+| z | 数 | 四元数の z 成分 |
+
+ **Result:**
+
+
+
+---
+
+
+### getLength{#getLength}
+
+| 名前 | 説明 |
+| --- | --- |
+| getLength() | 四元数の長さを取得します |
+
+ **Result:**
+
+
+
+---
+
+
+### equals{#equals}
+
+| 名前 | 説明 |
+| --- | --- |
+| equals(obj) | 二つの四元数が等しいかチェックします |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| obj | オブジェクト | 等価性をチェックするオブジェクトです。 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### hashCode{#hashCode}
+
+| 名前 | 説明 |
+| --- | --- |
+| hashCode() | Quaternion のハッシュコードを取得します |
+
+ **Result:**
+数
+
+
+---
+
+
+### conjugate{#conjugate}
+
+| 名前 | 説明 |
+| --- | --- |
+| conjugate() | 現在の四元数の共役四元数を返します |
+
+ **Result:**
+クォータニオン
+
+
+---
+
+
+### inverse{#inverse}
+
+| 名前 | 説明 |
+| --- | --- |
+| inverse() | 現在の四元数の逆四元数を返します |
+
+ **Result:**
+クォータニオン
+
+
+---
+
+
+### dot{#dot}
+
+| 名前 | 説明 |
+| --- | --- |
+| dot(q) | Dots の積 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| q | クォータニオン | クォータニオン |
+
+ **Result:**
+数
+
+
+---
+
+
+### eulerAngles{#eulerAngles}
+
+| 名前 | 説明 |
+| --- | --- |
+| eulerAngles() | クォータニオンをオイラー角で表される回転に変換します。すべての成分はラジアンです。 |
+
+ **Result:**
+Vector3
+
+
+---
+
+
+### normalize{#normalize}
+
+| 名前 | 説明 |
+| --- | --- |
+| normalize() | クォータニオンを正規化する |
+
+ **Result:**
+クォータニオン
+
+
+---
+
+
+### concat{#concat}
+
+| 名前 | 説明 |
+| --- | --- |
+| concat(rhs) | 2つのクォータニオンを連結する |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| rh | クォータニオン | null |
+
+ **Result:**
+クォータニオン
+
+
+---
+
+
+### fromAngleAxis{#fromAngleAxis}
+
+| 名前 | 説明 |
+| --- | --- |
+| fromAngleAxis(a, axis) | 指定された軸の周りにクォータニオンを作成し、時計回りに回転させます |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| a | 数 | 時計回りの回転（ラジアン） |
+| axis | Vector3 | 軸 |
+
+ **Result:**
+クォータニオン
+
+
+---
+
+
+### fromRotation{#fromRotation}
+
+| 名前 | 説明 |
+| --- | --- |
+| fromRotation(orig, dest) | 元の方向から目的地の方向へ回転するクォータニオンを作成します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| orig | Vector3 | 元の方向 |
+| dest | Vector3 | 目的地の方向 |
+
+ **Result:**
+クォータニオン
+
+
+---
+
+
+### fromEulerAngle{#fromEulerAngle}
+
+| 名前 | 説明 |
+| --- | --- |
+| fromEulerAngle(pitch, yaw, roll) | 指定されたオイラー角からクォータニオンを作成します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| pitch | 数 | ピッチ（ラジアン） |
+| yaw | 数 | ヨー（ラジアン） |
+| ロール | 数 | ラジアンでの回転 |
+
+ **Result:**
+クォータニオン
+
+
+---
+
+
+### fromEulerAngle{#fromEulerAngle}
+
+| 名前 | 説明 |
+| --- | --- |
+| fromEulerAngle(eulerAngle) | 指定されたオイラー角からクォータニオンを作成します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| eulerAngle | Vector3 | ラジアン単位のオイラー角 |
+
+ **Result:**
+クォータニオン
+
+
+---
+
+
+### toMatrix{#toMatrix}
+
+| 名前 | 説明 |
+| --- | --- |
+| toMatrix() | クォータニオンで表現された回転を変換行列に変換します。 |
+
+ **Result:**
+Matrix4
+
+
+---
+
+
+### toString{#toString}
+
+| 名前 | 説明 |
+| --- | --- |
+| toString() | クォータニオンの文字列表現を取得します。 |
+
+ **Result:**
+文字列
+
+
+---
+
+
+### interpolate{#interpolate}
+
+| 名前 | 説明 |
+| --- | --- |
+| interpolate(t, from, to) | このクォータニオンに、from と to の間の t の値に対する、与えられたクォータニオン引数間の補間値を設定します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| t | 数 | 補間に使用する係数です。 |
+| from | クォータニオン | ソースクォータニオン。 |
+| to | クォータニオン | ターゲットクォータニオン。 |
+
+ **Result:**
+クォータニオン
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/rect/_index.md
+++ b/japanese/nodejs-java/aspose.threed/rect/_index.md
@@ -1,0 +1,227 @@
+---
+title: "Rect"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/rect/
+---
+## Rect class
+
+矩形を表すクラス
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload(x, y, width, height) | Rect クラスのコンストラクタ |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+|  | 数 | null |
+|  | 数 | null |
+| 幅 | 数 | null |
+| 高さ | 数 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### getWidth{#getWidth}
+
+| 名前 | 説明 |
+| --- | --- |
+| getWidth() | サイズの幅を取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setWidth{#setWidth}
+
+| 名前 | 説明 |
+| --- | --- |
+| setWidth(value) | サイズの幅を取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getHeight{#getHeight}
+
+| 名前 | 説明 |
+| --- | --- |
+| getHeight() | サイズの高さを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setHeight{#setHeight}
+
+| 名前 | 説明 |
+| --- | --- |
+| setHeight(value) | サイズの高さを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getX{#getX}
+
+| 名前 | 説明 |
+| --- | --- |
+| getX() | サイズの x を取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setX{#setX}
+
+| 名前 | 説明 |
+| --- | --- |
+| setX(value) | サイズの x を取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getY{#getY}
+
+| 名前 | 説明 |
+| --- | --- |
+| getY() | サイズの y を取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setY{#setY}
+
+| 名前 | 説明 |
+| --- | --- |
+| setY(value) | サイズの y を取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getLeft{#getLeft}
+
+| 名前 | 説明 |
+| --- | --- |
+| getLeft() | 矩形の左側を取得します |
+
+ **Result:**
+
+
+
+---
+
+
+### getRight{#getRight}
+
+| 名前 | 説明 |
+| --- | --- |
+| getRight() | 矩形の右側を取得します |
+
+ **Result:**
+
+
+
+---
+
+
+### getTop{#getTop}
+
+| 名前 | 説明 |
+| --- | --- |
+| getTop() | 矩形の上側を取得します |
+
+ **Result:**
+
+
+
+---
+
+
+### getBottom{#getBottom}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBottom() | 矩形の下側を取得します |
+
+ **Result:**
+
+
+
+---
+
+
+### contains{#contains}
+
+| 名前 | 説明 |
+| --- | --- |
+| contains(x, y) | 与えられた点が矩形内にある場合は true を返します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+|  | 数 | null |
+|  | 数 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/rectangleshape/_index.md
+++ b/japanese/nodejs-java/aspose.threed/rectangleshape/_index.md
@@ -1,0 +1,359 @@
+---
+title: "RectangleShape"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/rectangleshape/
+---
+## RectangleShape class
+
+IFC 互換の角が丸められた矩形形状。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | RectangleShape のコンストラクタ |
+
+ **Result:**
+
+
+
+---
+
+
+### getRoundingRadius{#getRoundingRadius}
+
+| 名前 | 説明 |
+| --- | --- |
+| getRoundingRadius() | すべての四隅の円弧の半径を取得または設定します（単位は度）。デフォルト値は 0.0 です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setRoundingRadius{#setRoundingRadius}
+
+| 名前 | 説明 |
+| --- | --- |
+| setRoundingRadius(value) | すべての四隅の円弧の半径を取得または設定します（単位は度）。デフォルト値は 0.0 です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getXDim{#getXDim}
+
+| 名前 | 説明 |
+| --- | --- |
+| getXDim() | 矩形の x 軸方向の広がりを取得または設定します。デフォルト値は 2.0 です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setXDim{#setXDim}
+
+| 名前 | 説明 |
+| --- | --- |
+| setXDim(value) | 矩形の x 軸方向の広がりを取得または設定します。デフォルト値は 2.0 です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getYDim{#getYDim}
+
+| 名前 | 説明 |
+| --- | --- |
+| getYDim() | 矩形の y 軸方向の広がりを取得または設定します。デフォルト値は 2.0 です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setYDim{#setYDim}
+
+| 名前 | 説明 |
+| --- | --- |
+| setYDim(value) | 矩形の y 軸方向の広がりを取得または設定します。デフォルト値は 2.0 です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNodes() | すべての親ノードを取得します。エンティティはジオメトリインスタンシングのために複数の親ノードにアタッチできます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExcluded() | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExcluded(value) | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNode() | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setParentNode(value) | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 名前 | 説明 |
+| --- | --- |
+| getScene() | このオブジェクトが属するシーンを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtent{#getExtent}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExtent() | x と y の次元での範囲を取得します |
+
+ **Result:**
+Vector2
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEntityRendererKey() | レンダラーに登録されたエンティティレンダラーのキーを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBoundingBox() | 現在のエンティティのオブジェクト空間座標系におけるバウンディングボックスを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/rectangulartorus/_index.md
+++ b/japanese/nodejs-java/aspose.threed/rectangulartorus/_index.md
@@ -1,0 +1,502 @@
+---
+title: "RectangularTorus"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/rectangulartorus/
+---
+## RectangularTorus class
+
+パラメータ化された矩形トーラス。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | RectangularTorus のコンストラクタ |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload(name) | RectangularTorus のコンストラクタ |
+
+ **Result:**
+
+
+
+---
+
+
+### getInnerRadius{#getInnerRadius}
+
+| 名前 | 説明 |
+| --- | --- |
+| getInnerRadius() | 矩形トーラスの内部半径（デフォルト値は 17） |
+
+ **Result:**
+
+
+
+---
+
+
+### setInnerRadius{#setInnerRadius}
+
+| 名前 | 説明 |
+| --- | --- |
+| setInnerRadius(value) | 矩形トーラスの内部半径（デフォルト値は 17） |
+
+ **Result:**
+
+
+
+---
+
+
+### getOuterRadius{#getOuterRadius}
+
+| 名前 | 説明 |
+| --- | --- |
+| getOuterRadius() | 矩形トーラスの外部半径（デフォルト値は 20） |
+
+ **Result:**
+
+
+
+---
+
+
+### setOuterRadius{#setOuterRadius}
+
+| 名前 | 説明 |
+| --- | --- |
+| setOuterRadius(value) | 矩形トーラスの外部半径（デフォルト値は 20） |
+
+ **Result:**
+
+
+
+---
+
+
+### getHeight{#getHeight}
+
+| 名前 | 説明 |
+| --- | --- |
+| getHeight() | 矩形トーラスの高さ（デフォルト値は 20） |
+
+ **Result:**
+
+
+
+---
+
+
+### setHeight{#setHeight}
+
+| 名前 | 説明 |
+| --- | --- |
+| setHeight(value) | 矩形トーラスの高さ（デフォルト値は 20） |
+
+ **Result:**
+
+
+
+---
+
+
+### getArc{#getArc}
+
+| 名前 | 説明 |
+| --- | --- |
+| getArc() | 弧の総角度（ラジアンで測定、デフォルト値は PI） |
+
+ **Result:**
+
+
+
+---
+
+
+### setArc{#setArc}
+
+| 名前 | 説明 |
+| --- | --- |
+| setArc(value) | 弧の総角度（ラジアンで測定、デフォルト値は PI） |
+
+ **Result:**
+
+
+
+---
+
+
+### getAngleStart{#getAngleStart}
+
+| 名前 | 説明 |
+| --- | --- |
+| getAngleStart() | 弧の開始角度（ラジアンで測定、デフォルト値は 0） |
+
+ **Result:**
+
+
+
+---
+
+
+### setAngleStart{#setAngleStart}
+
+| 名前 | 説明 |
+| --- | --- |
+| setAngleStart(value) | 弧の開始角度（ラジアンで測定、デフォルト値は 0） |
+
+ **Result:**
+
+
+
+---
+
+
+### getRadialSegments{#getRadialSegments}
+
+| 名前 | 説明 |
+| --- | --- |
+| getRadialSegments() | ラジアルセグメント（デフォルト値は 10） |
+
+ **Result:**
+
+
+
+---
+
+
+### setRadialSegments{#setRadialSegments}
+
+| 名前 | 説明 |
+| --- | --- |
+| setRadialSegments(value) | ラジアルセグメント（デフォルト値は 10） |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastShadows{#getCastShadows}
+
+| 名前 | 説明 |
+| --- | --- |
+| getCastShadows() | このジオメトリが影を落とすかどうかを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastShadows{#setCastShadows}
+
+| 名前 | 説明 |
+| --- | --- |
+| setCastShadows(value) | このジオメトリが影を落とすかどうかを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getReceiveShadows{#getReceiveShadows}
+
+| 名前 | 説明 |
+| --- | --- |
+| getReceiveShadows() | このジオメトリが影を受け取るかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setReceiveShadows{#setReceiveShadows}
+
+| 名前 | 説明 |
+| --- | --- |
+| setReceiveShadows(value) | このジオメトリが影を受け取るかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNodes() | すべての親ノードを取得します。エンティティはジオメトリインスタンシングのために複数の親ノードにアタッチできます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExcluded() | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExcluded(value) | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNode() | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setParentNode(value) | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 名前 | 説明 |
+| --- | --- |
+| getScene() | このオブジェクトが属するシーンを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### toMesh{#toMesh}
+
+| 名前 | 説明 |
+| --- | --- |
+| toMesh() |  |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBoundingBox() | 現在のエンティティのオブジェクト空間座標系におけるバウンディングボックスを取得します。 |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEntityRendererKey() | レンダラーに登録されたエンティティレンダラーのキーを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/relativerectangle/_index.md
+++ b/japanese/nodejs-java/aspose.threed/relativerectangle/_index.md
@@ -1,0 +1,316 @@
+---
+title: "RelativeRectangle"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/relativerectangle/
+---
+## RelativeRectangle class
+
+相対矩形  相対コンポーネントと絶対値の間の式は:  Scale  (Reference Width) + offset  したがって、絶対値を表したい場合は、すべてのスケールフィールドをゼロにし、代わりにオフセットフィールドを使用してください。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload(left, top, width, height) | RelativeRectangle を構築します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| 左 | 数 | null |
+| to | 数 | null |
+| 幅 | 数 | null |
+| 高さ | 数 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### getScaleX{#getScaleX}
+
+| 名前 | 説明 |
+| --- | --- |
+| getScaleX() | 相対座標 X |
+
+ **Result:**
+
+
+
+---
+
+
+### setScaleX{#setScaleX}
+
+| 名前 | 説明 |
+| --- | --- |
+| setScaleX(value) | 相対座標 X |
+
+ **Result:**
+
+
+
+---
+
+
+### getScaleY{#getScaleY}
+
+| 名前 | 説明 |
+| --- | --- |
+| getScaleY() | 相対座標 Y |
+
+ **Result:**
+
+
+
+---
+
+
+### setScaleY{#setScaleY}
+
+| 名前 | 説明 |
+| --- | --- |
+| setScaleY(value) | 相対座標 Y |
+
+ **Result:**
+
+
+
+---
+
+
+### getScaleWidth{#getScaleWidth}
+
+| 名前 | 説明 |
+| --- | --- |
+| getScaleWidth() | 相対幅 |
+
+ **Result:**
+
+
+
+---
+
+
+### setScaleWidth{#setScaleWidth}
+
+| 名前 | 説明 |
+| --- | --- |
+| setScaleWidth(value) | 相対幅 |
+
+ **Result:**
+
+
+
+---
+
+
+### getScaleHeight{#getScaleHeight}
+
+| 名前 | 説明 |
+| --- | --- |
+| getScaleHeight() | 相対高さ |
+
+ **Result:**
+
+
+
+---
+
+
+### setScaleHeight{#setScaleHeight}
+
+| 名前 | 説明 |
+| --- | --- |
+| setScaleHeight(value) | 相対高さ |
+
+ **Result:**
+
+
+
+---
+
+
+### getOffsetX{#getOffsetX}
+
+| 名前 | 説明 |
+| --- | --- |
+| getOffsetX() | 座標 X のオフセットを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setOffsetX{#setOffsetX}
+
+| 名前 | 説明 |
+| --- | --- |
+| setOffsetX(value) | 座標 X のオフセットを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getOffsetY{#getOffsetY}
+
+| 名前 | 説明 |
+| --- | --- |
+| getOffsetY() | 座標 Y のオフセットを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setOffsetY{#setOffsetY}
+
+| 名前 | 説明 |
+| --- | --- |
+| setOffsetY(value) | 座標 Y のオフセットを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getOffsetWidth{#getOffsetWidth}
+
+| 名前 | 説明 |
+| --- | --- |
+| getOffsetWidth() | 幅のオフセットを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setOffsetWidth{#setOffsetWidth}
+
+| 名前 | 説明 |
+| --- | --- |
+| setOffsetWidth(value) | 幅のオフセットを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getOffsetHeight{#getOffsetHeight}
+
+| 名前 | 説明 |
+| --- | --- |
+| getOffsetHeight() | 高さのオフセットを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setOffsetHeight{#setOffsetHeight}
+
+| 名前 | 説明 |
+| --- | --- |
+| setOffsetHeight(value) | 高さのオフセットを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### toAbsolute{#toAbsolute}
+
+| 名前 | 説明 |
+| --- | --- |
+| toAbsolute(left, top, width, height) | 相対矩形を絶対矩形に変換します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| 左 | 数 | 矩形の左側 |
+| 上 | 数 | 矩形の上側 |
+| 幅 | 数 | 矩形の幅 |
+| height | 数 | 矩形の高さ |
+
+ **Result:**
+Rect
+
+
+---
+
+
+### fromScale{#fromScale}
+
+| 名前 | 説明 |
+| --- | --- |
+| fromScale(scaleX, scaleY, scaleWidth, scaleHeight) | すべてのオフセットフィールドを0にし、スケールフィールドを指定されたパラメータから設定した RelativeRectangle を構築します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| スケール | 数 | null |
+| スケール | 数 | null |
+| scaleWidt | 数 | null |
+| scaleHeigh | 数 | null |
+
+ **Result:**
+RelativeRectangle
+
+
+---
+
+
+### toString{#toString}
+
+| 名前 | 説明 |
+| --- | --- |
+| toString() | このインスタンスの値を java.lang.String に変換します。 |
+
+ **Result:**
+RelativeRectangle
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/renderer/_index.md
+++ b/japanese/nodejs-java/aspose.threed/renderer/_index.md
@@ -1,0 +1,398 @@
+---
+title: "レンダラー"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/renderer/
+---
+## Renderer class
+
+レンダラーに関するコンテキスト。  @hideconstructor
+
+
+## メソッド
+
+### getShaderSet{#getShaderSet}
+
+| 名前 | 説明 |
+| --- | --- |
+| getShaderSet() | シーンのレンダリングに使用されるシェーダーセットを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setShaderSet{#setShaderSet}
+
+| 名前 | 説明 |
+| --- | --- |
+| setShaderSet(value) | シーンのレンダリングに使用されるシェーダーセットを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getVariables{#getVariables}
+
+| 名前 | 説明 |
+| --- | --- |
+| getVariables() | レンダリングに使用される内部変数へのアクセス |
+
+ **Result:**
+
+
+
+---
+
+
+### getPresetShaders{#getPresetShaders}
+
+| 名前 | 説明 |
+| --- | --- |
+| getPresetShaders() | プリセットシェーダーセットを取得または設定します。プロパティの値は PresetShaders の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setPresetShaders{#setPresetShaders}
+
+| 名前 | 説明 |
+| --- | --- |
+| setPresetShaders(value) | プリセットシェーダーセットを取得または設定します。プロパティの値は PresetShaders の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getRenderFactory{#getRenderFactory}
+
+| 名前 | 説明 |
+| --- | --- |
+| getRenderFactory() | レンダー関連オブジェクトを構築するファクトリを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getAssetDirectories{#getAssetDirectories}
+
+| 名前 | 説明 |
+| --- | --- |
+| getAssetDirectories() | 外部アセットが格納されているディレクトリ |
+
+ **Result:**
+
+
+
+---
+
+
+### getPostProcessings{#getPostProcessings}
+
+| 名前 | 説明 |
+| --- | --- |
+| getPostProcessings() | アクティブなポストプロセッシングチェーン |
+
+ **Result:**
+
+
+
+---
+
+
+### getEnableShadows{#getEnableShadows}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEnableShadows() | シャドウを有効にするかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setEnableShadows{#setEnableShadows}
+
+| 名前 | 説明 |
+| --- | --- |
+| setEnableShadows(value) | シャドウを有効にするかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getRenderTarget{#getRenderTarget}
+
+| 名前 | 説明 |
+| --- | --- |
+| getRenderTarget() | 以下のレンダー操作が実行されるレンダーターゲットを指定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getNode{#getNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getNode() | ワールド変換行列を提供するために使用される Node インスタンスを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setNode{#setNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setNode(value) | ワールド変換行列を提供するために使用される Node インスタンスを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFrustum{#getFrustum}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFrustum() | ビュー行列を提供するために使用される視錐台を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFrustum{#setFrustum}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFrustum(value) | ビュー行列を提供するために使用される視錐台を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getRenderStage{#getRenderStage}
+
+| 名前 | 説明 |
+| --- | --- |
+| getRenderStage() | 現在のレンダーステージを取得します。プロパティの値は RenderStage の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getMaterial{#getMaterial}
+
+| 名前 | 説明 |
+| --- | --- |
+| getMaterial() | シェーダーで使用されるマテリアル情報を提供するために使用されるマテリアルを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setMaterial{#setMaterial}
+
+| 名前 | 説明 |
+| --- | --- |
+| setMaterial(value) | シェーダーで使用されるマテリアル情報を提供するために使用されるマテリアルを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getShader{#getShader}
+
+| 名前 | 説明 |
+| --- | --- |
+| getShader() | ジオメトリのレンダリングに使用されるシェーダーインスタンスを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setShader{#setShader}
+
+| 名前 | 説明 |
+| --- | --- |
+| setShader(value) | ジオメトリのレンダリングに使用されるシェーダーインスタンスを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFallbackEntityRenderer{#getFallbackEntityRenderer}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFallbackEntityRenderer() | エンティティに特別なレンダラーが定義されていない場合のフォールバックエンティティレンダラーを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFallbackEntityRenderer{#setFallbackEntityRenderer}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFallbackEntityRenderer(value) | エンティティに特別なレンダラーが定義されていない場合のフォールバックエンティティレンダラーを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### clearCache{#clearCache}
+
+| 名前 | 説明 |
+| --- | --- |
+| clearCache() | キャッシュを手動でクリアします。Aspose.3D はマテリアルやジオメトリなどのオブジェクトをレンダーパイプラインと互換性のある内部タイプにキャッシュします。シーンに大幅な変更があった場合は手動で呼び出す必要があります。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getPostProcessing{#getPostProcessing}
+
+| 名前 | 説明 |
+| --- | --- |
+| getPostProcessing(name) | レンダラーがサポートする組み込みのポストプロセッサを取得します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | 文字列 | null |
+
+ **Result:**
+ポストプロセッシング
+
+
+---
+
+
+### execute{#execute}
+
+| 名前 | 説明 |
+| --- | --- |
+| execute(postProcessing, result) | 指定されたレンダーターゲットでポストプロセッシングを実行します。 |
+
+ **Result:**
+ポストプロセッシング
+
+
+---
+
+
+### createRenderer{#createRenderer}
+
+| 名前 | 説明 |
+| --- | --- |
+| createRenderer() | デフォルトプロファイルで新しい Renderer を作成します。 |
+
+ **Result:**
+レンダラー
+
+
+---
+
+
+### registerEntityRenderer{#registerEntityRenderer}
+
+| 名前 | 説明 |
+| --- | --- |
+| registerEntityRenderer(renderer) | 指定されたエンティティのエンティティレンダラーを登録します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| rendere | EntityRenderer | null |
+
+ **Result:**
+レンダラー
+
+
+---
+
+
+### render{#render}
+
+| 名前 | 説明 |
+| --- | --- |
+| render(renderTarget) | 指定されたターゲットをレンダーします |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| renderTarge | IRenderTarget | null |
+
+ **Result:**
+レンダラー
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/renderervariablemanager/_index.md
+++ b/japanese/nodejs-java/aspose.threed/renderervariablemanager/_index.md
@@ -1,0 +1,328 @@
+---
+title: "RendererVariableManager"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/renderervariablemanager/
+---
+## RendererVariableManager class
+
+このクラスはレンダリングで使用される変数を管理します  @hideconstructor
+
+
+## メソッド
+
+### getWorldTime{#getWorldTime}
+
+| 名前 | 説明 |
+| --- | --- |
+| getWorldTime() | 時間（秒） |
+
+ **Result:**
+
+
+
+---
+
+
+### setWorldTime{#setWorldTime}
+
+| 名前 | 説明 |
+| --- | --- |
+| setWorldTime(value) | 時間（秒） |
+
+ **Result:**
+
+
+
+---
+
+
+### getShadowCaster{#getShadowCaster}
+
+| 名前 | 説明 |
+| --- | --- |
+| getShadowCaster() | ワールド座標系におけるシャドウキャスターの位置 |
+
+ **Result:**
+
+
+
+---
+
+
+### setShadowCaster{#setShadowCaster}
+
+| 名前 | 説明 |
+| --- | --- |
+| setShadowCaster(value) | ワールド座標系におけるシャドウキャスターの位置 |
+
+ **Result:**
+
+
+
+---
+
+
+### getShadowmap{#getShadowmap}
+
+| 名前 | 説明 |
+| --- | --- |
+| getShadowmap() | シャドウマッピングに使用される深度テクスチャ |
+
+ **Result:**
+
+
+
+---
+
+
+### setShadowmap{#setShadowmap}
+
+| 名前 | 説明 |
+| --- | --- |
+| setShadowmap(value) | シャドウマッピングに使用される深度テクスチャ |
+
+ **Result:**
+
+
+
+---
+
+
+### getMatrixLightSpace{#getMatrixLightSpace}
+
+| 名前 | 説明 |
+| --- | --- |
+| getMatrixLightSpace() | 光空間変換用の行列 |
+
+ **Result:**
+
+
+
+---
+
+
+### setMatrixLightSpace{#setMatrixLightSpace}
+
+| 名前 | 説明 |
+| --- | --- |
+| setMatrixLightSpace(value) | 光空間変換用の行列 |
+
+ **Result:**
+
+
+
+---
+
+
+### getMatrixViewProjection{#getMatrixViewProjection}
+
+| 名前 | 説明 |
+| --- | --- |
+| getMatrixViewProjection() | ビューと投影変換用の行列。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getMatrixWorldViewProjection{#getMatrixWorldViewProjection}
+
+| 名前 | 説明 |
+| --- | --- |
+| getMatrixWorldViewProjection() | ワールドビューと投影変換用の行列 |
+
+ **Result:**
+
+
+
+---
+
+
+### getMatrixWorld{#getMatrixWorld}
+
+| 名前 | 説明 |
+| --- | --- |
+| getMatrixWorld() | ワールド変換用の行列 |
+
+ **Result:**
+
+
+
+---
+
+
+### getMatrixWorldNormal{#getMatrixWorldNormal}
+
+| 名前 | 説明 |
+| --- | --- |
+| getMatrixWorldNormal() | オブジェクトからワールド空間への法線変換用の行列。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getMatrixProjection{#getMatrixProjection}
+
+| 名前 | 説明 |
+| --- | --- |
+| getMatrixProjection() | 投影変換用の行列 |
+
+ **Result:**
+
+
+
+---
+
+
+### setMatrixProjection{#setMatrixProjection}
+
+| 名前 | 説明 |
+| --- | --- |
+| setMatrixProjection(value) | 投影変換用の行列 |
+
+ **Result:**
+
+
+
+---
+
+
+### getMatrixView{#getMatrixView}
+
+| 名前 | 説明 |
+| --- | --- |
+| getMatrixView() | ビュー変換用の行列 |
+
+ **Result:**
+
+
+
+---
+
+
+### setMatrixView{#setMatrixView}
+
+| 名前 | 説明 |
+| --- | --- |
+| setMatrixView(value) | ビュー変換用の行列 |
+
+ **Result:**
+
+
+
+---
+
+
+### getCameraPosition{#getCameraPosition}
+
+| 名前 | 説明 |
+| --- | --- |
+| getCameraPosition() | カメラの位置（ワールド座標系） |
+
+ **Result:**
+
+
+
+---
+
+
+### setCameraPosition{#setCameraPosition}
+
+| 名前 | 説明 |
+| --- | --- |
+| setCameraPosition(value) | カメラの位置（ワールド座標系） |
+
+ **Result:**
+
+
+
+---
+
+
+### getDepthBias{#getDepthBias}
+
+| 名前 | 説明 |
+| --- | --- |
+| getDepthBias() | シャドウマッピング用の深度バイアス、デフォルト値は0.001です |
+
+ **Result:**
+
+
+
+---
+
+
+### setDepthBias{#setDepthBias}
+
+| 名前 | 説明 |
+| --- | --- |
+| setDepthBias(value) | シャドウマッピング用の深度バイアス、デフォルト値は0.001です |
+
+ **Result:**
+
+
+
+---
+
+
+### getViewportSize{#getViewportSize}
+
+| 名前 | 説明 |
+| --- | --- |
+| getViewportSize() | ビューポートのサイズ（ピクセル単位） |
+
+ **Result:**
+
+
+
+---
+
+
+### setViewportSize{#setViewportSize}
+
+| 名前 | 説明 |
+| --- | --- |
+| setViewportSize(value) | ビューポートのサイズ（ピクセル単位） |
+
+ **Result:**
+
+
+
+---
+
+
+### getWorldAmbient{#getWorldAmbient}
+
+| 名前 | 説明 |
+| --- | --- |
+| getWorldAmbient() | ビューポートで定義された環境光の色。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setWorldAmbient{#setWorldAmbient}
+
+| 名前 | 説明 |
+| --- | --- |
+| setWorldAmbient(value) | ビューポートで定義された環境光の色。 |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/renderfactory/_index.md
+++ b/japanese/nodejs-java/aspose.threed/renderfactory/_index.md
@@ -1,0 +1,243 @@
+---
+title: "RenderFactory"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/renderfactory/
+---
+## RenderFactory class
+
+RenderFactory はレンダリングパイプラインで表現されるすべてのリソースを作成します。  @hideconstructor
+
+
+## メソッド
+
+### createRenderTexture{#createRenderTexture}
+
+| 名前 | 説明 |
+| --- | --- |
+| createRenderTexture(parameters, targets, width, height) | テクスチャにレンダリングするレンダーターゲットを作成します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| パラメータ | RenderParameters | レンダー テクスチャを作成するためのパラメータ |
+| ターゲット | 数 | カラー出力ターゲットの数 |
+| 幅 | 数 | レンダー テクスチャの幅 |
+| height | 数 | レンダー テクスチャの高さ |
+
+ **Result:**
+IRenderTexture
+
+
+---
+
+
+### createRenderTexture{#createRenderTexture}
+
+| 名前 | 説明 |
+| --- | --- |
+| createRenderTexture(parameters, width, height) | テクスチャにレンダリングする1つのターゲットを含むレンダーターゲットを作成します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| パラメータ | RenderParameters | レンダー テクスチャを作成するためのパラメータ |
+| 幅 | 数 | レンダー テクスチャの幅 |
+| height | 数 | レンダー テクスチャの高さ |
+
+ **Result:**
+IRenderTexture
+
+
+---
+
+
+### createDescriptorSet{#createDescriptorSet}
+
+| 名前 | 説明 |
+| --- | --- |
+| createDescriptorSet(shader) | 指定されたシェーダープログラム用のディスクリプタセットを作成します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| シェーダー | ShaderProgram | シェーダープログラム |
+
+ **Result:**
+IDescriptorSet
+
+
+---
+
+
+### createCubeRenderTexture{#createCubeRenderTexture}
+
+| 名前 | 説明 |
+| --- | --- |
+| createCubeRenderTexture(parameters, width, height) | 1つのキューブテクスチャを含むレンダーターゲットを作成します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| パラメータ | RenderParameters | レンダー テクスチャを作成するためのパラメータ |
+| 幅 | 数 | レンダー テクスチャの幅 |
+| height | 数 | レンダー テクスチャの高さ |
+
+ **Result:**
+IRenderTexture
+
+
+---
+
+
+### createRenderWindow{#createRenderWindow}
+
+| 名前 | 説明 |
+| --- | --- |
+| createRenderWindow(parameters, handle) | ネイティブウィンドウにレンダリングするレンダーターゲットを作成します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| パラメータ | RenderParameters | レンダーウィンドウを作成するためのパラメータ |
+| ハンドル | WindowHandle | レンダリングするウィンドウのハンドル |
+
+ **Result:**
+IRenderWindow
+
+
+---
+
+
+### createVertexBuffer{#createVertexBuffer}
+
+| 名前 | 説明 |
+| --- | --- |
+| createVertexBuffer(declaration) | ポリゴンの頂点情報を格納するための com.aspose.threed.IVertexBuffer インスタンスを作成します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| 宣言 | VertexDeclaration | null |
+
+ **Result:**
+IVertexBuffer
+
+
+---
+
+
+### createIndexBuffer{#createIndexBuffer}
+
+| 名前 | 説明 |
+| --- | --- |
+| createIndexBuffer() | ポリゴンの面情報を格納するための com.aspose.threed.IIndexBuffer インスタンスを作成します。 |
+
+ **Result:**
+IIndexBuffer
+
+
+---
+
+
+### createTextureUnit{#createTextureUnit}
+
+| 名前 | 説明 |
+| --- | --- |
+| createTextureUnit(textureType) | シェーダーからアクセス可能なテクスチャユニットを作成します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| textureType | TextureType | TextureType |
+
+ **Result:**
+ITextureUnit
+
+
+---
+
+
+### createTextureUnit{#createTextureUnit}
+
+| 名前 | 説明 |
+| --- | --- |
+| createTextureUnit() | シェーダーからアクセス可能な 2D テクスチャユニットを作成します。 |
+
+ **Result:**
+ITextureUnit
+
+
+---
+
+
+### createShaderProgram{#createShaderProgram}
+
+| 名前 | 説明 |
+| --- | --- |
+| createShaderProgram(shaderSource) | ShaderProgram オブジェクトを作成します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| shaderSource | シェーダーソース | シェーダーのソースコード |
+
+ **Result:**
+ShaderProgram
+
+
+---
+
+
+### createPipeline{#createPipeline}
+
+| 名前 | 説明 |
+| --- | --- |
+| createPipeline(shader, renderState, vertexDeclaration, drawOperation) | 事前設定されたシェーダー、レンダー状態、頂点宣言、描画操作を備えたグラフィックスパイプラインを作成します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| シェーダー | ShaderProgram | レンダリングで使用されるシェーダー |
+| renderState | RenderState | レンダリングで使用されるレンダー状態 |
+| vertexDeclaration | VertexDeclaration | 入力頂点データの頂点宣言 |
+| drawOperation | DrawOperation | DrawOperation |
+
+ **Result:**
+IPipeline
+
+
+---
+
+
+### createUniformBuffer{#createUniformBuffer}
+
+| 名前 | 説明 |
+| --- | --- |
+| createUniformBuffer(size) | GPU側で事前に割り当てられたサイズで新しいユニフォームバッファを作成します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| サイズ | 数 | ユニフォームバッファのサイズ |
+
+ **Result:**
+IBuffer
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/renderparameters/_index.md
+++ b/japanese/nodejs-java/aspose.threed/renderparameters/_index.md
@@ -1,0 +1,133 @@
+---
+title: "RenderParameters"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/renderparameters/
+---
+## RenderParameters class
+
+レンダーターゲットのパラメータを記述します
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| コンストラクタ(doubleBuffering, colorBits, depthBits, stencilBits) | PixelFormat のインスタンスを初期化する |
+
+ **Result:**
+
+
+
+---
+
+
+### getDoubleBuffering{#getDoubleBuffering}
+
+| 名前 | 説明 |
+| --- | --- |
+| getDoubleBuffering() | ダブルバッファが使用されているかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setDoubleBuffering{#setDoubleBuffering}
+
+| 名前 | 説明 |
+| --- | --- |
+| setDoubleBuffering(value) | ダブルバッファが使用されているかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getColorBits{#getColorBits}
+
+| 名前 | 説明 |
+| --- | --- |
+| getColorBits() | カラーバッファに使用されるビット数を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setColorBits{#setColorBits}
+
+| 名前 | 説明 |
+| --- | --- |
+| setColorBits(value) | カラーバッファに使用されるビット数を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getDepthBits{#getDepthBits}
+
+| 名前 | 説明 |
+| --- | --- |
+| getDepthBits() | デプスバッファで使用されるビット数を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setDepthBits{#setDepthBits}
+
+| 名前 | 説明 |
+| --- | --- |
+| setDepthBits(value) | デプスバッファで使用されるビット数を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getStencilBits{#getStencilBits}
+
+| 名前 | 説明 |
+| --- | --- |
+| getStencilBits() | ステンシルバッファで使用されるビット数を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setStencilBits{#setStencilBits}
+
+| 名前 | 説明 |
+| --- | --- |
+| setStencilBits(value) | ステンシルバッファで使用されるビット数を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/renderresource/_index.md
+++ b/japanese/nodejs-java/aspose.threed/renderresource/_index.md
@@ -1,0 +1,13 @@
+---
+title: "RenderResource"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/renderresource/
+---
+## RenderResource class
+
+すべてのレンダーリソースの抽象クラス  レンダラーが解放されると、すべてのレンダーリソースは破棄されます。  Mesh/Texture のようなクラスは対応する RenderResource を持ちます。  @hideconstructor
+
+

--- a/japanese/nodejs-java/aspose.threed/renderstate/_index.md
+++ b/japanese/nodejs-java/aspose.threed/renderstate/_index.md
@@ -1,0 +1,477 @@
+---
+title: "RenderState"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/renderstate/
+---
+## RenderState class
+
+パイプライン構築用のレンダー状態  レンダー状態に加えた変更は、作成されたパイプラインインスタンスに影響しません。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | RenderState のコンストラクタ |
+
+ **Result:**
+
+
+
+---
+
+
+### getBlend{#getBlend}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBlend() | フラグメントブレンディングを有効または無効にします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setBlend{#setBlend}
+
+| 名前 | 説明 |
+| --- | --- |
+| setBlend(value) | フラグメントブレンディングを有効または無効にします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getBlendColor{#getBlendColor}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBlendColor() | BlendFactor.CONSTANT_COLOR で使用されるブレンドカラーを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setBlendColor{#setBlendColor}
+
+| 名前 | 説明 |
+| --- | --- |
+| setBlendColor(value) | BlendFactor.CONSTANT_COLOR で使用されるブレンドカラーを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getSourceBlendFactor{#getSourceBlendFactor}
+
+| 名前 | 説明 |
+| --- | --- |
+| getSourceBlendFactor() | 色がどのようにブレンドされるかを取得または設定します。プロパティの値は BlendFactor の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setSourceBlendFactor{#setSourceBlendFactor}
+
+| 名前 | 説明 |
+| --- | --- |
+| setSourceBlendFactor(value) | 色がどのようにブレンドされるかを取得または設定します。プロパティの値は BlendFactor の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getDestinationBlendFactor{#getDestinationBlendFactor}
+
+| 名前 | 説明 |
+| --- | --- |
+| getDestinationBlendFactor() | 色がどのようにブレンドされるかを取得または設定します。プロパティの値は BlendFactor の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setDestinationBlendFactor{#setDestinationBlendFactor}
+
+| 名前 | 説明 |
+| --- | --- |
+| setDestinationBlendFactor(value) | 色がどのようにブレンドされるかを取得または設定します。プロパティの値は BlendFactor の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getCullFace{#getCullFace}
+
+| 名前 | 説明 |
+| --- | --- |
+| getCullFace() | カリングフェイスを有効または無効にします |
+
+ **Result:**
+
+
+
+---
+
+
+### setCullFace{#setCullFace}
+
+| 名前 | 説明 |
+| --- | --- |
+| setCullFace(value) | カリングフェイスを有効または無効にします |
+
+ **Result:**
+
+
+
+---
+
+
+### getCullFaceMode{#getCullFaceMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getCullFaceMode() | 取得または設定します。どの面がカリングされるかを指定します。プロパティの値は CullFaceMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setCullFaceMode{#setCullFaceMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setCullFaceMode(value) | 取得または設定します。どの面がカリングされるかを指定します。プロパティの値は CullFaceMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFrontFace{#getFrontFace}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFrontFace() | 取得または設定します。どの順序が前面かを指定します。プロパティの値は FrontFace の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFrontFace{#setFrontFace}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFrontFace(value) | 取得または設定します。どの順序が前面かを指定します。プロパティの値は FrontFace の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getDepthTest{#getDepthTest}
+
+| 名前 | 説明 |
+| --- | --- |
+| getDepthTest() | 深度テストを有効または無効にします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setDepthTest{#setDepthTest}
+
+| 名前 | 説明 |
+| --- | --- |
+| setDepthTest(value) | 深度テストを有効または無効にします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getDepthMask{#getDepthMask}
+
+| 名前 | 説明 |
+| --- | --- |
+| getDepthMask() | 深度書き込みを有効または無効にします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setDepthMask{#setDepthMask}
+
+| 名前 | 説明 |
+| --- | --- |
+| setDepthMask(value) | 深度書き込みを有効または無効にします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getDepthFunction{#getDepthFunction}
+
+| 名前 | 説明 |
+| --- | --- |
+| getDepthFunction() | 取得または設定します。深度テストで使用される比較関数を指定します。プロパティの値は CompareFunction の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setDepthFunction{#setDepthFunction}
+
+| 名前 | 説明 |
+| --- | --- |
+| setDepthFunction(value) | 取得または設定します。深度テストで使用される比較関数を指定します。プロパティの値は CompareFunction の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getStencilTest{#getStencilTest}
+
+| 名前 | 説明 |
+| --- | --- |
+| getStencilTest() | ステンシルテストを有効または無効にします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setStencilTest{#setStencilTest}
+
+| 名前 | 説明 |
+| --- | --- |
+| setStencilTest(value) | ステンシルテストを有効または無効にします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getStencilReference{#getStencilReference}
+
+| 名前 | 説明 |
+| --- | --- |
+| getStencilReference() | 取得または設定します。ステンシルテストの参照値を指定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setStencilReference{#setStencilReference}
+
+| 名前 | 説明 |
+| --- | --- |
+| setStencilReference(value) | 取得または設定します。ステンシルテストの参照値を指定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getStencilMask{#getStencilMask}
+
+| 名前 | 説明 |
+| --- | --- |
+| getStencilMask() | 取得または設定します。テストが完了したときに、参照値と保存されたステンシル値の両方に AND 演算されるマスクを指定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getStencilFrontFace{#getStencilFrontFace}
+
+| 名前 | 説明 |
+| --- | --- |
+| getStencilFrontFace() | 前面のステンシル状態を取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getStencilBackFace{#getStencilBackFace}
+
+| 名前 | 説明 |
+| --- | --- |
+| getStencilBackFace() | 背面のステンシル状態を取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getScissorTest{#getScissorTest}
+
+| 名前 | 説明 |
+| --- | --- |
+| getScissorTest() | シザーテストを有効化または無効化します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setScissorTest{#setScissorTest}
+
+| 名前 | 説明 |
+| --- | --- |
+| setScissorTest(value) | シザーテストを有効化または無効化します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getPolygonMode{#getPolygonMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getPolygonMode() | ポリゴンのレンダリングモードを取得または設定します。プロパティの値は PolygonMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setPolygonMode{#setPolygonMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setPolygonMode(value) | ポリゴンのレンダリングモードを取得または設定します。プロパティの値は PolygonMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### equals{#equals}
+
+| 名前 | 説明 |
+| --- | --- |
+| equals(obj) | このインスタンスが指定されたオブジェクトと等しいかどうかを示す値を返します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### hashCode{#hashCode}
+
+| 名前 | 説明 |
+| --- | --- |
+| hashCode() | このインスタンスのハッシュコードを返します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### compareTo{#compareTo}
+
+| 名前 | 説明 |
+| --- | --- |
+| compareTo(other) | レンダリング状態を別のインスタンスと比較します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| othe | RenderState | null |
+
+ **Result:**
+数
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/revolvedareasolid/_index.md
+++ b/japanese/nodejs-java/aspose.threed/revolvedareasolid/_index.md
@@ -1,0 +1,411 @@
+---
+title: "RevolvedAreaSolid"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/revolvedareasolid/
+---
+## RevolvedAreaSolid class
+
+このクラスは、プロファイルで提供された断面を軸の周りに回転させることで、ソリッドモデルを表現します。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getAngleStart{#getAngleStart}
+
+| 名前 | 説明 |
+| --- | --- |
+| getAngleStart() | 回転手順の開始角度を取得または設定します（ラジアンで測定）、デフォルト値は 0 です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setAngleStart{#setAngleStart}
+
+| 名前 | 説明 |
+| --- | --- |
+| setAngleStart(value) | 回転手順の開始角度を取得または設定します（ラジアンで測定）、デフォルト値は 0 です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getAngleEnd{#getAngleEnd}
+
+| 名前 | 説明 |
+| --- | --- |
+| getAngleEnd() | 回転手順の終了角度を取得または設定します（ラジアンで測定）、デフォルト値は π です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setAngleEnd{#setAngleEnd}
+
+| 名前 | 説明 |
+| --- | --- |
+| setAngleEnd(value) | 回転手順の終了角度を取得または設定します（ラジアンで測定）、デフォルト値は π です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getAxis{#getAxis}
+
+| 名前 | 説明 |
+| --- | --- |
+| getAxis() | 軸方向を取得または設定します、デフォルト値は (0, 1, 0) です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setAxis{#setAxis}
+
+| 名前 | 説明 |
+| --- | --- |
+| setAxis(value) | 軸方向を取得または設定します、デフォルト値は (0, 1, 0) です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getOrigin{#getOrigin}
+
+| 名前 | 説明 |
+| --- | --- |
+| getOrigin() | 回転の原点を取得または設定します、デフォルト値は (0, 0, 0) です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setOrigin{#setOrigin}
+
+| 名前 | 説明 |
+| --- | --- |
+| setOrigin(value) | 回転の原点を取得または設定します、デフォルト値は (0, 0, 0) です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getShape{#getShape}
+
+| 名前 | 説明 |
+| --- | --- |
+| getShape() | 回転に使用されるベースプロファイルを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setShape{#setShape}
+
+| 名前 | 説明 |
+| --- | --- |
+| setShape(value) | 回転に使用されるベースプロファイルを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNodes() | すべての親ノードを取得します。エンティティはジオメトリインスタンシングのために複数の親ノードにアタッチできます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExcluded() | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExcluded(value) | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNode() | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setParentNode(value) | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 名前 | 説明 |
+| --- | --- |
+| getScene() | このオブジェクトが属するシーンを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### toMesh{#toMesh}
+
+| 名前 | 説明 |
+| --- | --- |
+| toMesh() | RevolvedAreaSolid をメッシュに変換します。 |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBoundingBox() | 現在のエンティティのオブジェクト空間座標系におけるバウンディングボックスを取得します。 |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEntityRendererKey() | レンダラーに登録されたエンティティレンダラーのキーを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/rvmformat/_index.md
+++ b/japanese/nodejs-java/aspose.threed/rvmformat/_index.md
@@ -1,0 +1,141 @@
+---
+title: "RvmFormat"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/rvmformat/
+---
+## RvmFormat class
+
+RVM フォーマット  @hideconstructor
+
+
+## メソッド
+
+### getVersion{#getVersion}
+
+| 名前 | 説明 |
+| --- | --- |
+| getVersion() | ファイル形式のバージョンを取得します |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtension{#getExtension}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExtension() | このタイプの拡張子名を取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtensions{#getExtensions}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExtensions() | このタイプの拡張子名を取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getContentType{#getContentType}
+
+| 名前 | 説明 |
+| --- | --- |
+| getContentType() | ファイル形式のコンテンツタイプを取得します。このプロパティの値は FileContentType 整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormatType{#getFileFormatType}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileFormatType() | ファイル形式のタイプを取得します |
+
+ **Result:**
+
+
+
+---
+
+
+### loadAttributes{#loadAttributes}
+
+| 名前 | 説明 |
+| --- | --- |
+| loadAttributes(scene, fileName, prefix) | 指定されたファイル名から属性をロードします |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| シーン | Scene | 属性が適用されるシーン |
+| fileName | 文字列 | 属性を含むファイル名 |
+| prefix | 文字列 | 属性名の競合を回避するために使用される属性のプレフィックス。デフォルト値は "rvm:" です |
+
+ **Result:**
+
+
+
+---
+
+
+### createLoadOptions{#createLoadOptions}
+
+| 名前 | 説明 |
+| --- | --- |
+| createLoadOptions() | このファイル形式のデフォルトのロードオプションを作成します |
+
+ **Result:**
+LoadOptions
+
+
+---
+
+
+### createSaveOptions{#createSaveOptions}
+
+| 名前 | 説明 |
+| --- | --- |
+| createSaveOptions() | このファイル形式のデフォルトの保存オプションを作成します |
+
+ **Result:**
+SaveOptions
+
+
+---
+
+
+### toString{#toString}
+
+| 名前 | 説明 |
+| --- | --- |
+| toString() | フォーマットを文字列に変換 |
+
+ **Result:**
+文字列
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/rvmloadoptions/_index.md
+++ b/japanese/nodejs-java/aspose.threed/rvmloadoptions/_index.md
@@ -1,0 +1,373 @@
+---
+title: "RvmLoadOptions"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/rvmloadoptions/
+---
+## RvmLoadOptions class
+
+AVEVA Plant Design Management System の RVM ファイルのロードオプション。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor(contentType) | RvmLoadOptions のインスタンスを作成します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| contentType | FileContentType | FileContentType |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload() | RvmLoadOptions のインスタンスを作成します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getGenerateMaterials{#getGenerateMaterials}
+
+| 名前 | 説明 |
+| --- | --- |
+| getGenerateMaterials() | シーン内の各オブジェクトに対して、カラー テーブルが RVM ファイル内にエクスポートされていない場合、ランダムな色でマテリアルを生成します。デフォルト値は true です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setGenerateMaterials{#setGenerateMaterials}
+
+| 名前 | 説明 |
+| --- | --- |
+| setGenerateMaterials(value) | シーン内の各オブジェクトに対して、カラー テーブルが RVM ファイル内にエクスポートされていない場合、ランダムな色でマテリアルを生成します。デフォルト値は true です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getCylinderRadialSegments{#getCylinderRadialSegments}
+
+| 名前 | 説明 |
+| --- | --- |
+| getCylinderRadialSegments() | シリンダーの放射状セグメント数を取得または設定します。デフォルト値は 16 です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setCylinderRadialSegments{#setCylinderRadialSegments}
+
+| 名前 | 説明 |
+| --- | --- |
+| setCylinderRadialSegments(value) | シリンダーの放射状セグメント数を取得または設定します。デフォルト値は 16 です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getDishLongitudeSegments{#getDishLongitudeSegments}
+
+| 名前 | 説明 |
+| --- | --- |
+| getDishLongitudeSegments() | ディッシュの経度セグメント数を取得または設定します。デフォルト値は 12 です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setDishLongitudeSegments{#setDishLongitudeSegments}
+
+| 名前 | 説明 |
+| --- | --- |
+| setDishLongitudeSegments(value) | ディッシュの経度セグメント数を取得または設定します。デフォルト値は 12 です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getDishLatitudeSegments{#getDishLatitudeSegments}
+
+| 名前 | 説明 |
+| --- | --- |
+| getDishLatitudeSegments() | ディッシュの緯度セグメント数を取得または設定します。デフォルト値は 8 です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setDishLatitudeSegments{#setDishLatitudeSegments}
+
+| 名前 | 説明 |
+| --- | --- |
+| setDishLatitudeSegments(value) | ディッシュの緯度セグメント数を取得または設定します。デフォルト値は 8 です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getTorusTubularSegments{#getTorusTubularSegments}
+
+| 名前 | 説明 |
+| --- | --- |
+| getTorusTubularSegments() | トーラスのチューブ状セグメント数を取得または設定します。デフォルト値は 20 です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setTorusTubularSegments{#setTorusTubularSegments}
+
+| 名前 | 説明 |
+| --- | --- |
+| setTorusTubularSegments(value) | トーラスのチューブ状セグメント数を取得または設定します。デフォルト値は 20 です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getRectangularTorusSegments{#getRectangularTorusSegments}
+
+| 名前 | 説明 |
+| --- | --- |
+| getRectangularTorusSegments() | 矩形トーラスの放射状セグメント数を取得または設定します。デフォルト値は 20 です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setRectangularTorusSegments{#setRectangularTorusSegments}
+
+| 名前 | 説明 |
+| --- | --- |
+| setRectangularTorusSegments(value) | 矩形トーラスの放射状セグメント数を取得または設定します。デフォルト値は 20 です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getCenterScene{#getCenterScene}
+
+| 名前 | 説明 |
+| --- | --- |
+| getCenterScene() | シーンがロードされた後に中心に配置します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setCenterScene{#setCenterScene}
+
+| 名前 | 説明 |
+| --- | --- |
+| setCenterScene(value) | シーンがロードされた後に中心に配置します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getAttributePrefix{#getAttributePrefix}
+
+| 名前 | 説明 |
+| --- | --- |
+| getAttributePrefix() | 外部属性ファイルで定義された属性のプレフィックスを取得または設定します。プレフィックスは名前の衝突を防ぐために使用され、デフォルト値は "rvm:" です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setAttributePrefix{#setAttributePrefix}
+
+| 名前 | 説明 |
+| --- | --- |
+| setAttributePrefix(value) | 外部属性ファイルで定義された属性のプレフィックスを取得または設定します。プレフィックスは名前の衝突を防ぐために使用され、デフォルト値は "rvm:" です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupAttributes{#getLookupAttributes}
+
+| 名前 | 説明 |
+| --- | --- |
+| getLookupAttributes() | 外部属性リストファイル（.att/.attrib/.txt）から属性をロードするかどうかを取得または設定します。デフォルト値は true です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setLookupAttributes{#setLookupAttributes}
+
+| 名前 | 説明 |
+| --- | --- |
+| setLookupAttributes(value) | 外部属性リストファイル（.att/.attrib/.txt）から属性をロードするかどうかを取得または設定します。デフォルト値は true です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileFormat() | 現在の保存/読み込みオプションで指定されたファイル形式を取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEncoding() | テキストベースのファイルのデフォルトエンコーディングを取得または設定します。デフォルト値は null で、インポーター/エクスポーターが使用するエンコーディングを決定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileSystem() | ロード/セーブ時に外部依存関係を管理する方法をユーザーが処理できるようにします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFileSystem(value) | ロード/セーブ時に外部依存関係を管理する方法をユーザーが処理できるようにします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| 名前 | 説明 |
+| --- | --- |
+| getLookupPaths() | OBJ のような一部のファイルは外部ファイルに依存しており、検索パスにより Aspose.3D が外部ファイルを探してロードできるようになります。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileName() | エクスポート/インポートシーンのファイル名です。これはオプションですが、OBJ のマテリアルなど外部アセットをシリアライズする際に便利です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFileName(value) | エクスポート/インポートシーンのファイル名です。これはオプションですが、OBJ のマテリアルなど外部アセットをシリアライズする際に便利です。 |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/rvmsaveoptions/_index.md
+++ b/japanese/nodejs-java/aspose.threed/rvmsaveoptions/_index.md
@@ -1,0 +1,321 @@
+---
+title: "RvmSaveOptions"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/rvmsaveoptions/
+---
+## RvmSaveOptions class
+
+Aveva PDMS RVM ファイルの保存オプション。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | RvmSaveOptions のコンストラクタ |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload(contentType) | RvmSaveOptions のコンストラクタ |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| contentType | FileContentType | FileContentType |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileNote{#getFileNote}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileNote() | ファイルヘッダー内のファイルノート。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileNote{#setFileNote}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFileNote(value) | ファイルヘッダー内のファイルノート。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getAuthor{#getAuthor}
+
+| 名前 | 説明 |
+| --- | --- |
+| getAuthor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### setAuthor{#setAuthor}
+
+| 名前 | 説明 |
+| --- | --- |
+| setAuthor(value) |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getCreationTime{#getCreationTime}
+
+| 名前 | 説明 |
+| --- | --- |
+| getCreationTime() | このファイルをエクスポートしたタイムスタンプ。デフォルト値は現在時刻です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setCreationTime{#setCreationTime}
+
+| 名前 | 説明 |
+| --- | --- |
+| setCreationTime(value) | このファイルをエクスポートしたタイムスタンプ。デフォルト値は現在時刻です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getAttributePrefix{#getAttributePrefix}
+
+| 名前 | 説明 |
+| --- | --- |
+| getAttributePrefix() | エクスポートされる属性のプレフィックスを取得または設定します。エクスポートされたプロパティにはプレフィックスが含まれません。異なるプレフィックスを持つカスタムプロパティはエクスポートされません。デフォルト値は 'rvm:' です。例えば、プロパティが rvm:Refno=345 の場合、エクスポートされる属性は Refno = 345 となり、プレフィックスは除去されます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setAttributePrefix{#setAttributePrefix}
+
+| 名前 | 説明 |
+| --- | --- |
+| setAttributePrefix(value) | エクスポートされる属性のプレフィックスを取得または設定します。エクスポートされたプロパティにはプレフィックスが含まれません。異なるプレフィックスを持つカスタムプロパティはエクスポートされません。デフォルト値は 'rvm:' です。例えば、プロパティが rvm:Refno=345 の場合、エクスポートされる属性は Refno = 345 となり、プレフィックスは除去されます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getAttributeListFile{#getAttributeListFile}
+
+| 名前 | 説明 |
+| --- | --- |
+| getAttributeListFile() | 属性リストファイルのファイル名を取得または設定します。プロパティが未定義の場合、エクスポーターは .rvm ファイル名に基づいて名前を生成します。デフォルト値は null です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setAttributeListFile{#setAttributeListFile}
+
+| 名前 | 説明 |
+| --- | --- |
+| setAttributeListFile(value) | 属性リストファイルのファイル名を取得または設定します。プロパティが未定義の場合、エクスポーターは .rvm ファイル名に基づいて名前を生成します。デフォルト値は null です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportAttributes{#getExportAttributes}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExportAttributes() | 属性リストを外部の .att ファイルにエクスポートするかどうかを取得または設定します。デフォルト値は false です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportAttributes{#setExportAttributes}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExportAttributes(value) | 属性リストを外部の .att ファイルにエクスポートするかどうかを取得または設定します。デフォルト値は false です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportTextures{#getExportTextures}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExportTextures() | シーンで使用されているテクスチャを出力ディレクトリにコピーしようとします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextures{#setExportTextures}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExportTextures(value) | シーンで使用されているテクスチャを出力ディレクトリにコピーしようとします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileFormat() | 現在の保存/読み込みオプションで指定されたファイル形式を取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEncoding() | テキストベースのファイルのデフォルトエンコーディングを取得または設定します。デフォルト値は null で、インポーター/エクスポーターが使用するエンコーディングを決定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileSystem() | ロード/セーブ時に外部依存関係を管理する方法をユーザーが処理できるようにします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFileSystem(value) | ロード/セーブ時に外部依存関係を管理する方法をユーザーが処理できるようにします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| 名前 | 説明 |
+| --- | --- |
+| getLookupPaths() | OBJ のような一部のファイルは外部ファイルに依存しており、検索パスにより Aspose.3D が外部ファイルを探してロードできるようになります。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileName() | エクスポート/インポートシーンのファイル名です。これはオプションですが、OBJ のマテリアルなど外部アセットをシリアライズする際に便利です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFileName(value) | エクスポート/インポートシーンのファイル名です。これはオプションですが、OBJ のマテリアルなど外部アセットをシリアライズする際に便利です。 |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/saveoptions/_index.md
+++ b/japanese/nodejs-java/aspose.threed/saveoptions/_index.md
@@ -1,0 +1,133 @@
+---
+title: "SaveOptions"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/saveoptions/
+---
+## SaveOptions class
+
+さまざまなタイプのファイル保存オプションを構成するための基底クラス  @hideconstructor
+
+
+## メソッド
+
+### getExportTextures{#getExportTextures}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExportTextures() | シーンで使用されているテクスチャを出力ディレクトリにコピーしようとします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextures{#setExportTextures}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExportTextures(value) | シーンで使用されているテクスチャを出力ディレクトリにコピーしようとします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileFormat() | 現在の保存/読み込みオプションで指定されたファイル形式を取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEncoding() | テキストベースのファイルのデフォルトエンコーディングを取得または設定します。デフォルト値は null で、インポーター/エクスポーターが使用するエンコーディングを決定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileSystem() | ロード/セーブ時に外部依存関係を管理する方法をユーザーが処理できるようにします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFileSystem(value) | ロード/セーブ時に外部依存関係を管理する方法をユーザーが処理できるようにします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| 名前 | 説明 |
+| --- | --- |
+| getLookupPaths() | OBJ のような一部のファイルは外部ファイルに依存しており、検索パスにより Aspose.3D が外部ファイルを探してロードできるようになります。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileName() | エクスポート/インポートシーンのファイル名です。これはオプションですが、OBJ のマテリアルなど外部アセットをシリアライズする際に便利です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFileName(value) | エクスポート/インポートシーンのファイル名です。これはオプションですが、OBJ のマテリアルなど外部アセットをシリアライズする際に便利です。 |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/scene/_index.md
+++ b/japanese/nodejs-java/aspose.threed/scene/_index.md
@@ -1,0 +1,626 @@
+---
+title: "Scene"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/scene/
+---
+## Scene class
+
+シーンは、ノード、ジオメトリ、マテリアル、テクスチャ、アニメーション、ポーズ、サブシーンなどを含むトップレベルオブジェクトです。シーンはサブシーンを持つことができ、collada/blender/fbx などのファイルにおけるマルチドキュメントサポートとして機能します。ノード階層は RootNodeLibrary を通じてアクセスでき、シリアライズ中（メタデータやカスタムオブジェクトなど）に未接続オブジェクトへの参照を保持するために使用され、ライブラリとして利用できます。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | Scene クラスの新しいインスタンスを初期化します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload(entity) | 新しいノードにエンティティがアタッチされた状態で、Scene クラスの新しいインスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| エンティティ | エンティティ | シーンにアタッチされた初期エンティティ |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload2(parentScene, name) | Scene クラスの新しいインスタンスをサブシーンとして初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| parentScene | Scene | 親シーンです。 |
+| name | 文字列 | Scene の名前です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload3{#constructor_overload3}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload3(fileName) | Scene クラスの新しいインスタンスを初期化し、すぐにファイルを開きます。このコンストラクタは廃止されました。#Error Cref: M:Aspose.ThreeD.Scene.FromFile(System.String,System.Threading.CancellationToken) を使用してください。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| fileName | 文字列 | 開くファイルの名前です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getSubScenes{#getSubScenes}
+
+| 名前 | 説明 |
+| --- | --- |
+| getSubScenes() | すべてのサブシーンを取得します |
+
+ **Result:**
+
+
+
+---
+
+
+### getLibrary{#getLibrary}
+
+| 名前 | 説明 |
+| --- | --- |
+| getLibrary() | シーン階層で直接使用されないオブジェクトは Library に定義できます。サブシーンを使用し、再利用可能なコンポーネントをサブシーンの下に配置する場合に便利です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getAnimationClips{#getAnimationClips}
+
+| 名前 | 説明 |
+| --- | --- |
+| getAnimationClips() | シーンで定義されたすべての AnimationClip を取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getCurrentAnimationClip{#getCurrentAnimationClip}
+
+| 名前 | 説明 |
+| --- | --- |
+| getCurrentAnimationClip() | アクティブな AnimationClip を取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setCurrentAnimationClip{#setCurrentAnimationClip}
+
+| 名前 | 説明 |
+| --- | --- |
+| setCurrentAnimationClip(value) | アクティブな AnimationClip を取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getAssetInfo{#getAssetInfo}
+
+| 名前 | 説明 |
+| --- | --- |
+| getAssetInfo() | トップレベルのアセット情報であるドキュメント情報を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setAssetInfo{#setAssetInfo}
+
+| 名前 | 説明 |
+| --- | --- |
+| setAssetInfo(value) | トップレベルのアセット情報であるドキュメント情報を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getPoses{#getPoses}
+
+| 名前 | 説明 |
+| --- | --- |
+| getPoses() | このシーンで使用されているすべての Pose を取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getRootNode{#getRootNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getRootNode() | シーンのルートノードを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 名前 | 説明 |
+| --- | --- |
+| getScene() | このオブジェクトが属するシーンを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getAnimationClip{#getAnimationClip}
+
+| 名前 | 説明 |
+| --- | --- |
+| getAnimationClip(name) | 指定された名前の AnimationClip を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| name | 文字列 | その |
+
+ **Result:**
+AnimationClip
+
+
+---
+
+
+### clear{#clear}
+
+| 名前 | 説明 |
+| --- | --- |
+| clear() | シーンの内容をクリアし、デフォルト設定を復元します。 |
+
+ **Result:**
+AnimationClip
+
+
+---
+
+
+### createAnimationClip{#createAnimationClip}
+
+| 名前 | 説明 |
+| --- | --- |
+| createAnimationClip(name) | AnimationClip を作成し登録するための省略形関数です。最初の AnimationClip は CurrentAnimationClip に割り当てられます。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| name | 文字列 | Animation clip の名前 |
+
+ **Result:**
+AnimationClip
+
+
+---
+
+
+### open{#open}
+
+| 名前 | 説明 |
+| --- | --- |
+| open(fileName, options) | 指定されたファイル形式を使用して、指定されたパスからシーンを開きます。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| fileName | 文字列 | ファイル名。 |
+| オプション | LoadOptions | ストリームを開くための詳細な構成です。 |
+
+ **Result:**
+AnimationClip
+
+
+---
+
+
+### open{#open}
+
+| 名前 | 説明 |
+| --- | --- |
+| open(fileName) | 指定されたパスからシーンを開きます |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| fileName | 文字列 | ファイル名。 |
+
+ **Result:**
+AnimationClip
+
+
+---
+
+
+### fromFile{#fromFile}
+
+| 名前 | 説明 |
+| --- | --- |
+| fromFile(fileName) | 指定されたパスからシーンを開きます |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| fileName | 文字列 | ファイル名。 |
+
+ **Result:**
+AnimationClip
+
+
+---
+
+
+### save{#save}
+
+| 名前 | 説明 |
+| --- | --- |
+| save(fileName) | 指定されたファイル形式を使用して、指定されたパスにシーンを保存します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| fileName | 文字列 | ファイル名。 |
+
+ **Result:**
+AnimationClip
+
+
+---
+
+
+### save{#save}
+
+| 名前 | 説明 |
+| --- | --- |
+| save(fileName, format) | 指定されたファイル形式を使用して、指定されたパスにシーンを保存します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| fileName | 文字列 | ファイル名。 |
+| format | ファイル形式 | 形式。 |
+
+ **Result:**
+AnimationClip
+
+
+---
+
+
+### save{#save}
+
+| 名前 | 説明 |
+| --- | --- |
+| save(fileName, options) | 指定されたファイル形式を使用して、指定されたパスにシーンを保存します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| fileName | 文字列 | ファイル名。 |
+| オプション | SaveOptions | ストリームを保存するための詳細な構成です。 |
+
+ **Result:**
+AnimationClip
+
+
+---
+
+
+### render{#render}
+
+| 名前 | 説明 |
+| --- | --- |
+| render(camera, fileName) | 指定されたカメラの視点からシーンを外部ファイルにレンダリングします。デフォルトの出力サイズは 1024x768 で、出力形式は png です。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| カメラ | カメラ | シーンをレンダリングするカメラの視点を指定します |
+| fileName | 文字列 | 出力ファイルのファイル名 |
+
+ **Result:**
+AnimationClip
+
+
+---
+
+
+### render{#render}
+
+| 名前 | 説明 |
+| --- | --- |
+| render(camera, fileName, size, format) | 指定されたカメラの視点からシーンを外部ファイルにレンダリングします。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| カメラ | カメラ | シーンをレンダリングするカメラの視点を指定します |
+| fileName | 文字列 | 出力ファイルのファイル名 |
+| サイズ | Vector2 | 最終的にレンダリングされた画像のサイズ |
+| format | 文字列 | 出力ファイルの画像形式 |
+
+ **Result:**
+AnimationClip
+
+
+---
+
+
+### render{#render}
+
+| 名前 | 説明 |
+| --- | --- |
+| render(camera, fileName, size, format, options) | 指定されたカメラの視点からシーンを外部ファイルにレンダリングします。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| カメラ | カメラ | シーンをレンダリングするカメラの視点を指定します |
+| fileName | 文字列 | 出力ファイルのファイル名 |
+| サイズ | Vector2 | 最終的にレンダリングされた画像のサイズ |
+| format | 文字列 | 出力ファイルの画像形式 |
+| オプション | ImageRenderOptions | 内部設定のいくつかをカスタマイズするオプション。 |
+
+ **Result:**
+AnimationClip
+
+
+---
+
+
+### render{#render}
+
+| 名前 | 説明 |
+| --- | --- |
+| render(camera, bitmap) | 指定されたカメラの視点からシーンをビットマップにレンダリングします。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| カメラ | カメラ | シーンをレンダリングするカメラの視点を指定します |
+| ビットマップ | TextureData | レンダリング結果のターゲット |
+
+ **Result:**
+AnimationClip
+
+
+---
+
+
+### render{#render}
+
+| 名前 | 説明 |
+| --- | --- |
+| render(camera, bitmap, options) | 指定されたカメラの視点からシーンをビットマップにレンダリングします。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| カメラ | カメラ | シーンをレンダリングするカメラの視点を指定します |
+| ビットマップ | TextureData | レンダリング結果のターゲット |
+| オプション | ImageRenderOptions | 内部設定のいくつかをカスタマイズするオプション。 |
+
+ **Result:**
+AnimationClip
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/sceneobject/_index.md
+++ b/japanese/nodejs-java/aspose.threed/sceneobject/_index.md
@@ -1,0 +1,196 @@
+---
+title: "SceneObject"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/sceneobject/
+---
+## SceneObject class
+
+シーン内に格納されるオブジェクトのルートクラスです。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor(name) | デフォルト名で SceneObject を初期化します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| name | 文字列 | このインスタンスの名前 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload() | SceneObject を初期化します |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 名前 | 説明 |
+| --- | --- |
+| getScene() | このオブジェクトが属するシーンを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/shaderexception/_index.md
+++ b/japanese/nodejs-java/aspose.threed/shaderexception/_index.md
@@ -1,0 +1,35 @@
+---
+title: "ShaderException"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/shaderexception/
+---
+## ShaderException class
+
+シェーダー関連の例外
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor(message) | ShaderException のコンストラクタ |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| メッセージ | 文字列 | null |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/shadermaterial/_index.md
+++ b/japanese/nodejs-java/aspose.threed/shadermaterial/_index.md
@@ -1,0 +1,261 @@
+---
+title: "ShaderMaterial"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/shadermaterial/
+---
+## ShaderMaterial class
+
+シェーダーマテリアルは、外部のレンダリングエンジンまたはシェーダー言語でマテリアルを記述できるようにします。ShaderMaterial は ShaderTechnique を使用して具体的なレンダリング詳細を記述し、最終的なレンダリングプラットフォームに応じて最適なものが使用されます。例えば、ShaderMaterial インスタンスは 2 つのテクニックを持つことができ、1 つは HLSL で定義され、もう 1 つは GLSL で定義されます。ウィンドウ以外のプラットフォームでは、GLSL を使用すべきです。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | ShaderMaterial クラスの新しいインスタンスを初期化します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload(name) | ShaderMaterial クラスの新しいインスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| name | 文字列 | 名前 |
+
+ **Result:**
+
+
+
+---
+
+
+### getTechniques{#getTechniques}
+
+| 名前 | 説明 |
+| --- | --- |
+| getTechniques() | この素材で定義されている利用可能なすべての手法を取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getTexture{#getTexture}
+
+| 名前 | 説明 |
+| --- | --- |
+| getTexture(slotName) | 指定されたスロットからテクスチャを取得します。スロットはマテリアルのプロパティ名またはシェーダーのパラメータ名にすることができます。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| slotName | 文字列 | スロット名。 |
+
+ **Result:**
+TextureBase
+
+
+---
+
+
+### setTexture{#setTexture}
+
+| 名前 | 説明 |
+| --- | --- |
+| setTexture(slotName, texture) | テクスチャを指定されたスロットに設定します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| slotName | 文字列 | スロット名。 |
+| texture | TextureBase | テクスチャ。 |
+
+ **Result:**
+TextureBase
+
+
+---
+
+
+### toString{#toString}
+
+| 名前 | 説明 |
+| --- | --- |
+| toString() | オブジェクトを文字列にフォーマットします |
+
+ **Result:**
+文字列
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+### iterator{#iterator}
+
+| 名前 | 説明 |
+| --- | --- |
+| iterator() | 内部使用のために予約されています。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/shaderprogram/_index.md
+++ b/japanese/nodejs-java/aspose.threed/shaderprogram/_index.md
@@ -1,0 +1,13 @@
+---
+title: "ShaderProgram"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/shaderprogram/
+---
+## ShaderProgram class
+
+シェーダープログラム  @hideconstructor
+
+

--- a/japanese/nodejs-java/aspose.threed/shaderset/_index.md
+++ b/japanese/nodejs-java/aspose.threed/shaderset/_index.md
@@ -1,0 +1,133 @@
+---
+title: "ShaderSet"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/shaderset/
+---
+## ShaderSet class
+
+各種マテリアル用のシェーダープログラム
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | ShaderSet のインスタンスを構築します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getLambert{#getLambert}
+
+| 名前 | 説明 |
+| --- | --- |
+| getLambert() | Lambert マテリアルのレンダリングに使用されるシェーダーを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setLambert{#setLambert}
+
+| 名前 | 説明 |
+| --- | --- |
+| setLambert(value) | Lambert マテリアルのレンダリングに使用されるシェーダーを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getPhong{#getPhong}
+
+| 名前 | 説明 |
+| --- | --- |
+| getPhong() | phong マテリアルのレンダリングに使用されるシェーダーを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setPhong{#setPhong}
+
+| 名前 | 説明 |
+| --- | --- |
+| setPhong(value) | phong マテリアルのレンダリングに使用されるシェーダーを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getPbr{#getPbr}
+
+| 名前 | 説明 |
+| --- | --- |
+| getPbr() | PBR マテリアルのレンダリングに使用されるシェーダーを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setPbr{#setPbr}
+
+| 名前 | 説明 |
+| --- | --- |
+| setPbr(value) | PBR マテリアルのレンダリングに使用されるシェーダーを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getFallback{#getFallback}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFallback() | 必要なシェーダーが利用できない場合のフォールバックシェーダーを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setFallback{#setFallback}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFallback(value) | 必要なシェーダーが利用できない場合のフォールバックシェーダーを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/shadersource/_index.md
+++ b/japanese/nodejs-java/aspose.threed/shadersource/_index.md
@@ -1,0 +1,13 @@
+---
+title: "シェーダーソース"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/shadersource/
+---
+## ShaderSource class
+
+シェーダーのソースコード  @hideconstructor
+
+

--- a/japanese/nodejs-java/aspose.threed/shadertechnique/_index.md
+++ b/japanese/nodejs-java/aspose.threed/shadertechnique/_index.md
@@ -1,0 +1,270 @@
+---
+title: "ShaderTechnique"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/shadertechnique/
+---
+## ShaderTechnique class
+
+シェーダーテクニックは具体的なレンダリング実装を表します。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | ShaderTechnique クラスの新しいインスタンスを初期化します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getDescription{#getDescription}
+
+| 名前 | 説明 |
+| --- | --- |
+| getDescription() | このテクニックの説明を取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setDescription{#setDescription}
+
+| 名前 | 説明 |
+| --- | --- |
+| setDescription(value) | このテクニックの説明を取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getShaderLanguage{#getShaderLanguage}
+
+| 名前 | 説明 |
+| --- | --- |
+| getShaderLanguage() | このテクニックで使用されるシェーダー言語を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setShaderLanguage{#setShaderLanguage}
+
+| 名前 | 説明 |
+| --- | --- |
+| setShaderLanguage(value) | このテクニックで使用されるシェーダー言語を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getShaderVersion{#getShaderVersion}
+
+| 名前 | 説明 |
+| --- | --- |
+| getShaderVersion() | このテクニックで使用されるシェーダーバージョンを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setShaderVersion{#setShaderVersion}
+
+| 名前 | 説明 |
+| --- | --- |
+| setShaderVersion(value) | このテクニックで使用されるシェーダーバージョンを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getShaderFile{#getShaderFile}
+
+| 名前 | 説明 |
+| --- | --- |
+| getShaderFile() | 外部シェーダーファイルのファイル名を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setShaderFile{#setShaderFile}
+
+| 名前 | 説明 |
+| --- | --- |
+| setShaderFile(value) | 外部シェーダーファイルのファイル名を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getShaderContent{#getShaderContent}
+
+| 名前 | 説明 |
+| --- | --- |
+| getShaderContent() | 埋め込みシェーダースクリプトの内容を取得または設定します。HLSL/GLSL のシェーダーソースファイルである可能性があります。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setShaderContent{#setShaderContent}
+
+| 名前 | 説明 |
+| --- | --- |
+| setShaderContent(value) | 埋め込みシェーダースクリプトの内容を取得または設定します。HLSL/GLSL のシェーダーソースファイルである可能性があります。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getShaderEntry{#getShaderEntry}
+
+| 名前 | 説明 |
+| --- | --- |
+| getShaderEntry() | シェーダーのエントリーポイントを取得または設定します。HLSL のようなシェーダーはカスタマイズされたエントリを持つことができます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setShaderEntry{#setShaderEntry}
+
+| 名前 | 説明 |
+| --- | --- |
+| setShaderEntry(value) | シェーダーのエントリーポイントを取得または設定します。HLSL のようなシェーダーはカスタマイズされたエントリを持つことができます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getRenderAPI{#getRenderAPI}
+
+| 名前 | 説明 |
+| --- | --- |
+| getRenderAPI() | このテクニックで使用されるレンダリング API を取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setRenderAPI{#setRenderAPI}
+
+| 名前 | 説明 |
+| --- | --- |
+| setRenderAPI(value) | このテクニックで使用されるレンダリング API を取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getRenderAPIVersion{#getRenderAPIVersion}
+
+| 名前 | 説明 |
+| --- | --- |
+| getRenderAPIVersion() | レンダリング API のバージョンを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setRenderAPIVersion{#setRenderAPIVersion}
+
+| 名前 | 説明 |
+| --- | --- |
+| setRenderAPIVersion(value) | レンダリング API のバージョンを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getShaderParameters{#getShaderParameters}
+
+| 名前 | 説明 |
+| --- | --- |
+| getShaderParameters() | シェーダーパラメータの定義を取得します。キーは動的プロパティの名前で、値はそのプロパティが接続されているシェーダーパラメータ名です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### addBinding{#addBinding}
+
+| 名前 | 説明 |
+| --- | --- |
+| addBinding(property, shaderParameter) | 動的プロパティをシェーダーパラメータにバインドします。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | 動的プロパティの名前です。 |
+| shaderParameter | 文字列 | シェーダーパラメータの名前です。 |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/shadervariable/_index.md
+++ b/japanese/nodejs-java/aspose.threed/shadervariable/_index.md
@@ -1,0 +1,68 @@
+---
+title: "ShaderVariable"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/shadervariable/
+---
+## ShaderVariable class
+
+シェーダー変数
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor(name) | ShaderVariable のコンストラクタ |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | 文字列 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload(name, shaderStage) | ShaderVariable のコンストラクタ |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | 文字列 | null |
+| shaderStage | 数 | ShaderStage |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | この変数の名前を取得します |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/shape/_index.md
+++ b/japanese/nodejs-java/aspose.threed/shape/_index.md
@@ -1,0 +1,573 @@
+---
+title: "シェイプ"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/shape/
+---
+## Shape class
+
+シェイプは制御点の集合に対する変形を記述し、Maya のクラスターデフォーマーに似ています。例えば、作成したジオメトリにシェイプを追加できます。シェイプとジオメトリは同じトポロジ情報を持ちますが、制御点の位置が異なります。影響度の違いにより、ジオメトリは変形効果を実行します。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | Shape クラスの新しいインスタンスを初期化します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload(name) | Shape クラスの新しいインスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| name | 文字列 | 名前 |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| 名前 | 説明 |
+| --- | --- |
+| getIndices() | インデックスを取得します。インデックス。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getVisible{#getVisible}
+
+| 名前 | 説明 |
+| --- | --- |
+| getVisible() | ジオメトリが表示されているかどうかを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setVisible{#setVisible}
+
+| 名前 | 説明 |
+| --- | --- |
+| setVisible(value) | ジオメトリが表示されているかどうかを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getDeformers{#getDeformers}
+
+| 名前 | 説明 |
+| --- | --- |
+| getDeformers() | このジオメトリに関連付けられたすべてのデフォーマーを取得します。デフォーマー。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getControlPoints{#getControlPoints}
+
+| 名前 | 説明 |
+| --- | --- |
+| getControlPoints() | すべての制御点を取得します |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastShadows{#getCastShadows}
+
+| 名前 | 説明 |
+| --- | --- |
+| getCastShadows() | このジオメトリが影を落とすかどうかを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastShadows{#setCastShadows}
+
+| 名前 | 説明 |
+| --- | --- |
+| setCastShadows(value) | このジオメトリが影を落とすかどうかを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getReceiveShadows{#getReceiveShadows}
+
+| 名前 | 説明 |
+| --- | --- |
+| getReceiveShadows() | このジオメトリが影を受け取るかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setReceiveShadows{#setReceiveShadows}
+
+| 名前 | 説明 |
+| --- | --- |
+| setReceiveShadows(value) | このジオメトリが影を受け取るかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElements{#getVertexElements}
+
+| 名前 | 説明 |
+| --- | --- |
+| getVertexElements() | すべての頂点要素を取得します |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNodes() | すべての親ノードを取得します。エンティティはジオメトリインスタンシングのために複数の親ノードにアタッチできます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExcluded() | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExcluded(value) | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNode() | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setParentNode(value) | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 名前 | 説明 |
+| --- | --- |
+| getScene() | このオブジェクトが属するシーンを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### fromControlPoints{#fromControlPoints}
+
+| 名前 | 説明 |
+| --- | --- |
+| fromControlPoints(controlPoints) | 指定された制御点とデフォルトのインデックスでシェイプを作成します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| controlPoint | Vector3[] | null |
+
+ **Result:**
+シェイプ
+
+
+---
+
+
+### getElement{#getElement}
+
+| 名前 | 説明 |
+| --- | --- |
+| getElement(type) | 指定されたタイプの頂点要素を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| type | VertexElementType | VertexElementType |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### getVertexElementOfUV{#getVertexElementOfUV}
+
+| 名前 | 説明 |
+| --- | --- |
+| getVertexElementOfUV(textureMapping) | 指定されたテクスチャマッピングタイプの VertexElementUV インスタンスを取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| textureMapping | TextureMapping | TextureMapping |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### createElement{#createElement}
+
+| 名前 | 説明 |
+| --- | --- |
+| createElement(type) | 指定されたタイプの頂点要素を作成し、ジオメトリに追加します。type が VertexElementType.UV の場合、テクスチャマッピングタイプが TextureMapping.DIFFUSE の VertexElementUV が作成されます。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| type | VertexElementType | VertexElementType |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### addElement{#addElement}
+
+| 名前 | 説明 |
+| --- | --- |
+| addElement(element) | 既存の頂点要素を現在のジオメトリに追加します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| element | VertexElement | 追加する頂点要素 |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### createElement{#createElement}
+
+| 名前 | 説明 |
+| --- | --- |
+| createElement(type, mappingMode, referenceMode) | 指定されたタイプの頂点要素を作成し、ジオメトリに追加します。type が VertexElementType.UV の場合、テクスチャマッピングタイプが TextureMapping.DIFFUSE の VertexElementUV が作成されます。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| type | VertexElementType | VertexElementType |
+| mappingMode | MappingMode | MappingMode |
+| referenceMode | ReferenceMode | ReferenceMode |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### createElementUV{#createElementUV}
+
+| 名前 | 説明 |
+| --- | --- |
+| createElementUV(uvMapping) | 指定されたテクスチャマッピングタイプで VertexElementUV を作成します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| uvMapping | TextureMapping | TextureMapping |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### createElementUV{#createElementUV}
+
+| 名前 | 説明 |
+| --- | --- |
+| createElementUV(uvMapping, mappingMode, referenceMode) | 指定されたテクスチャマッピングタイプで VertexElementUV を作成します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| uvMapping | TextureMapping | TextureMapping |
+| mappingMode | MappingMode | MappingMode |
+| referenceMode | ReferenceMode | ReferenceMode |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBoundingBox() | 現在のエンティティのオブジェクト空間座標系におけるバウンディングボックスを取得します。 |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEntityRendererKey() | レンダラーに登録されたエンティティレンダラーのキーを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/skeleton/_index.md
+++ b/japanese/nodejs-java/aspose.threed/skeleton/_index.md
@@ -1,0 +1,339 @@
+---
+title: "スケルトン"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/skeleton/
+---
+## Skeleton class
+
+Skeletonは主にCADソフトウェアで使用され、設計者が骨格構造の変換を操作できるようにしますが、CADソフトウェア外では通常役に立ちません。Skeleton階層をCADソフトウェア内で1つのオブジェクトとして機能させるには、上位SkeletonノードをTypeをSkeletonType.SKELETONに設定してルートとしてマークし、すべての子ノードをSkeletonType.BONEに設定する必要があります。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | Skeleton クラスの新しいインスタンスを初期化します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload(name) | Skeleton クラスの新しいインスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| name | 文字列 | 名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getSize{#getSize}
+
+| 名前 | 説明 |
+| --- | --- |
+| getSize() | 骨のサイズを表すために CAD ソフトウェアで使用されるリムノードサイズを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setSize{#setSize}
+
+| 名前 | 説明 |
+| --- | --- |
+| setSize(value) | 骨のサイズを表すために CAD ソフトウェアで使用されるリムノードサイズを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getType{#getType}
+
+| 名前 | 説明 |
+| --- | --- |
+| getType() | スケルトンのタイプを取得または設定します。プロパティの値は SkeletonType の整数定数です。スケルトンのタイプです。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setType{#setType}
+
+| 名前 | 説明 |
+| --- | --- |
+| setType(value) | スケルトンのタイプを取得または設定します。プロパティの値は SkeletonType の整数定数です。スケルトンのタイプです。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNodes() | すべての親ノードを取得します。エンティティはジオメトリインスタンシングのために複数の親ノードにアタッチできます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExcluded() | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExcluded(value) | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNode() | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setParentNode(value) | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 名前 | 説明 |
+| --- | --- |
+| getScene() | このオブジェクトが属するシーンを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBoundingBox() | 現在のエンティティのオブジェクト空間座標系におけるバウンディングボックスを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEntityRendererKey() | レンダラーに登録されたエンティティレンダラーのキーを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/skindeformer/_index.md
+++ b/japanese/nodejs-java/aspose.threed/skindeformer/_index.md
@@ -1,0 +1,209 @@
+---
+title: "SkinDeformer"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/skindeformer/
+---
+## SkinDeformer class
+
+スキンデフォーマーは複数のボーンを含み、各ボーンはコントロールポイントのウェイトによってジオメトリの一部をブレンドします。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor(name) | SkinDeformer クラスの新しいインスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| name | 文字列 | 名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload() | SkinDeformer クラスの新しいインスタンスを初期化します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getBones{#getBones}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBones() | skin deformer が含むすべてのボーンを取得します |
+
+ **Result:**
+
+
+
+---
+
+
+### getOwner{#getOwner}
+
+| 名前 | 説明 |
+| --- | --- |
+| getOwner() | このデフォーマーを所有するジオメトリを取得します |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/sphere/_index.md
+++ b/japanese/nodejs-java/aspose.threed/sphere/_index.md
@@ -1,0 +1,581 @@
+---
+title: "Sphere"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/sphere/
+---
+## Sphere class
+
+パラメータ化された球体。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | デフォルト半径 1 の Sphere の新しいインスタンスを初期化します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload(radius) | 指定された半径で Sphere クラスの新しいインスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| 半径 | 数 | 半径。 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload2(radius, widthSegments, heightSegments) | 指定された半径、幅セグメント、そして高さセグメントで Sphere クラスの新しいインスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| 半径 | 数 | 球体の半径。 |
+| widthSegments | 数 | 幅のセグメント。 |
+| heightSegments | 数 | 高さセグメント。 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload3{#constructor_overload3}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload3(name, radius, widthSegments, heightSegments, phiStart, phiLength, thetaStart, thetaLength) | Sphere クラスの新しいインスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| name | 文字列 | 名前。 |
+| 半径 | 数 | 球体の半径。 |
+| widthSegments | 数 | 幅のセグメント。 |
+| heightSegments | 数 | 高さセグメント。 |
+| phiStart | 数 | Phi の開始。 |
+| phiLength | 数 | Phi の長さ。 |
+| thetaStart | 数 | Theta の開始。 |
+| thetaLength | 数 | Theta の長さ。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getWidthSegments{#getWidthSegments}
+
+| 名前 | 説明 |
+| --- | --- |
+| getWidthSegments() | 幅のセグメントを取得または設定します。幅のセグメント。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setWidthSegments{#setWidthSegments}
+
+| 名前 | 説明 |
+| --- | --- |
+| setWidthSegments(value) | 幅のセグメントを取得または設定します。幅のセグメント。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getHeightSegments{#getHeightSegments}
+
+| 名前 | 説明 |
+| --- | --- |
+| getHeightSegments() | 高さセグメントを取得または設定します。高さセグメント。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setHeightSegments{#setHeightSegments}
+
+| 名前 | 説明 |
+| --- | --- |
+| setHeightSegments(value) | 高さセグメントを取得または設定します。高さセグメント。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getPhiStart{#getPhiStart}
+
+| 名前 | 説明 |
+| --- | --- |
+| getPhiStart() | phi の開始位置を取得または設定します。phi の開始位置。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setPhiStart{#setPhiStart}
+
+| 名前 | 説明 |
+| --- | --- |
+| setPhiStart(value) | phi の開始位置を取得または設定します。phi の開始位置。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getPhiLength{#getPhiLength}
+
+| 名前 | 説明 |
+| --- | --- |
+| getPhiLength() | phi の長さを取得または設定します。phi の長さ。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setPhiLength{#setPhiLength}
+
+| 名前 | 説明 |
+| --- | --- |
+| setPhiLength(value) | phi の長さを取得または設定します。phi の長さ。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getThetaStart{#getThetaStart}
+
+| 名前 | 説明 |
+| --- | --- |
+| getThetaStart() | theta の開始位置を取得または設定します。theta の開始位置。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setThetaStart{#setThetaStart}
+
+| 名前 | 説明 |
+| --- | --- |
+| setThetaStart(value) | theta の開始位置を取得または設定します。theta の開始位置。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getThetaLength{#getThetaLength}
+
+| 名前 | 説明 |
+| --- | --- |
+| getThetaLength() | theta の長さを取得または設定します。theta の長さ。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setThetaLength{#setThetaLength}
+
+| 名前 | 説明 |
+| --- | --- |
+| setThetaLength(value) | theta の長さを取得または設定します。theta の長さ。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getRadius{#getRadius}
+
+| 名前 | 説明 |
+| --- | --- |
+| getRadius() | 球体の半径を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setRadius{#setRadius}
+
+| 名前 | 説明 |
+| --- | --- |
+| setRadius(value) | 球体の半径を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastShadows{#getCastShadows}
+
+| 名前 | 説明 |
+| --- | --- |
+| getCastShadows() | このジオメトリが影を落とすかどうかを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastShadows{#setCastShadows}
+
+| 名前 | 説明 |
+| --- | --- |
+| setCastShadows(value) | このジオメトリが影を落とすかどうかを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getReceiveShadows{#getReceiveShadows}
+
+| 名前 | 説明 |
+| --- | --- |
+| getReceiveShadows() | このジオメトリが影を受け取るかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setReceiveShadows{#setReceiveShadows}
+
+| 名前 | 説明 |
+| --- | --- |
+| setReceiveShadows(value) | このジオメトリが影を受け取るかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNodes() | すべての親ノードを取得します。エンティティはジオメトリインスタンシングのために複数の親ノードにアタッチできます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExcluded() | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExcluded(value) | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNode() | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setParentNode(value) | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 名前 | 説明 |
+| --- | --- |
+| getScene() | このオブジェクトが属するシーンを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### toMesh{#toMesh}
+
+| 名前 | 説明 |
+| --- | --- |
+| toMesh() | 現在のオブジェクトをメッシュに変換します |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBoundingBox() | 現在のエンティティのオブジェクト空間座標系におけるバウンディングボックスを取得します。 |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEntityRendererKey() | レンダラーに登録されたエンティティレンダラーのキーを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/spirvsource/_index.md
+++ b/japanese/nodejs-java/aspose.threed/spirvsource/_index.md
@@ -1,0 +1,159 @@
+---
+title: "SPIRVSource"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/spirvsource/
+---
+## SPIRVSource class
+
+SPIR-V形式のコンパイル済みシェーダー。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | SPIR-V ベースのシェーダーソースのコンストラクタです。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getMaximumDescriptorSets{#getMaximumDescriptorSets}
+
+| 名前 | 説明 |
+| --- | --- |
+| getMaximumDescriptorSets() | 最大ディスクリプタセット数、デフォルト値は 10 です |
+
+ **Result:**
+
+
+
+---
+
+
+### setMaximumDescriptorSets{#setMaximumDescriptorSets}
+
+| 名前 | 説明 |
+| --- | --- |
+| setMaximumDescriptorSets(value) | 最大ディスクリプタセット数、デフォルト値は 10 です |
+
+ **Result:**
+
+
+
+---
+
+
+### getComputeShader{#getComputeShader}
+
+| 名前 | 説明 |
+| --- | --- |
+| getComputeShader() | コンピュートシェーダーのソースコードを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setComputeShader{#setComputeShader}
+
+| 名前 | 説明 |
+| --- | --- |
+| setComputeShader(value) | コンピュートシェーダーのソースコードを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getGeometryShader{#getGeometryShader}
+
+| 名前 | 説明 |
+| --- | --- |
+| getGeometryShader() | ジオメトリシェーダーのソースコードを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setGeometryShader{#setGeometryShader}
+
+| 名前 | 説明 |
+| --- | --- |
+| setGeometryShader(value) | ジオメトリシェーダーのソースコードを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexShader{#getVertexShader}
+
+| 名前 | 説明 |
+| --- | --- |
+| getVertexShader() | 頂点シェーダーのソースコードを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setVertexShader{#setVertexShader}
+
+| 名前 | 説明 |
+| --- | --- |
+| setVertexShader(value) | 頂点シェーダーのソースコードを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getFragmentShader{#getFragmentShader}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFragmentShader() | フラグメントシェーダーのソースコードを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFragmentShader{#setFragmentShader}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFragmentShader(value) | フラグメントシェーダーのソースコードを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/stencilstate/_index.md
+++ b/japanese/nodejs-java/aspose.threed/stencilstate/_index.md
@@ -1,0 +1,152 @@
+---
+title: "StencilState"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/stencilstate/
+---
+## StencilState class
+
+面ごとのステンシルステート。  @hideconstructor
+
+
+## メソッド
+
+### getCompare{#getCompare}
+
+| 名前 | 説明 |
+| --- | --- |
+| getCompare() | ステンシルテストで使用される比較関数を取得または設定します。プロパティの値は CompareFunction 整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setCompare{#setCompare}
+
+| 名前 | 説明 |
+| --- | --- |
+| setCompare(value) | ステンシルテストで使用される比較関数を取得または設定します。プロパティの値は CompareFunction 整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFailAction{#getFailAction}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFailAction() | ステンシルテストが失敗したときのステンシルアクションを取得または設定します。プロパティの値は StencilAction の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFailAction{#setFailAction}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFailAction(value) | ステンシルテストが失敗したときのステンシルアクションを取得または設定します。プロパティの値は StencilAction の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getDepthFailAction{#getDepthFailAction}
+
+| 名前 | 説明 |
+| --- | --- |
+| getDepthFailAction() | ステンシルテストが合格し、深度テストが失敗したときのステンシルアクションを取得または設定します。プロパティの値は StencilAction の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setDepthFailAction{#setDepthFailAction}
+
+| 名前 | 説明 |
+| --- | --- |
+| setDepthFailAction(value) | ステンシルテストが合格し、深度テストが失敗したときのステンシルアクションを取得または設定します。プロパティの値は StencilAction の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getPassAction{#getPassAction}
+
+| 名前 | 説明 |
+| --- | --- |
+| getPassAction() | ステンシルテストと深度テストの両方が合格したときのステンシルアクションを取得または設定します。プロパティの値は StencilAction の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setPassAction{#setPassAction}
+
+| 名前 | 説明 |
+| --- | --- |
+| setPassAction(value) | ステンシルテストと深度テストの両方が合格したときのステンシルアクションを取得または設定します。プロパティの値は StencilAction の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### equals{#equals}
+
+| 名前 | 説明 |
+| --- | --- |
+| equals(obj) | このインスタンスが指定されたオブジェクトと等しいかどうかを示す値を返します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| ob | オブジェクト | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### hashCode{#hashCode}
+
+| 名前 | 説明 |
+| --- | --- |
+| hashCode() | このインスタンスのハッシュコードを返します。 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/stlloadoptions/_index.md
+++ b/japanese/nodejs-java/aspose.threed/stlloadoptions/_index.md
@@ -1,0 +1,191 @@
+---
+title: "StlLoadOptions"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/stlloadoptions/
+---
+## StlLoadOptions class
+
+STLのロードオプション
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | 新しい StlLoadOptions インスタンスを初期化します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload(contentType) | 新しい StlLoadOptions インスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| contentType | FileContentType | FileContentType |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlipCoordinateSystem{#getFlipCoordinateSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFlipCoordinateSystem() | インポート時に制御点/法線の座標系を反転させるかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlipCoordinateSystem{#setFlipCoordinateSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFlipCoordinateSystem(value) | インポート時に制御点/法線の座標系を反転させるかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getRecalculateNormal{#getRecalculateNormal}
+
+| 名前 | 説明 |
+| --- | --- |
+| getRecalculateNormal() | STL ファイルに保存されている法線データを無視し、頂点位置に基づいて法線データを再計算します。デフォルト値は false です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setRecalculateNormal{#setRecalculateNormal}
+
+| 名前 | 説明 |
+| --- | --- |
+| setRecalculateNormal(value) | STL ファイルに保存されている法線データを無視し、頂点位置に基づいて法線データを再計算します。デフォルト値は false です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileFormat() | 現在の保存/読み込みオプションで指定されたファイル形式を取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEncoding() | テキストベースのファイルのデフォルトエンコーディングを取得または設定します。デフォルト値は null で、インポーター/エクスポーターが使用するエンコーディングを決定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileSystem() | ロード/セーブ時に外部依存関係を管理する方法をユーザーが処理できるようにします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFileSystem(value) | ロード/セーブ時に外部依存関係を管理する方法をユーザーが処理できるようにします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| 名前 | 説明 |
+| --- | --- |
+| getLookupPaths() | OBJ のような一部のファイルは外部ファイルに依存しており、検索パスにより Aspose.3D が外部ファイルを探してロードできるようになります。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileName() | エクスポート/インポートシーンのファイル名です。これはオプションですが、OBJ のマテリアルなど外部アセットをシリアライズする際に便利です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFileName(value) | エクスポート/インポートシーンのファイル名です。これはオプションですが、OBJ のマテリアルなど外部アセットをシリアライズする際に便利です。 |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/stlsaveoptions/_index.md
+++ b/japanese/nodejs-java/aspose.threed/stlsaveoptions/_index.md
@@ -1,0 +1,191 @@
+---
+title: "StlSaveOptions"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/stlsaveoptions/
+---
+## StlSaveOptions class
+
+STLの保存オプション
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | 新しい StlSaveOptions インスタンスを初期化します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload(contentType) | 新しい StlSaveOptions インスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| contentType | FileContentType | FileContentType |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlipCoordinateSystem{#getFlipCoordinateSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFlipCoordinateSystem() | エクスポート時に制御点/法線の座標系を反転するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlipCoordinateSystem{#setFlipCoordinateSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFlipCoordinateSystem(value) | エクスポート時に制御点/法線の座標系を反転するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportTextures{#getExportTextures}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExportTextures() | シーンで使用されているテクスチャを出力ディレクトリにコピーしようとします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextures{#setExportTextures}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExportTextures(value) | シーンで使用されているテクスチャを出力ディレクトリにコピーしようとします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileFormat() | 現在の保存/読み込みオプションで指定されたファイル形式を取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEncoding() | テキストベースのファイルのデフォルトエンコーディングを取得または設定します。デフォルト値は null で、インポーター/エクスポーターが使用するエンコーディングを決定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileSystem() | ロード/セーブ時に外部依存関係を管理する方法をユーザーが処理できるようにします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFileSystem(value) | ロード/セーブ時に外部依存関係を管理する方法をユーザーが処理できるようにします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| 名前 | 説明 |
+| --- | --- |
+| getLookupPaths() | OBJ のような一部のファイルは外部ファイルに依存しており、検索パスにより Aspose.3D が外部ファイルを探してロードできるようになります。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileName() | エクスポート/インポートシーンのファイル名です。これはオプションですが、OBJ のマテリアルなど外部アセットをシリアライズする際に便利です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFileName(value) | エクスポート/インポートシーンのファイル名です。これはオプションですが、OBJ のマテリアルなど外部アセットをシリアライズする際に便利です。 |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/sweptareasolid/_index.md
+++ b/japanese/nodejs-java/aspose.threed/sweptareasolid/_index.md
@@ -1,0 +1,385 @@
+---
+title: "SweptAreaSolid"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/sweptareasolid/
+---
+## SweptAreaSolid class
+
+SweptAreaSolidはプロファイルを導軌に沿って掃引することでジオメトリを構築します。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getShape{#getShape}
+
+| 名前 | 説明 |
+| --- | --- |
+| getShape() | ジオメトリを構築するためのベースプロファイルです。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setShape{#setShape}
+
+| 名前 | 説明 |
+| --- | --- |
+| setShape(value) | ジオメトリを構築するためのベースプロファイルです。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getDirectrix{#getDirectrix}
+
+| 名前 | 説明 |
+| --- | --- |
+| getDirectrix() | 掃掘領域が沿って移動する導線です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setDirectrix{#setDirectrix}
+
+| 名前 | 説明 |
+| --- | --- |
+| setDirectrix(value) | 掃掘領域が沿って移動する導線です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getStartPoint{#getStartPoint}
+
+| 名前 | 説明 |
+| --- | --- |
+| getStartPoint() | 直接線の開始点。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setStartPoint{#setStartPoint}
+
+| 名前 | 説明 |
+| --- | --- |
+| setStartPoint(value) | 直接線の開始点。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEndPoint{#getEndPoint}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEndPoint() | 直接線の終点。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setEndPoint{#setEndPoint}
+
+| 名前 | 説明 |
+| --- | --- |
+| setEndPoint(value) | 直接線の終点。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNodes() | すべての親ノードを取得します。エンティティはジオメトリインスタンシングのために複数の親ノードにアタッチできます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExcluded() | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExcluded(value) | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNode() | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setParentNode(value) | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 名前 | 説明 |
+| --- | --- |
+| getScene() | このオブジェクトが属するシーンを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### toMesh{#toMesh}
+
+| 名前 | 説明 |
+| --- | --- |
+| toMesh() | 現在のオブジェクトをメッシュに変換します |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBoundingBox() | 現在のエンティティのオブジェクト空間座標系におけるバウンディングボックスを取得します。 |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEntityRendererKey() | レンダラーに登録されたエンティティレンダラーのキーを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/text/_index.md
+++ b/japanese/nodejs-java/aspose.threed/text/_index.md
@@ -1,0 +1,346 @@
+---
+title: "テキスト"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/text/
+---
+## Text class
+
+テキストプロファイル。このプロファイルはフォントとテキストを使用して輪郭を記述します。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getContent{#getContent}
+
+| 名前 | 説明 |
+| --- | --- |
+| getContent() | テキストの内容 |
+
+ **Result:**
+
+
+
+---
+
+
+### setContent{#setContent}
+
+| 名前 | 説明 |
+| --- | --- |
+| setContent(value) | テキストの内容 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFont{#getFont}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFont() | テキストのフォント。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFont{#setFont}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFont(value) | テキストのフォント。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFontSize{#getFontSize}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFontSize() | フォントサイズのスケール。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFontSize{#setFontSize}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFontSize(value) | フォントサイズのスケール。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNodes() | すべての親ノードを取得します。エンティティはジオメトリインスタンシングのために複数の親ノードにアタッチできます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExcluded() | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExcluded(value) | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNode() | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setParentNode(value) | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 名前 | 説明 |
+| --- | --- |
+| getScene() | このオブジェクトが属するシーンを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEntityRendererKey() | レンダラーに登録されたエンティティレンダラーのキーを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBoundingBox() | 現在のエンティティのオブジェクト空間座標系におけるバウンディングボックスを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/texture/_index.md
+++ b/japanese/nodejs-java/aspose.threed/texture/_index.md
@@ -1,0 +1,607 @@
+---
+title: "Texture"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/texture/
+---
+## Texture class
+
+このクラスは外部ファイルからテクスチャを定義します。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | Texture クラスの新しいインスタンスを初期化します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload(name) | Texture クラスの新しいインスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| name | 文字列 | 名前 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEnableMipMap{#getEnableMipMap}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEnableMipMap() | このテクスチャでミップマップが有効かどうかを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setEnableMipMap{#setEnableMipMap}
+
+| 名前 | 説明 |
+| --- | --- |
+| setEnableMipMap(value) | このテクスチャでミップマップが有効かどうかを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getContent{#getContent}
+
+| 名前 | 説明 |
+| --- | --- |
+| getContent() | テクスチャのバイナリコンテンツを取得または設定します。埋め込みテクスチャコンテンツはオプションであり、欠如している場合は外部ファイルからテクスチャをロードする必要があります。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setContent{#setContent}
+
+| 名前 | 説明 |
+| --- | --- |
+| setContent(value) | テクスチャのバイナリコンテンツを取得または設定します。埋め込みテクスチャコンテンツはオプションであり、欠如している場合は外部ファイルからテクスチャをロードする必要があります。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileName() | 関連付けられたテクスチャファイルを取得または設定します。ファイル名です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFileName(value) | 関連付けられたテクスチャファイルを取得または設定します。ファイル名です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getAlpha{#getAlpha}
+
+| 名前 | 説明 |
+| --- | --- |
+| getAlpha() | テクスチャのデフォルトアルファ値を取得または設定します。これは AlphaSource が AlphaSource.PIXEL_ALPHA のときに有効です。デフォルト値は 1.0 で、有効な範囲は 0 から 1 です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setAlpha{#setAlpha}
+
+| 名前 | 説明 |
+| --- | --- |
+| setAlpha(value) | テクスチャのデフォルトアルファ値を取得または設定します。これは AlphaSource が AlphaSource.PIXEL_ALPHA のときに有効です。デフォルト値は 1.0 で、有効な範囲は 0 から 1 です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getAlphaSource{#getAlphaSource}
+
+| 名前 | 説明 |
+| --- | --- |
+| getAlphaSource() | テクスチャがアルファチャンネルを定義するかどうかを取得または設定します。デフォルト値は AlphaSource.NONE です。このプロパティの値は AlphaSource の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setAlphaSource{#setAlphaSource}
+
+| 名前 | 説明 |
+| --- | --- |
+| setAlphaSource(value) | テクスチャがアルファチャンネルを定義するかどうかを取得または設定します。デフォルト値は AlphaSource.NONE です。このプロパティの値は AlphaSource の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getWrapModeU{#getWrapModeU}
+
+| 名前 | 説明 |
+| --- | --- |
+| getWrapModeU() | U 方向のテクスチャラップモードを取得または設定します。このプロパティの値は WrapMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setWrapModeU{#setWrapModeU}
+
+| 名前 | 説明 |
+| --- | --- |
+| setWrapModeU(value) | U 方向のテクスチャラップモードを取得または設定します。このプロパティの値は WrapMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getWrapModeV{#getWrapModeV}
+
+| 名前 | 説明 |
+| --- | --- |
+| getWrapModeV() | V 方向のテクスチャラップモードを取得または設定します。このプロパティの値は WrapMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setWrapModeV{#setWrapModeV}
+
+| 名前 | 説明 |
+| --- | --- |
+| setWrapModeV(value) | V 方向のテクスチャラップモードを取得または設定します。このプロパティの値は WrapMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getWrapModeW{#getWrapModeW}
+
+| 名前 | 説明 |
+| --- | --- |
+| getWrapModeW() | W 方向のテクスチャラップモードを取得または設定します。このプロパティの値は WrapMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setWrapModeW{#setWrapModeW}
+
+| 名前 | 説明 |
+| --- | --- |
+| setWrapModeW(value) | W 方向のテクスチャラップモードを取得または設定します。このプロパティの値は WrapMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getMinFilter{#getMinFilter}
+
+| 名前 | 説明 |
+| --- | --- |
+| getMinFilter() | 縮小時のフィルタを取得または設定します。このプロパティの値は TextureFilter の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setMinFilter{#setMinFilter}
+
+| 名前 | 説明 |
+| --- | --- |
+| setMinFilter(value) | 縮小時のフィルタを取得または設定します。このプロパティの値は TextureFilter の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getMagFilter{#getMagFilter}
+
+| 名前 | 説明 |
+| --- | --- |
+| getMagFilter() | 拡大用のフィルタを取得または設定します。プロパティの値は TextureFilter の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setMagFilter{#setMagFilter}
+
+| 名前 | 説明 |
+| --- | --- |
+| setMagFilter(value) | 拡大用のフィルタを取得または設定します。プロパティの値は TextureFilter の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getMipFilter{#getMipFilter}
+
+| 名前 | 説明 |
+| --- | --- |
+| getMipFilter() | ミップレベルサンプリング用のフィルタを取得または設定します。プロパティの値は TextureFilter の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setMipFilter{#setMipFilter}
+
+| 名前 | 説明 |
+| --- | --- |
+| setMipFilter(value) | ミップレベルサンプリング用のフィルタを取得または設定します。プロパティの値は TextureFilter の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getUVRotation{#getUVRotation}
+
+| 名前 | 説明 |
+| --- | --- |
+| getUVRotation() | テクスチャの回転を取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setUVRotation{#setUVRotation}
+
+| 名前 | 説明 |
+| --- | --- |
+| setUVRotation(value) | テクスチャの回転を取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getUVScale{#getUVScale}
+
+| 名前 | 説明 |
+| --- | --- |
+| getUVScale() | UV スケールを取得または設定します。UV スケールです。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setUVScale{#setUVScale}
+
+| 名前 | 説明 |
+| --- | --- |
+| setUVScale(value) | UV スケールを取得または設定します。UV スケールです。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getUVTranslation{#getUVTranslation}
+
+| 名前 | 説明 |
+| --- | --- |
+| getUVTranslation() | UV 平行移動を取得または設定します。UV 平行移動です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setUVTranslation{#setUVTranslation}
+
+| 名前 | 説明 |
+| --- | --- |
+| setUVTranslation(value) | UV 平行移動を取得または設定します。UV 平行移動です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setTranslation{#setTranslation}
+
+| 名前 | 説明 |
+| --- | --- |
+| setTranslation(u, v) | UV 平行移動を設定します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| u | 数 | U. |
+| v | 数 | V. |
+
+ **Result:**
+
+
+
+---
+
+
+### setScale{#setScale}
+
+| 名前 | 説明 |
+| --- | --- |
+| setScale(u, v) | UV スケールを設定します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| u | 数 | U. |
+| v | 数 | V. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRotation{#setRotation}
+
+| 名前 | 説明 |
+| --- | --- |
+| setRotation(u, v) | UV 回転を設定します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| u | 数 | U. |
+| v | 数 | V. |
+
+ **Result:**
+
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/texturebase/_index.md
+++ b/japanese/nodejs-java/aspose.threed/texturebase/_index.md
@@ -1,0 +1,516 @@
+---
+title: "TextureBase"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/texturebase/
+---
+## TextureBase class
+
+すべての具体的なテクスチャの基底クラス。Textureはジオメトリ表面の外観と質感を定義します。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor(name) | TextureBase クラスの新しいインスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| name | 文字列 | 名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getAlpha{#getAlpha}
+
+| 名前 | 説明 |
+| --- | --- |
+| getAlpha() | テクスチャのデフォルトアルファ値を取得または設定します。これは AlphaSource が AlphaSource.PIXEL_ALPHA のときに有効です。デフォルト値は 1.0 で、有効な範囲は 0 から 1 です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setAlpha{#setAlpha}
+
+| 名前 | 説明 |
+| --- | --- |
+| setAlpha(value) | テクスチャのデフォルトアルファ値を取得または設定します。これは AlphaSource が AlphaSource.PIXEL_ALPHA のときに有効です。デフォルト値は 1.0 で、有効な範囲は 0 から 1 です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getAlphaSource{#getAlphaSource}
+
+| 名前 | 説明 |
+| --- | --- |
+| getAlphaSource() | テクスチャがアルファチャンネルを定義するかどうかを取得または設定します。デフォルト値は AlphaSource.NONE です。このプロパティの値は AlphaSource の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setAlphaSource{#setAlphaSource}
+
+| 名前 | 説明 |
+| --- | --- |
+| setAlphaSource(value) | テクスチャがアルファチャンネルを定義するかどうかを取得または設定します。デフォルト値は AlphaSource.NONE です。このプロパティの値は AlphaSource の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getWrapModeU{#getWrapModeU}
+
+| 名前 | 説明 |
+| --- | --- |
+| getWrapModeU() | U 方向のテクスチャラップモードを取得または設定します。このプロパティの値は WrapMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setWrapModeU{#setWrapModeU}
+
+| 名前 | 説明 |
+| --- | --- |
+| setWrapModeU(value) | U 方向のテクスチャラップモードを取得または設定します。このプロパティの値は WrapMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getWrapModeV{#getWrapModeV}
+
+| 名前 | 説明 |
+| --- | --- |
+| getWrapModeV() | V 方向のテクスチャラップモードを取得または設定します。このプロパティの値は WrapMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setWrapModeV{#setWrapModeV}
+
+| 名前 | 説明 |
+| --- | --- |
+| setWrapModeV(value) | V 方向のテクスチャラップモードを取得または設定します。このプロパティの値は WrapMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getWrapModeW{#getWrapModeW}
+
+| 名前 | 説明 |
+| --- | --- |
+| getWrapModeW() | W 方向のテクスチャラップモードを取得または設定します。このプロパティの値は WrapMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setWrapModeW{#setWrapModeW}
+
+| 名前 | 説明 |
+| --- | --- |
+| setWrapModeW(value) | W 方向のテクスチャラップモードを取得または設定します。このプロパティの値は WrapMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getMinFilter{#getMinFilter}
+
+| 名前 | 説明 |
+| --- | --- |
+| getMinFilter() | 縮小時のフィルタを取得または設定します。このプロパティの値は TextureFilter の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setMinFilter{#setMinFilter}
+
+| 名前 | 説明 |
+| --- | --- |
+| setMinFilter(value) | 縮小時のフィルタを取得または設定します。このプロパティの値は TextureFilter の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getMagFilter{#getMagFilter}
+
+| 名前 | 説明 |
+| --- | --- |
+| getMagFilter() | 拡大用のフィルタを取得または設定します。プロパティの値は TextureFilter の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setMagFilter{#setMagFilter}
+
+| 名前 | 説明 |
+| --- | --- |
+| setMagFilter(value) | 拡大用のフィルタを取得または設定します。プロパティの値は TextureFilter の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getMipFilter{#getMipFilter}
+
+| 名前 | 説明 |
+| --- | --- |
+| getMipFilter() | ミップレベルサンプリング用のフィルタを取得または設定します。プロパティの値は TextureFilter の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setMipFilter{#setMipFilter}
+
+| 名前 | 説明 |
+| --- | --- |
+| setMipFilter(value) | ミップレベルサンプリング用のフィルタを取得または設定します。プロパティの値は TextureFilter の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getUVRotation{#getUVRotation}
+
+| 名前 | 説明 |
+| --- | --- |
+| getUVRotation() | テクスチャの回転を取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setUVRotation{#setUVRotation}
+
+| 名前 | 説明 |
+| --- | --- |
+| setUVRotation(value) | テクスチャの回転を取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getUVScale{#getUVScale}
+
+| 名前 | 説明 |
+| --- | --- |
+| getUVScale() | UV スケールを取得または設定します。UV スケールです。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setUVScale{#setUVScale}
+
+| 名前 | 説明 |
+| --- | --- |
+| setUVScale(value) | UV スケールを取得または設定します。UV スケールです。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getUVTranslation{#getUVTranslation}
+
+| 名前 | 説明 |
+| --- | --- |
+| getUVTranslation() | UV 平行移動を取得または設定します。UV 平行移動です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setUVTranslation{#setUVTranslation}
+
+| 名前 | 説明 |
+| --- | --- |
+| setUVTranslation(value) | UV 平行移動を取得または設定します。UV 平行移動です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setTranslation{#setTranslation}
+
+| 名前 | 説明 |
+| --- | --- |
+| setTranslation(u, v) | UV 平行移動を設定します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| u | 数 | U. |
+| v | 数 | V. |
+
+ **Result:**
+
+
+
+---
+
+
+### setScale{#setScale}
+
+| 名前 | 説明 |
+| --- | --- |
+| setScale(u, v) | UV スケールを設定します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| u | 数 | U. |
+| v | 数 | V. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRotation{#setRotation}
+
+| 名前 | 説明 |
+| --- | --- |
+| setRotation(u, v) | UV 回転を設定します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| u | 数 | U. |
+| v | 数 | V. |
+
+ **Result:**
+
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/texturecodec/_index.md
+++ b/japanese/nodejs-java/aspose.threed/texturecodec/_index.md
@@ -1,0 +1,61 @@
+---
+title: "TextureCodec"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/texturecodec/
+---
+## TextureCodec class
+
+テクスチャのエンコーダーとデコーダーを管理するクラス。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getSupportedEncoderFormats{#getSupportedEncoderFormats}
+
+| 名前 | 説明 |
+| --- | --- |
+| getSupportedEncoderFormats() | サポートされているすべてのエンコーダフォーマットを取得します |
+
+ **Result:**
+String[]
+
+
+---
+
+
+### registerCodec{#registerCodec}
+
+| 名前 | 説明 |
+| --- | --- |
+| registerCodec(codec) | テクスチャエンコーダとデコーダのセットを登録します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| コード | ITextureCodec | null |
+
+ **Result:**
+String[]
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/texturedata/_index.md
+++ b/japanese/nodejs-java/aspose.threed/texturedata/_index.md
@@ -1,0 +1,289 @@
+---
+title: "TextureData"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/texturedata/
+---
+## TextureData class
+
+このクラスはテクスチャの生データとフォーマット定義を含みます。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor(width, height, stride, bytesPerPixel, pixelFormat, data) | TextureData のコンストラクタ |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| 幅 | 数 | null |
+| 高さ | 数 | null |
+| strid | 数 | null |
+| bytesPerPixe | 数 | null |
+| pixelFormat | PixelFormat | PixelFormat |
+| dat | byte[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload(width, height, pixelFormat) | 新しい TextureData を作成し、ピクセルデータを割り当てます。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| 幅 | 数 | null |
+| 高さ | 数 | null |
+| pixelFormat | PixelFormat | PixelFormat |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload2() | TextureData のコンストラクタ |
+
+ **Result:**
+
+
+
+---
+
+
+### getData{#getData}
+
+| 名前 | 説明 |
+| --- | --- |
+| getData() | ピクセルデータの生バイト |
+
+ **Result:**
+
+
+
+---
+
+
+### getWidth{#getWidth}
+
+| 名前 | 説明 |
+| --- | --- |
+| getWidth() | 水平ピクセル数 |
+
+ **Result:**
+
+
+
+---
+
+
+### getHeight{#getHeight}
+
+| 名前 | 説明 |
+| --- | --- |
+| getHeight() | 垂直ピクセル数 |
+
+ **Result:**
+
+
+
+---
+
+
+### getStride{#getStride}
+
+| 名前 | 説明 |
+| --- | --- |
+| getStride() | 走査線あたりのバイト数。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getBytesPerPixel{#getBytesPerPixel}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBytesPerPixel() | ピクセルあたりのバイト数 |
+
+ **Result:**
+
+
+
+---
+
+
+### getPixelFormat{#getPixelFormat}
+
+| 名前 | 説明 |
+| --- | --- |
+| getPixelFormat() | ピクセルのフォーマットです。このプロパティの値は PixelFormat の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### fromFile{#fromFile}
+
+| 名前 | 説明 |
+| --- | --- |
+| fromFile(fileName) | ファイルからテクスチャを読み込みます |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| fileNam | 文字列 | null |
+
+ **Result:**
+TextureData
+
+
+---
+
+
+### save{#save}
+
+| 名前 | 説明 |
+| --- | --- |
+| save(fileName) | テクスチャ データを画像ファイルに保存する |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| fileName | 文字列 | 画像が保存される場所のファイル名です。 |
+
+ **Result:**
+TextureData
+
+
+---
+
+
+### save{#save}
+
+| 名前 | 説明 |
+| --- | --- |
+| save(fileName, format) | テクスチャ データを画像ファイルに保存する |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| fileName | 文字列 | 画像が保存される場所のファイル名です。 |
+| format | 文字列 | 出力ファイルの画像形式です。 |
+
+ **Result:**
+TextureData
+
+
+---
+
+
+### mapPixels{#mapPixels}
+
+| 名前 | 説明 |
+| --- | --- |
+| mapPixels(mapMode) | 読み取り/書き込み用にすべてのピクセルをマップする |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| mapMode | PixelMapMode | PixelMapMode |
+
+ **Result:**
+PixelMapping
+
+
+---
+
+
+### mapPixels{#mapPixels}
+
+| 名前 | 説明 |
+| --- | --- |
+| mapPixels(mapMode, format) | 指定されたピクセル形式で読み取り/書き込み用にすべてのピクセルをマップする |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| mapMode | PixelMapMode | PixelMapMode |
+| format | PixelFormat | PixelFormat |
+
+ **Result:**
+PixelMapping
+
+
+---
+
+
+### mapPixels{#mapPixels}
+
+| 名前 | 説明 |
+| --- | --- |
+| mapPixels(rect, mapMode, format) | rect で指定されたピクセルを、指定されたピクセル形式で読み取り/書き込み用にマップする |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| rect | Rect | アクセスされるピクセル領域 |
+| mapMode | PixelMapMode | PixelMapMode |
+| format | PixelFormat | PixelFormat |
+
+ **Result:**
+PixelMapping
+
+
+---
+
+
+### transformPixelFormat{#transformPixelFormat}
+
+| 名前 | 説明 |
+| --- | --- |
+| transformPixelFormat(pixelFormat) | ピクセルのレイアウトを新しいピクセル形式に変換する。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| pixelFormat | PixelFormat | PixelFormat |
+
+ **Result:**
+PixelMapping
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/textureslot/_index.md
+++ b/japanese/nodejs-java/aspose.threed/textureslot/_index.md
@@ -1,0 +1,42 @@
+---
+title: "TextureSlot"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/textureslot/
+---
+## TextureSlot class
+
+Material内のテクスチャスロットで、マテリアルインスタンスを通じて列挙可能です。  @hideconstructor
+
+
+## メソッド
+
+### getSlotName{#getSlotName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getSlotName() | このテクスチャがバインドされる場所を示すスロット名です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getTexture{#getTexture}
+
+| 名前 | 説明 |
+| --- | --- |
+| getTexture() | マテリアルにバインドされるテクスチャ。 |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/torus/_index.md
+++ b/japanese/nodejs-java/aspose.threed/torus/_index.md
@@ -1,0 +1,528 @@
+---
+title: "トーラス"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/torus/
+---
+## Torus class
+
+パラメータ化されたトーラス。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | Torus クラスの新しいインスタンスを初期化します |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload(radius, tube) | Torus クラスの新しいインスタンスを初期化します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| 半径 | 数 | トーラスの半径です。 |
+| チューブ | 数 | トーラスのチューブの半径です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload2(radius, tube, arc) | Torus クラスの新しいインスタンスを初期化します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| 半径 | 数 | トーラスの半径です。 |
+| チューブ | 数 | トーラスのチューブの半径です。 |
+| 弧 | 数 | 弧。 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload3{#constructor_overload3}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload3(name, radius, tube, radialSegments, tubularSegments, arc) | Torus クラスの新しいインスタンスを初期化します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| name | 文字列 | 名前。 |
+| 半径 | 数 | トーラスの半径です。 |
+| チューブ | 数 | トーラスのチューブの半径です。 |
+| radialSegments | 数 | ラジアルセグメントです。 |
+| tubularSegments | 数 | チューブ状セグメント。 |
+| 弧 | 数 | 弧。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getRadius{#getRadius}
+
+| 名前 | 説明 |
+| --- | --- |
+| getRadius() | トーラスの半径を取得または設定します。半径。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setRadius{#setRadius}
+
+| 名前 | 説明 |
+| --- | --- |
+| setRadius(value) | トーラスの半径を取得または設定します。半径。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getTube{#getTube}
+
+| 名前 | 説明 |
+| --- | --- |
+| getTube() | チューブの半径を取得または設定します。チューブ。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setTube{#setTube}
+
+| 名前 | 説明 |
+| --- | --- |
+| setTube(value) | チューブの半径を取得または設定します。チューブ。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getRadialSegments{#getRadialSegments}
+
+| 名前 | 説明 |
+| --- | --- |
+| getRadialSegments() | ラジアルセグメントを取得または設定します。ラジアルセグメントです。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setRadialSegments{#setRadialSegments}
+
+| 名前 | 説明 |
+| --- | --- |
+| setRadialSegments(value) | ラジアルセグメントを取得または設定します。ラジアルセグメントです。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getTubularSegments{#getTubularSegments}
+
+| 名前 | 説明 |
+| --- | --- |
+| getTubularSegments() | チューブ状セグメントを取得または設定します。チューブ状セグメント。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setTubularSegments{#setTubularSegments}
+
+| 名前 | 説明 |
+| --- | --- |
+| setTubularSegments(value) | チューブ状セグメントを取得または設定します。チューブ状セグメント。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getArc{#getArc}
+
+| 名前 | 説明 |
+| --- | --- |
+| getArc() | 弧を取得または設定します。弧。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setArc{#setArc}
+
+| 名前 | 説明 |
+| --- | --- |
+| setArc(value) | 弧を取得または設定します。弧。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastShadows{#getCastShadows}
+
+| 名前 | 説明 |
+| --- | --- |
+| getCastShadows() | このジオメトリが影を落とすかどうかを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastShadows{#setCastShadows}
+
+| 名前 | 説明 |
+| --- | --- |
+| setCastShadows(value) | このジオメトリが影を落とすかどうかを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getReceiveShadows{#getReceiveShadows}
+
+| 名前 | 説明 |
+| --- | --- |
+| getReceiveShadows() | このジオメトリが影を受け取るかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setReceiveShadows{#setReceiveShadows}
+
+| 名前 | 説明 |
+| --- | --- |
+| setReceiveShadows(value) | このジオメトリが影を受け取るかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNodes() | すべての親ノードを取得します。エンティティはジオメトリインスタンシングのために複数の親ノードにアタッチできます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExcluded() | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExcluded(value) | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNode() | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setParentNode(value) | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 名前 | 説明 |
+| --- | --- |
+| getScene() | このオブジェクトが属するシーンを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### toMesh{#toMesh}
+
+| 名前 | 説明 |
+| --- | --- |
+| toMesh() | 現在のオブジェクトをメッシュに変換します |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBoundingBox() | 現在のエンティティのオブジェクト空間座標系におけるバウンディングボックスを取得します。 |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEntityRendererKey() | レンダラーに登録されたエンティティレンダラーのキーを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/transform/_index.md
+++ b/japanese/nodejs-java/aspose.threed/transform/_index.md
@@ -1,0 +1,561 @@
+---
+title: "変換"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/transform/
+---
+## Transform class
+
+変換はオブジェクトの平行移動/スケール/回転または変換行列へのアクセスを最小コストで可能にする情報を含みます。これはローカル変換で使用されます。  @hideconstructor
+
+
+## メソッド
+
+### getGeometricTranslation{#getGeometricTranslation}
+
+| 名前 | 説明 |
+| --- | --- |
+| getGeometricTranslation() | 幾何学的平行移動を取得または設定します。幾何学的変換は、添付されたエンティティにのみ影響し、子ノードには影響しません。サポートされていないファイル形式に幾何学的変換をエクスポートする場合、ローカル変換としてマージされます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setGeometricTranslation{#setGeometricTranslation}
+
+| 名前 | 説明 |
+| --- | --- |
+| setGeometricTranslation(value) | 幾何学的平行移動を取得または設定します。幾何学的変換は、添付されたエンティティにのみ影響し、子ノードには影響しません。サポートされていないファイル形式に幾何学的変換をエクスポートする場合、ローカル変換としてマージされます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getGeometricScaling{#getGeometricScaling}
+
+| 名前 | 説明 |
+| --- | --- |
+| getGeometricScaling() | 幾何学的スケーリングを取得または設定します。幾何学的変換は、添付されたエンティティにのみ影響し、子ノードには影響しません。サポートされていないファイル形式に幾何学的変換をエクスポートする場合、ローカル変換としてマージされます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setGeometricScaling{#setGeometricScaling}
+
+| 名前 | 説明 |
+| --- | --- |
+| setGeometricScaling(value) | 幾何学的スケーリングを取得または設定します。幾何学的変換は、添付されたエンティティにのみ影響し、子ノードには影響しません。サポートされていないファイル形式に幾何学的変換をエクスポートする場合、ローカル変換としてマージされます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getGeometricRotation{#getGeometricRotation}
+
+| 名前 | 説明 |
+| --- | --- |
+| getGeometricRotation() | 幾何学的オイラー回転（度単位）を取得または設定します。幾何学的変換は、添付されたエンティティにのみ影響し、子ノードには影響しません。サポートされていないファイル形式に幾何学的変換をエクスポートする場合、ローカル変換としてマージされます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setGeometricRotation{#setGeometricRotation}
+
+| 名前 | 説明 |
+| --- | --- |
+| setGeometricRotation(value) | 幾何学的オイラー回転（度単位）を取得または設定します。幾何学的変換は、添付されたエンティティにのみ影響し、子ノードには影響しません。サポートされていないファイル形式に幾何学的変換をエクスポートする場合、ローカル変換としてマージされます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getTranslation{#getTranslation}
+
+| 名前 | 説明 |
+| --- | --- |
+| getTranslation() | 変換を取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setTranslation{#setTranslation}
+
+| 名前 | 説明 |
+| --- | --- |
+| setTranslation(value) | 変換を取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getScale{#getScale}
+
+| 名前 | 説明 |
+| --- | --- |
+| getScale() | スケールを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setScale{#setScale}
+
+| 名前 | 説明 |
+| --- | --- |
+| setScale(value) | スケールを取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getPreRotation{#getPreRotation}
+
+| 名前 | 説明 |
+| --- | --- |
+| getPreRotation() | 度で表される事前回転を取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setPreRotation{#setPreRotation}
+
+| 名前 | 説明 |
+| --- | --- |
+| setPreRotation(value) | 度で表される事前回転を取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getPostRotation{#getPostRotation}
+
+| 名前 | 説明 |
+| --- | --- |
+| getPostRotation() | 度で表される事後回転を取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setPostRotation{#setPostRotation}
+
+| 名前 | 説明 |
+| --- | --- |
+| setPostRotation(value) | 度で表される事後回転を取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getEulerAngles{#getEulerAngles}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEulerAngles() | 度で測定されたEuler角で表される回転を取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setEulerAngles{#setEulerAngles}
+
+| 名前 | 説明 |
+| --- | --- |
+| setEulerAngles(value) | 度で測定されたEuler角で表される回転を取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getRotation{#getRotation}
+
+| 名前 | 説明 |
+| --- | --- |
+| getRotation() | クォータニオンで表される回転を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setRotation{#setRotation}
+
+| 名前 | 説明 |
+| --- | --- |
+| setRotation(value) | クォータニオンで表される回転を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getTransformMatrix{#getTransformMatrix}
+
+| 名前 | 説明 |
+| --- | --- |
+| getTransformMatrix() | 変換行列を取得または設定します。このプロパティに代入すると Translation、Scale、Rotation がリセットされますが、GeometricRotation、GeometricScaling、GeometricTranslation は影響を受けません。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setTransformMatrix{#setTransformMatrix}
+
+| 名前 | 説明 |
+| --- | --- |
+| setTransformMatrix(value) | 変換行列を取得または設定します。このプロパティに代入すると Translation、Scale、Rotation がリセットされますが、GeometricRotation、GeometricScaling、GeometricTranslation は影響を受けません。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setGeometricTranslation{#setGeometricTranslation}
+
+| 名前 | 説明 |
+| --- | --- |
+| setGeometricTranslation(x, y, z) | 幾何的平行移動を設定します。幾何変換は添付されたエンティティにのみ影響し、子ノードには影響しません。サポートされていないファイル形式に幾何変換をエクスポートする際には、ローカル変換としてマージされます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setGeometricScaling{#setGeometricScaling}
+
+| 名前 | 説明 |
+| --- | --- |
+| setGeometricScaling(sx, sy, sz) | 幾何的スケーリングを設定します。幾何変換は添付されたエンティティにのみ影響し、子ノードには影響しません。サポートされていないファイル形式に幾何変換をエクスポートする際には、ローカル変換としてマージされます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setGeometricRotation{#setGeometricRotation}
+
+| 名前 | 説明 |
+| --- | --- |
+| setGeometricRotation(rx, ry, rz) | 幾何的Euler回転（度で測定）を設定します。幾何変換は添付されたエンティティにのみ影響し、子ノードには影響しません。サポートされていないファイル形式に幾何変換をエクスポートする際には、ローカル変換としてマージされます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setTranslation{#setTranslation}
+
+| 名前 | 説明 |
+| --- | --- |
+| setTranslation(tx, ty, tz) | 現在の変換の平行移動を設定します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| t | 数 | null |
+| t | 数 | null |
+| t | 数 | null |
+
+ **Result:**
+変換
+
+
+---
+
+
+### setScale{#setScale}
+
+| 名前 | 説明 |
+| --- | --- |
+| setScale(sx, sy, sz) | 現在の変換のスケールを設定します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| s | 数 | null |
+| s | 数 | null |
+| s | 数 | null |
+
+ **Result:**
+変換
+
+
+---
+
+
+### setEulerAngles{#setEulerAngles}
+
+| 名前 | 説明 |
+| --- | --- |
+| setEulerAngles(rx, ry, rz) | 現在の変換のオイラー角を度単位で設定します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| r | 数 | null |
+| r | 数 | null |
+| r | 数 | null |
+
+ **Result:**
+変換
+
+
+---
+
+
+### setRotation{#setRotation}
+
+| 名前 | 説明 |
+| --- | --- |
+| setRotation(rw, rx, ry, rz) | 現在の変換の回転を（クォータニオン成分として）設定します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| r | 数 | null |
+| r | 数 | null |
+| r | 数 | null |
+| r | 数 | null |
+
+ **Result:**
+変換
+
+
+---
+
+
+### setPreRotation{#setPreRotation}
+
+| 名前 | 説明 |
+| --- | --- |
+| setPreRotation(rx, ry, rz) | 度で表された事前回転を設定します。 |
+
+ **Result:**
+変換
+
+
+---
+
+
+### setPostRotation{#setPostRotation}
+
+| 名前 | 説明 |
+| --- | --- |
+| setPostRotation(rx, ry, rz) | 度で表された事後回転を設定します。 |
+
+ **Result:**
+変換
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/transformbuilder/_index.md
+++ b/japanese/nodejs-java/aspose.threed/transformbuilder/_index.md
@@ -1,0 +1,457 @@
+---
+title: "TransformBuilder"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/transformbuilder/
+---
+## TransformBuilder class
+
+TransformBuilderは変換のチェーンによって変換行列を構築するために使用されます。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor(initial, order) | 初期変換行列と指定された合成順序で TransformBuilder を構築します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| initia | Matrix4 | null |
+| 順序 | ComposeOrder | ComposeOrder |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload(order) | 初期の単位変換行列と指定された合成順序で TransformBuilder を構築します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| 順序 | ComposeOrder | ComposeOrder |
+
+ **Result:**
+
+
+
+---
+
+
+### getMatrix{#getMatrix}
+
+| 名前 | 説明 |
+| --- | --- |
+| getMatrix() | 現在の行列値を取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### setMatrix{#setMatrix}
+
+| 名前 | 説明 |
+| --- | --- |
+| setMatrix(value) | 現在の行列値を取得または設定します |
+
+ **Result:**
+
+
+
+---
+
+
+### getComposeOrder{#getComposeOrder}
+
+| 名前 | 説明 |
+| --- | --- |
+| getComposeOrder() | チェーンの合成順序を取得または設定します。プロパティの値は ComposeOrder の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setComposeOrder{#setComposeOrder}
+
+| 名前 | 説明 |
+| --- | --- |
+| setComposeOrder(value) | チェーンの合成順序を取得または設定します。プロパティの値は ComposeOrder の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### compose{#compose}
+
+| 名前 | 説明 |
+| --- | --- |
+| compose(m) | 引数を内部行列に追加または前置します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+|  | Matrix4 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### append{#append}
+
+| 名前 | 説明 |
+| --- | --- |
+| append(m) | 新しい変換行列を変換チェーンに追加します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+|  | Matrix4 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### prepend{#prepend}
+
+| 名前 | 説明 |
+| --- | --- |
+| prepend(m) | 新しい変換行列を変換チェーンの先頭に追加します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+|  | Matrix4 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### rearrange{#rearrange}
+
+| 名前 | 説明 |
+| --- | --- |
+| rearrange(newX, newY, newZ) | 軸のレイアウトを再配置します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| newX | 軸 | 軸 |
+| newY | 軸 | 軸 |
+| newZ | 軸 | 軸 |
+
+ **Result:**
+
+
+
+---
+
+
+### scale{#scale}
+
+| 名前 | 説明 |
+| --- | --- |
+| scale(s) | コンポーネントが s でスケールされた拡大変換行列をチェーンします。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+|  | 数 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### scale{#scale}
+
+| 名前 | 説明 |
+| --- | --- |
+| scale(x, y, z) | スケーリング変換行列をチェーンします。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+|  | 数 | null |
+|  | 数 | null |
+|  | 数 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### scale{#scale}
+
+| 名前 | 説明 |
+| --- | --- |
+| scale(s) | スケール変換をチェーンします。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+|  | Vector3 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### rotateDegree{#rotateDegree}
+
+| 名前 | 説明 |
+| --- | --- |
+| rotateDegree(angle, axis) | 度単位の回転変換をチェーンします。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| angle | 数 | 回転角度（度） |
+| axis | Vector3 | 回転軸 |
+
+ **Result:**
+
+
+
+---
+
+
+### rotateRadian{#rotateRadian}
+
+| 名前 | 説明 |
+| --- | --- |
+| rotateRadian(angle, axis) | ラジアン単位の回転変換をチェーンします。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| angle | 数 | 回転角度（ラジアン） |
+| axis | Vector3 | 回転軸 |
+
+ **Result:**
+
+
+
+---
+
+
+### rotate{#rotate}
+
+| 名前 | 説明 |
+| --- | --- |
+| rotate(q) | クォータニオンによる回転をチェーンします。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+|  | クォータニオン | null |
+
+ **Result:**
+
+
+
+---
+
+
+### rotateEulerDegree{#rotateEulerDegree}
+
+| 名前 | 説明 |
+| --- | --- |
+| rotateEulerDegree(degX, degY, degZ) | 度単位のオイラー角による回転をチェーンします。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| 度 | 数 | null |
+| 度 | 数 | null |
+| 度 | 数 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### rotateEulerRadian{#rotateEulerRadian}
+
+| 名前 | 説明 |
+| --- | --- |
+| rotateEulerRadian(x, y, z) | ラジアン単位のオイラー角による回転をチェーンします。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+|  | 数 | null |
+|  | 数 | null |
+|  | 数 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### rotateEulerRadian{#rotateEulerRadian}
+
+| 名前 | 説明 |
+| --- | --- |
+| rotateEulerRadian(r) | ラジアン単位のオイラー角による回転をチェーンします。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+|  | Vector3 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### translate{#translate}
+
+| 名前 | 説明 |
+| --- | --- |
+| translate(tx, ty, tz) | 平行移動変換をチェーンします。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| t | 数 | null |
+| t | 数 | null |
+| t | 数 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### translate{#translate}
+
+| 名前 | 説明 |
+| --- | --- |
+| translate(v) | 平行移動変換をチェーンします。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+|  | Vector3 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### reset{#reset}
+
+| 名前 | 説明 |
+| --- | --- |
+| reset() | 変換を単位行列にリセットします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### rotateDegree{#rotateDegree}
+
+| 名前 | 説明 |
+| --- | --- |
+| rotateDegree(rot, order) | 指定された順序で回転を追加する |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| rot | Vector3 | 回転角度（度） |
+| 順序 | RotationOrder | RotationOrder |
+
+ **Result:**
+
+
+
+---
+
+
+### rotateRadian{#rotateRadian}
+
+| 名前 | 説明 |
+| --- | --- |
+| rotateRadian(rot, order) | 指定された順序で回転を追加する |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| rot | Vector3 | ラジアンでの回転 |
+| 順序 | RotationOrder | RotationOrder |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/transformedcurve/_index.md
+++ b/japanese/nodejs-java/aspose.threed/transformedcurve/_index.md
@@ -1,0 +1,359 @@
+---
+title: "TransformedCurve"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/transformedcurve/
+---
+## TransformedCurve class
+
+TransformedCurveは変換行列を使用して曲線に配置を与えます。これによりTrimmedCurveやCompositeCurve内で変換を実行できます。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | TransformedCurve のコンストラクタ |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload(basisCurve, transformation) | TransformedCurve のコンストラクタ |
+
+ **Result:**
+
+
+
+---
+
+
+### getTransformMatrix{#getTransformMatrix}
+
+| 名前 | 説明 |
+| --- | --- |
+| getTransformMatrix() | 変換行列です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setTransformMatrix{#setTransformMatrix}
+
+| 名前 | 説明 |
+| --- | --- |
+| setTransformMatrix(value) | 変換行列です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getBasisCurve{#getBasisCurve}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBasisCurve() | 基底曲線です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setBasisCurve{#setBasisCurve}
+
+| 名前 | 説明 |
+| --- | --- |
+| setBasisCurve(value) | 基底曲線です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getColor{#getColor}
+
+| 名前 | 説明 |
+| --- | --- |
+| getColor() | 線の色を取得または設定します。デフォルト値は白 (1, 1, 1) です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setColor{#setColor}
+
+| 名前 | 説明 |
+| --- | --- |
+| setColor(value) | 線の色を取得または設定します。デフォルト値は白 (1, 1, 1) です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNodes() | すべての親ノードを取得します。エンティティはジオメトリインスタンシングのために複数の親ノードにアタッチできます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExcluded() | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExcluded(value) | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNode() | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setParentNode(value) | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 名前 | 説明 |
+| --- | --- |
+| getScene() | このオブジェクトが属するシーンを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEntityRendererKey() | レンダラーに登録されたエンティティレンダラーのキーを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBoundingBox() | 現在のエンティティのオブジェクト空間座標系におけるバウンディングボックスを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/trapeziumshape/_index.md
+++ b/japanese/nodejs-java/aspose.threed/trapeziumshape/_index.md
@@ -1,0 +1,385 @@
+---
+title: "TrapeziumShape"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/trapeziumshape/
+---
+## TrapeziumShape class
+
+パラメータで定義されたIFC互換の台形形状。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | TrapeziumShape のコンストラクタ |
+
+ **Result:**
+
+
+
+---
+
+
+### getBottomXDim{#getBottomXDim}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBottomXDim() | x 軸に沿って測定された底辺の長さを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setBottomXDim{#setBottomXDim}
+
+| 名前 | 説明 |
+| --- | --- |
+| setBottomXDim(value) | x 軸に沿って測定された底辺の長さを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getTopXDim{#getTopXDim}
+
+| 名前 | 説明 |
+| --- | --- |
+| getTopXDim() | x 軸に沿って測定された上部ラインの範囲を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setTopXDim{#setTopXDim}
+
+| 名前 | 説明 |
+| --- | --- |
+| setTopXDim(value) | x 軸に沿って測定された上部ラインの範囲を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getYDim{#getYDim}
+
+| 名前 | 説明 |
+| --- | --- |
+| getYDim() | y 軸に沿って測定された上部ラインと下部ライン間の距離を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setYDim{#setYDim}
+
+| 名前 | 説明 |
+| --- | --- |
+| setYDim(value) | y 軸に沿って測定された上部ラインと下部ライン間の距離を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getTopXOffset{#getTopXOffset}
+
+| 名前 | 説明 |
+| --- | --- |
+| getTopXOffset() | 上部ラインの開始点から下部ラインまでのオフセットを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setTopXOffset{#setTopXOffset}
+
+| 名前 | 説明 |
+| --- | --- |
+| setTopXOffset(value) | 上部ラインの開始点から下部ラインまでのオフセットを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNodes() | すべての親ノードを取得します。エンティティはジオメトリインスタンシングのために複数の親ノードにアタッチできます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExcluded() | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExcluded(value) | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNode() | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setParentNode(value) | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 名前 | 説明 |
+| --- | --- |
+| getScene() | このオブジェクトが属するシーンを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtent{#getExtent}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExtent() | x と y の次元での範囲を取得します |
+
+ **Result:**
+Vector2
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEntityRendererKey() | レンダラーに登録されたエンティティレンダラーのキーを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBoundingBox() | 現在のエンティティのオブジェクト空間座標系におけるバウンディングボックスを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/trialexception/_index.md
+++ b/japanese/nodejs-java/aspose.threed/trialexception/_index.md
@@ -1,0 +1,61 @@
+---
+title: "TrialException"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/trialexception/
+---
+## TrialException class
+
+Scene.Open/Scene.Saveでライセンスが適用されていない場合にこの例外が発生します。SuppressTrialExceptionをtrueに設定することでこの例外を無効にできます。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor(msg) | TrialException のコンストラクタ |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| ms | 文字列 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### getSuppressTrialException{#getSuppressTrialException}
+
+| 名前 | 説明 |
+| --- | --- |
+| getSuppressTrialException() | この値を true に設定すると、未ライセンス使用時のトライアル例外を抑制しますが、制限は解除されません。制限を解除するには、適切なライセンスをご使用ください。また、この値を true に設定することは、未ライセンスの制限を認識していることを意味します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setSuppressTrialException{#setSuppressTrialException}
+
+| 名前 | 説明 |
+| --- | --- |
+| setSuppressTrialException(value) | この値を true に設定すると、未ライセンス使用時のトライアル例外を抑制しますが、制限は解除されません。制限を解除するには、適切なライセンスをご使用ください。また、この値を true に設定することは、未ライセンスの制限を認識していることを意味します。 |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/trimesh/_index.md
+++ b/japanese/nodejs-java/aspose.threed/trimesh/_index.md
@@ -1,0 +1,679 @@
+---
+title: "TriMesh"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/trimesh/
+---
+## TriMesh class
+
+TriMeshはGPUが直接使用できる生データを含みます。このクラスは頂点ごとのデータのみを含むメッシュの構築を支援するユーティリティです。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor(name, declaration) | TriMesh のインスタンスを初期化する |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| name | 文字列 | この TriMesh の名前 |
+| declaration | VertexDeclaration | 頂点の宣言 |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexDeclaration{#getVertexDeclaration}
+
+| 名前 | 説明 |
+| --- | --- |
+| getVertexDeclaration() | TriMesh の頂点レイアウト。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getVerticesCount{#getVerticesCount}
+
+| 名前 | 説明 |
+| --- | --- |
+| getVerticesCount() | この TriMesh の頂点数 |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndicesCount{#getIndicesCount}
+
+| 名前 | 説明 |
+| --- | --- |
+| getIndicesCount() | この TriMesh のインデックス数 |
+
+ **Result:**
+
+
+
+---
+
+
+### getUnmergedVerticesCount{#getUnmergedVerticesCount}
+
+| 名前 | 説明 |
+| --- | --- |
+| getUnmergedVerticesCount() | beginVertex() と endVertex() によって渡された未マージ頂点の数 |
+
+ **Result:**
+
+
+
+---
+
+
+### getCapacity{#getCapacity}
+
+| 名前 | 説明 |
+| --- | --- |
+| getCapacity() | 事前割り当てされた頂点の容量 |
+
+ **Result:**
+
+
+
+---
+
+
+### getVerticesSizeInBytes{#getVerticesSizeInBytes}
+
+| 名前 | 説明 |
+| --- | --- |
+| getVerticesSizeInBytes() | すべての頂点の合計サイズ（バイト） |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNodes() | すべての親ノードを取得します。エンティティはジオメトリインスタンシングのために複数の親ノードにアタッチできます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExcluded() | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExcluded(value) | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNode() | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setParentNode(value) | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 名前 | 説明 |
+| --- | --- |
+| getScene() | このオブジェクトが属するシーンを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### fromMesh{#fromMesh}
+
+| 名前 | 説明 |
+| --- | --- |
+| fromMesh(declaration, mesh) | 指定された頂点レイアウトを持つメッシュオブジェクトから TriMesh を作成します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| 宣言 | VertexDeclaration | null |
+| メッシュ | Mesh | null |
+
+ **Result:**
+TriMesh
+
+
+---
+
+
+### copyFrom{#copyFrom}
+
+| 名前 | 説明 |
+| --- | --- |
+| copyFrom(input, vd) | 新しい頂点レイアウトで入力から TriMesh をコピーします |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| 入力 | TriMesh | コピー用の入力 TriMesh |
+| vd | VertexDeclaration | 出力 TriMesh の新しい頂点宣言 |
+
+ **Result:**
+TriMesh
+
+
+---
+
+
+### fromMesh{#fromMesh}
+
+| 名前 | 説明 |
+| --- | --- |
+| fromMesh(mesh, useFloat) | 入力メッシュの構造に基づく頂点宣言で、指定されたメッシュオブジェクトから TriMesh を作成します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| メッシュ | Mesh | null |
+| useFloat | boolean | 各頂点要素コンポーネントに double 型の代わりに float 型を使用します。 |
+
+ **Result:**
+TriMesh
+
+
+---
+
+
+### beginVertex{#beginVertex}
+
+| 名前 | 説明 |
+| --- | --- |
+| beginVertex() | 頂点の追加を開始します |
+
+ **Result:**
+頂点
+
+
+---
+
+
+### endVertex{#endVertex}
+
+| 名前 | 説明 |
+| --- | --- |
+| endVertex() | 頂点の追加を終了する |
+
+ **Result:**
+頂点
+
+
+---
+
+
+### verticesToArray{#verticesToArray}
+
+| 名前 | 説明 |
+| --- | --- |
+| verticesToArray() | 頂点データをバイト配列に変換する |
+
+ **Result:**
+byte[]
+
+
+---
+
+
+### toString{#toString}
+
+| 名前 | 説明 |
+| --- | --- |
+| toString() |  |
+
+ **Result:**
+文字列
+
+
+---
+
+
+### fromRawData{#fromRawData}
+
+| 名前 | 説明 |
+| --- | --- |
+| fromRawData(vd, vertices, indices, generateVertexMapping) | 生データから TriMesh を作成します。返される TriMesh はパフォーマンスのために入力バイト配列をコピーせず、配列への外部変更はこのインスタンスに反映されます。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| vd | VertexDeclaration | 頂点宣言は、少なくとも1つのフィールドを含む必要があります。 |
+| vertices | byte[] | 入力頂点データです。頂点の最小長さは、頂点宣言のサイズ以上である必要があります。 |
+| indices | Number[] | 三角形インデックス |
+| generateVertexMapping | boolean | 生成 |
+
+ **Result:**
+TriMesh
+
+
+---
+
+
+### loadVerticesFromBytes{#loadVerticesFromBytes}
+
+| 名前 | 説明 |
+| --- | --- |
+| loadVerticesFromBytes(verticesInBytes) | バイトから頂点をロードします。バイト長は頂点サイズの整数倍である必要があります。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| verticesInByte | byte[] | null |
+
+ **Result:**
+TriMesh
+
+
+---
+
+
+### readVector4{#readVector4}
+
+| 名前 | 説明 |
+| --- | --- |
+| readVector4(idx, field) | vector4 フィールドを読み取ります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| idx | 数 | 読み取る頂点のインデックス |
+| フィールド | VertexField | Vector4/FVector4 データ型を持つフィールド |
+
+ **Result:**
+Vector4
+
+
+---
+
+
+### readFVector4{#readFVector4}
+
+| 名前 | 説明 |
+| --- | --- |
+| readFVector4(idx, field) | vector4 フィールドを読み取ります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| idx | 数 | 読み取る頂点のインデックス |
+| フィールド | VertexField | Vector4/FVector4 データ型を持つフィールド |
+
+ **Result:**
+FVector4
+
+
+---
+
+
+### readVector3{#readVector3}
+
+| 名前 | 説明 |
+| --- | --- |
+| readVector3(idx, field) | vector3 フィールドを読み取ります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| idx | 数 | 読み取る頂点のインデックス |
+| フィールド | VertexField | Vector3/FVector3 データ型のフィールド |
+
+ **Result:**
+Vector3
+
+
+---
+
+
+### readFVector3{#readFVector3}
+
+| 名前 | 説明 |
+| --- | --- |
+| readFVector3(idx, field) | vector3 フィールドを読み取ります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| idx | 数 | 読み取る頂点のインデックス |
+| フィールド | VertexField | Vector3/FVector3 データ型のフィールド |
+
+ **Result:**
+FVector3
+
+
+---
+
+
+### readVector2{#readVector2}
+
+| 名前 | 説明 |
+| --- | --- |
+| readVector2(idx, field) | vector2 フィールドを読み取ります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| idx | 数 | 読み取る頂点のインデックス |
+| フィールド | VertexField | Vector2/FVector2 データ型のフィールド |
+
+ **Result:**
+Vector2
+
+
+---
+
+
+### readFVector2{#readFVector2}
+
+| 名前 | 説明 |
+| --- | --- |
+| readFVector2(idx, field) | vector2 フィールドを読み取ります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| idx | 数 | 読み取る頂点のインデックス |
+| フィールド | VertexField | Vector2/FVector2 データ型のフィールド |
+
+ **Result:**
+FVector2
+
+
+---
+
+
+### readDouble{#readDouble}
+
+| 名前 | 説明 |
+| --- | --- |
+| readDouble(idx, field) | double フィールドを読み取ります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| idx | 数 | 読み取る頂点のインデックス |
+| フィールド | VertexField | float/double 互換データ型のフィールド |
+
+ **Result:**
+数
+
+
+---
+
+
+### readFloat{#readFloat}
+
+| 名前 | 説明 |
+| --- | --- |
+| readFloat(idx, field) | float フィールドを読み取ります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| idx | 数 | 読み取る頂点のインデックス |
+| フィールド | VertexField | float/double 互換データ型のフィールド |
+
+ **Result:**
+数
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBoundingBox() | 現在のエンティティのオブジェクト空間座標系におけるバウンディングボックスを取得します。 |
+
+ **Result:**
+数
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEntityRendererKey() | レンダラーに登録されたエンティティレンダラーのキーを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+### iterator{#iterator}
+
+| 名前 | 説明 |
+| --- | --- |
+| iterator() | 内部使用のために予約されています。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/trimmedcurve/_index.md
+++ b/japanese/nodejs-java/aspose.threed/trimmedcurve/_index.md
@@ -1,0 +1,398 @@
+---
+title: "TrimmedCurve"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/trimmedcurve/
+---
+## TrimmedCurve class
+
+両端で基底曲線をトリムした有界曲線。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | TrimmedCurve のコンストラクタ |
+
+ **Result:**
+
+
+
+---
+
+
+### getBasisCurve{#getBasisCurve}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBasisCurve() | トリム対象の基底曲線。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setBasisCurve{#setBasisCurve}
+
+| 名前 | 説明 |
+| --- | --- |
+| setBasisCurve(value) | トリム対象の基底曲線。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFirst{#getFirst}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFirst() | トリムする最初の端点。デカルト点または実数パラメータのいずれかです。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFirst{#setFirst}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFirst(value) | トリムする最初の端点。デカルト点または実数パラメータのいずれかです。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getSecond{#getSecond}
+
+| 名前 | 説明 |
+| --- | --- |
+| getSecond() | トリムする第二の終点は、デカルト座標の点または実数パラメータにできます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setSecond{#setSecond}
+
+| 名前 | 説明 |
+| --- | --- |
+| setSecond(value) | トリムする第二の終点は、デカルト座標の点または実数パラメータにできます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getSameDirection{#getSameDirection}
+
+| 名前 | 説明 |
+| --- | --- |
+| getSameDirection() | トリムされた結果が基準曲線と同じ方向を使用するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setSameDirection{#setSameDirection}
+
+| 名前 | 説明 |
+| --- | --- |
+| setSameDirection(value) | トリムされた結果が基準曲線と同じ方向を使用するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getColor{#getColor}
+
+| 名前 | 説明 |
+| --- | --- |
+| getColor() | 線の色を取得または設定します。デフォルト値は白 (1, 1, 1) です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setColor{#setColor}
+
+| 名前 | 説明 |
+| --- | --- |
+| setColor(value) | 線の色を取得または設定します。デフォルト値は白 (1, 1, 1) です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNodes() | すべての親ノードを取得します。エンティティはジオメトリインスタンシングのために複数の親ノードにアタッチできます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExcluded() | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExcluded(value) | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNode() | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setParentNode(value) | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 名前 | 説明 |
+| --- | --- |
+| getScene() | このオブジェクトが属するシーンを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEntityRendererKey() | レンダラーに登録されたエンティティレンダラーのキーを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBoundingBox() | 現在のエンティティのオブジェクト空間座標系におけるバウンディングボックスを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/tshape/_index.md
+++ b/japanese/nodejs-java/aspose.threed/tshape/_index.md
@@ -1,0 +1,463 @@
+---
+title: "TShape"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/tshape/
+---
+## TShape class
+
+パラメータで定義されたIFC互換のT字形状。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | TShape のコンストラクタ |
+
+ **Result:**
+
+
+
+---
+
+
+### getDepth{#getDepth}
+
+| 名前 | 説明 |
+| --- | --- |
+| getDepth() | ウェブの長さを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setDepth{#setDepth}
+
+| 名前 | 説明 |
+| --- | --- |
+| setDepth(value) | ウェブの長さを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlangeWidth{#getFlangeWidth}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFlangeWidth() | フランジの長さを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlangeWidth{#setFlangeWidth}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFlangeWidth(value) | フランジの長さを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getWebThickness{#getWebThickness}
+
+| 名前 | 説明 |
+| --- | --- |
+| getWebThickness() | ウェブの壁厚さを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setWebThickness{#setWebThickness}
+
+| 名前 | 説明 |
+| --- | --- |
+| setWebThickness(value) | ウェブの壁厚さを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlangeThickness{#getFlangeThickness}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFlangeThickness() | フランジの壁厚さを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlangeThickness{#setFlangeThickness}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFlangeThickness(value) | フランジの壁厚さを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFilletRadius{#getFilletRadius}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFilletRadius() | ウェブとフランジ間のフィレットの半径を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFilletRadius{#setFilletRadius}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFilletRadius(value) | ウェブとフランジ間のフィレットの半径を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlangeEdgeRadius{#getFlangeEdgeRadius}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFlangeEdgeRadius() | フランジエッジの半径を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlangeEdgeRadius{#setFlangeEdgeRadius}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFlangeEdgeRadius(value) | フランジエッジの半径を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getWebEdgeRadius{#getWebEdgeRadius}
+
+| 名前 | 説明 |
+| --- | --- |
+| getWebEdgeRadius() | ウェブエッジの半径を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setWebEdgeRadius{#setWebEdgeRadius}
+
+| 名前 | 説明 |
+| --- | --- |
+| setWebEdgeRadius(value) | ウェブエッジの半径を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNodes() | すべての親ノードを取得します。エンティティはジオメトリインスタンシングのために複数の親ノードにアタッチできます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExcluded() | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExcluded(value) | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNode() | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setParentNode(value) | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 名前 | 説明 |
+| --- | --- |
+| getScene() | このオブジェクトが属するシーンを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtent{#getExtent}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExtent() | x と y の次元での範囲を取得します |
+
+ **Result:**
+Vector2
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEntityRendererKey() | レンダラーに登録されたエンティティレンダラーのキーを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBoundingBox() | 現在のエンティティのオブジェクト空間座標系におけるバウンディングボックスを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/u3dloadoptions/_index.md
+++ b/japanese/nodejs-java/aspose.threed/u3dloadoptions/_index.md
@@ -1,0 +1,146 @@
+---
+title: "U3dLoadOptions"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/u3dloadoptions/
+---
+## U3dLoadOptions class
+
+ユニバーサル3Dのロードオプション
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | U3dLoadOptions のコンストラクター |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlipCoordinateSystem{#getFlipCoordinateSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFlipCoordinateSystem() | インポート/エクスポート時に制御点/法線の座標系を反転させるかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlipCoordinateSystem{#setFlipCoordinateSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFlipCoordinateSystem(value) | インポート/エクスポート時に制御点/法線の座標系を反転させるかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileFormat() | 現在の保存/読み込みオプションで指定されたファイル形式を取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEncoding() | テキストベースのファイルのデフォルトエンコーディングを取得または設定します。デフォルト値は null で、インポーター/エクスポーターが使用するエンコーディングを決定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileSystem() | ロード/セーブ時に外部依存関係を管理する方法をユーザーが処理できるようにします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFileSystem(value) | ロード/セーブ時に外部依存関係を管理する方法をユーザーが処理できるようにします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| 名前 | 説明 |
+| --- | --- |
+| getLookupPaths() | OBJ のような一部のファイルは外部ファイルに依存しており、検索パスにより Aspose.3D が外部ファイルを探してロードできるようになります。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileName() | エクスポート/インポートシーンのファイル名です。これはオプションですが、OBJ のマテリアルなど外部アセットをシリアライズする際に便利です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFileName(value) | エクスポート/インポートシーンのファイル名です。これはオプションですが、OBJ のマテリアルなど外部アセットをシリアライズする際に便利です。 |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/u3dsaveoptions/_index.md
+++ b/japanese/nodejs-java/aspose.threed/u3dsaveoptions/_index.md
@@ -1,0 +1,328 @@
+---
+title: "U3dSaveOptions"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/u3dsaveoptions/
+---
+## U3dSaveOptions class
+
+ユニバーサル3Dの保存オプション
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | U3dSaveOptions のコンストラクタ |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlipCoordinateSystem{#getFlipCoordinateSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFlipCoordinateSystem() | インポート/エクスポート時に制御点/法線の座標系を反転させるかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlipCoordinateSystem{#setFlipCoordinateSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFlipCoordinateSystem(value) | インポート/エクスポート時に制御点/法線の座標系を反転させるかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getMeshCompression{#getMeshCompression}
+
+| 名前 | 説明 |
+| --- | --- |
+| getMeshCompression() | メッシュデータ圧縮を有効にするかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setMeshCompression{#setMeshCompression}
+
+| 名前 | 説明 |
+| --- | --- |
+| setMeshCompression(value) | メッシュデータ圧縮を有効にするかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportNormals{#getExportNormals}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExportNormals() | 法線データをエクスポートするかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportNormals{#setExportNormals}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExportNormals(value) | 法線データをエクスポートするかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportTextureCoordinates{#getExportTextureCoordinates}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExportTextureCoordinates() | テクスチャ座標をエクスポートするかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextureCoordinates{#setExportTextureCoordinates}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExportTextureCoordinates(value) | テクスチャ座標をエクスポートするかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportVertexDiffuse{#getExportVertexDiffuse}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExportVertexDiffuse() | 頂点の拡散色をエクスポートするかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportVertexDiffuse{#setExportVertexDiffuse}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExportVertexDiffuse(value) | 頂点の拡散色をエクスポートするかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportVertexSpecular{#getExportVertexSpecular}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExportVertexSpecular() | 頂点の鏡面色をエクスポートするかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportVertexSpecular{#setExportVertexSpecular}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExportVertexSpecular(value) | 頂点の鏡面色をエクスポートするかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEmbedTextures{#getEmbedTextures}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEmbedTextures() | 外部テクスチャをU3Dファイルに埋め込みます。デフォルト値は false です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setEmbedTextures{#setEmbedTextures}
+
+| 名前 | 説明 |
+| --- | --- |
+| setEmbedTextures(value) | 外部テクスチャをU3Dファイルに埋め込みます。デフォルト値は false です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportTextures{#getExportTextures}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExportTextures() | シーンで使用されているテクスチャを出力ディレクトリにコピーしようとします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextures{#setExportTextures}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExportTextures(value) | シーンで使用されているテクスチャを出力ディレクトリにコピーしようとします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileFormat() | 現在の保存/読み込みオプションで指定されたファイル形式を取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEncoding() | テキストベースのファイルのデフォルトエンコーディングを取得または設定します。デフォルト値は null で、インポーター/エクスポーターが使用するエンコーディングを決定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileSystem() | ロード/セーブ時に外部依存関係を管理する方法をユーザーが処理できるようにします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFileSystem(value) | ロード/セーブ時に外部依存関係を管理する方法をユーザーが処理できるようにします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| 名前 | 説明 |
+| --- | --- |
+| getLookupPaths() | OBJ のような一部のファイルは外部ファイルに依存しており、検索パスにより Aspose.3D が外部ファイルを探してロードできるようになります。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileName() | エクスポート/インポートシーンのファイル名です。これはオプションですが、OBJ のマテリアルなど外部アセットをシリアライズする際に便利です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFileName(value) | エクスポート/インポートシーンのファイル名です。これはオプションですが、OBJ のマテリアルなど外部アセットをシリアライズする際に便利です。 |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/usdsaveoptions/_index.md
+++ b/japanese/nodejs-java/aspose.threed/usdsaveoptions/_index.md
@@ -1,0 +1,237 @@
+---
+title: "UsdSaveOptions"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/usdsaveoptions/
+---
+## UsdSaveOptions class
+
+USD/USDZ フォーマットの保存オプション。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | FileFormat.USD フォーマットで新しい UsdSaveOptions を初期化します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload(fileFormat) | 指定された USD/USDZ フォーマットで新しい UsdSaveOptions を初期化します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getPrimitiveToMesh{#getPrimitiveToMesh}
+
+| 名前 | 説明 |
+| --- | --- |
+| getPrimitiveToMesh() | エクスポート時にプリミティブエンティティをメッシュに変換します。または、プリミティブを直接出力ファイルにエンコードします（Dish や Torus などの非公式プリミティブには Aspose の拡張定義が使用されます）。デフォルト値は true です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setPrimitiveToMesh{#setPrimitiveToMesh}
+
+| 名前 | 説明 |
+| --- | --- |
+| setPrimitiveToMesh(value) | エクスポート時にプリミティブエンティティをメッシュに変換します。または、プリミティブを直接出力ファイルにエンコードします（Dish や Torus などの非公式プリミティブには Aspose の拡張定義が使用されます）。デフォルト値は true です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportMetaData{#getExportMetaData}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExportMetaData() | USD の customData フィールドを介してノードのプロパティをエクスポートします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportMetaData{#setExportMetaData}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExportMetaData(value) | USD の customData フィールドを介してノードのプロパティをエクスポートします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getMaterialConverter{#getMaterialConverter}
+
+| 名前 | 説明 |
+| --- | --- |
+| getMaterialConverter() | ジオメトリのマテリアルを PBR マテリアルに変換するカスタムコンバータです。未割り当ての場合、USD エクスポーターは標準マテリアルを自動的に PBR マテリアルに変換します。デフォルト値は null です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setMaterialConverter{#setMaterialConverter}
+
+| 名前 | 説明 |
+| --- | --- |
+| setMaterialConverter(value) | ジオメトリのマテリアルを PBR マテリアルに変換するカスタムコンバータです。未割り当ての場合、USD エクスポーターは標準マテリアルを自動的に PBR マテリアルに変換します。デフォルト値は null です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportTextures{#getExportTextures}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExportTextures() | シーンで使用されているテクスチャを出力ディレクトリにコピーしようとします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextures{#setExportTextures}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExportTextures(value) | シーンで使用されているテクスチャを出力ディレクトリにコピーしようとします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileFormat() | 現在の保存/読み込みオプションで指定されたファイル形式を取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEncoding() | テキストベースのファイルのデフォルトエンコーディングを取得または設定します。デフォルト値は null で、インポーター/エクスポーターが使用するエンコーディングを決定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileSystem() | ロード/セーブ時に外部依存関係を管理する方法をユーザーが処理できるようにします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFileSystem(value) | ロード/セーブ時に外部依存関係を管理する方法をユーザーが処理できるようにします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| 名前 | 説明 |
+| --- | --- |
+| getLookupPaths() | OBJ のような一部のファイルは外部ファイルに依存しており、検索パスにより Aspose.3D が外部ファイルを探してロードできるようになります。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileName() | エクスポート/インポートシーンのファイル名です。これはオプションですが、OBJ のマテリアルなど外部アセットをシリアライズする際に便利です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFileName(value) | エクスポート/インポートシーンのファイル名です。これはオプションですが、OBJ のマテリアルなど外部アセットをシリアライズする際に便利です。 |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/ushape/_index.md
+++ b/japanese/nodejs-java/aspose.threed/ushape/_index.md
@@ -1,0 +1,437 @@
+---
+title: "UShape"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/ushape/
+---
+## UShape class
+
+IFC 互換の U 形状がパラメータで定義されました。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | UShape のコンストラクタ |
+
+ **Result:**
+
+
+
+---
+
+
+### getDepth{#getDepth}
+
+| 名前 | 説明 |
+| --- | --- |
+| getDepth() | ウェブの長さを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setDepth{#setDepth}
+
+| 名前 | 説明 |
+| --- | --- |
+| setDepth(value) | ウェブの長さを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlangeWidth{#getFlangeWidth}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFlangeWidth() | フランジの長さを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlangeWidth{#setFlangeWidth}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFlangeWidth(value) | フランジの長さを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getWebThickness{#getWebThickness}
+
+| 名前 | 説明 |
+| --- | --- |
+| getWebThickness() | ウェブの厚さを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setWebThickness{#setWebThickness}
+
+| 名前 | 説明 |
+| --- | --- |
+| setWebThickness(value) | ウェブの厚さを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlangeThickness{#getFlangeThickness}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFlangeThickness() | フランジの厚さを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlangeThickness{#setFlangeThickness}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFlangeThickness(value) | フランジの厚さを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFilletRadius{#getFilletRadius}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFilletRadius() | フランジとウェブの間のフィレット半径を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFilletRadius{#setFilletRadius}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFilletRadius(value) | フランジとウェブの間のフィレット半径を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEdgeRadius{#getEdgeRadius}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEdgeRadius() | フランジのエッジの半径を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setEdgeRadius{#setEdgeRadius}
+
+| 名前 | 説明 |
+| --- | --- |
+| setEdgeRadius(value) | フランジのエッジの半径を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNodes() | すべての親ノードを取得します。エンティティはジオメトリインスタンシングのために複数の親ノードにアタッチできます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExcluded() | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExcluded(value) | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNode() | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setParentNode(value) | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 名前 | 説明 |
+| --- | --- |
+| getScene() | このオブジェクトが属するシーンを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtent{#getExtent}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExtent() | x と y の次元での範囲を取得します |
+
+ **Result:**
+Vector2
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEntityRendererKey() | レンダラーに登録されたエンティティレンダラーのキーを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBoundingBox() | 現在のエンティティのオブジェクト空間座標系におけるバウンディングボックスを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/vector2/_index.md
+++ b/japanese/nodejs-java/aspose.threed/vector2/_index.md
@@ -1,0 +1,293 @@
+---
+title: "Vector2"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/vector2/
+---
+## Vector2 class
+
+2 つの成分を持つベクトル。
+
+
+## プロパティ
+
+| 名前 | 説明 |
+| --- | --- |
+| x | x 成分。 |
+| y | y 成分。 |
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload(s) | Vector2 構造体の新しいインスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| s | 数 | S. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload2(vec) | Vector2 構造体の新しいインスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| vec | FVector2 | float 型のベクトルです。 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload3{#constructor_overload3}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload3(x, y) | Vector2 構造体の新しいインスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| x | 数 | x座標。 |
+| y | 数 | y座標。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getU{#getU}
+
+| 名前 | 説明 |
+| --- | --- |
+| getU() | Vector2 がマッピング座標として使用される場合、U コンポーネントを取得または設定します。これは x コンポーネントのエイリアスです。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setU{#setU}
+
+| 名前 | 説明 |
+| --- | --- |
+| setU(value) | Vector2 がマッピング座標として使用される場合、U コンポーネントを取得または設定します。これは x コンポーネントのエイリアスです。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getV{#getV}
+
+| 名前 | 説明 |
+| --- | --- |
+| getV() | Vector2 がマッピング座標として使用される場合、V コンポーネントを取得または設定します。これは y コンポーネントのエイリアスです。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setV{#setV}
+
+| 名前 | 説明 |
+| --- | --- |
+| setV(value) | Vector2 がマッピング座標として使用される場合、V コンポーネントを取得または設定します。これは y コンポーネントのエイリアスです。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getLength{#getLength}
+
+| 名前 | 説明 |
+| --- | --- |
+| getLength() | 長さを取得します。長さです。 |
+
+ **Result:**
+
+
+
+---
+
+
+### dot{#dot}
+
+| 名前 | 説明 |
+| --- | --- |
+| dot(rhs) | 2つのベクトルのドット積を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| rhs | Vector2 | 右側の値です。 |
+
+ **Result:**
+数
+
+
+---
+
+
+### equals{#equals}
+
+| 名前 | 説明 |
+| --- | --- |
+| equals(rhs) | 2 つの vector2 が等しいか確認します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| rhs | Vector2 | 右辺の値です。 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### hashCode{#hashCode}
+
+| 名前 | 説明 |
+| --- | --- |
+| hashCode() | Vector2 のハッシュコードを取得します |
+
+ **Result:**
+数
+
+
+---
+
+
+### equals{#equals}
+
+| 名前 | 説明 |
+| --- | --- |
+| equals(obj) | 2 つの vector2 が等しいか確認します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| obj | オブジェクト | 比較対象のオブジェクトです。 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### toString{#toString}
+
+| 名前 | 説明 |
+| --- | --- |
+| toString() | 現在の Vector2 を表す java.lang.String を返します。 |
+
+ **Result:**
+文字列
+
+
+---
+
+
+### cross{#cross}
+
+| 名前 | 説明 |
+| --- | --- |
+| cross(v) | 2つのベクトルの外積 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+|  | Vector2 | null |
+
+ **Result:**
+数
+
+
+---
+
+
+### normalize{#normalize}
+
+| 名前 | 説明 |
+| --- | --- |
+| normalize() | このインスタンスを正規化します。 |
+
+ **Result:**
+Vector2
+
+
+---
+
+
+### compareTo{#compareTo}
+
+| 名前 | 説明 |
+| --- | --- |
+| compareTo(other) | 現在のベクトルを別のインスタンスと比較します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| othe | Vector2 | null |
+
+ **Result:**
+数
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/vector3/_index.md
+++ b/japanese/nodejs-java/aspose.threed/vector3/_index.md
@@ -1,0 +1,347 @@
+---
+title: "Vector3"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/vector3/
+---
+## Vector3 class
+
+3 つの成分を持つベクトル。
+
+
+## プロパティ
+
+| 名前 | 説明 |
+| --- | --- |
+| x | x 成分。 |
+| y | y 成分。 |
+| z | z 成分。 |
+| ORIGIN | 原点の位置を取得します。原点。 |
+| UNIT_SCALE | 単位スケールベクトルを取得します。 |
+| X_AXIS | X軸を取得します。X軸。 |
+| Y_AXIS | Y軸を取得します。Y軸。 |
+| Z_AXIS | Z軸を取得します。Z軸。 |
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload(x, y, z) | Vector3構造体の新しいインスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| x | 数 | x座標。 |
+| y | 数 | y座標。 |
+| z | 数 | z座標。 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload2(vec) | Vector3構造体の新しいインスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| vec | FVector3 | x座標。 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload3{#constructor_overload3}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload3(v) | Vector3構造体の新しいインスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| v | 数 | V. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload4{#constructor_overload4}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload4(vec4) | Vector3構造体の新しいインスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| vec4 | Vector4 | Vec4. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLength2{#getLength2}
+
+| 名前 | 説明 |
+| --- | --- |
+| getLength2() | 長さの二乗を取得します。length2。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getLength{#getLength}
+
+| 名前 | 説明 |
+| --- | --- |
+| getLength() | このベクトルの長さを取得します。長さ。 |
+
+ **Result:**
+
+
+
+---
+
+
+### equals{#equals}
+
+| 名前 | 説明 |
+| --- | --- |
+| equals(obj) | 2つの vector3 が等しいか確認します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| obj | オブジェクト | 等価性をチェックするオブジェクトです。 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### hashCode{#hashCode}
+
+| 名前 | 説明 |
+| --- | --- |
+| hashCode() | Vector3 のハッシュコードを取得します |
+
+ **Result:**
+数
+
+
+---
+
+
+### dot{#dot}
+
+| 名前 | 説明 |
+| --- | --- |
+| dot(rhs) | 2つのベクトルのドット積を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| rhs | Vector3 | 右側の値です。 |
+
+ **Result:**
+数
+
+
+---
+
+
+### normalize{#normalize}
+
+| 名前 | 説明 |
+| --- | --- |
+| normalize() | このインスタンスを正規化します。 |
+
+ **Result:**
+Vector3
+
+
+---
+
+
+### sin{#sin}
+
+| 名前 | 説明 |
+| --- | --- |
+| sin() | 各コンポーネントの正弦を計算します |
+
+ **Result:**
+Vector3
+
+
+---
+
+
+### cos{#cos}
+
+| 名前 | 説明 |
+| --- | --- |
+| cos() | 各コンポーネントの余弦を計算します |
+
+ **Result:**
+Vector3
+
+
+---
+
+
+### cross{#cross}
+
+| 名前 | 説明 |
+| --- | --- |
+| cross(rhs) | 2つのベクトルの外積 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| rhs | Vector3 | 右側の値です。 |
+
+ **Result:**
+Vector3
+
+
+---
+
+
+### set{#set}
+
+| 名前 | 説明 |
+| --- | --- |
+| set(newX, newY, newZ) | 1回の呼び出しで x/y/z コンポーネントを設定します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| newX | 数 | x 成分。 |
+| newY | 数 | y 成分。 |
+| newZ | 数 | z 成分。 |
+
+ **Result:**
+Vector3
+
+
+---
+
+
+### toString{#toString}
+
+| 名前 | 説明 |
+| --- | --- |
+| toString() | 現在の Vector3 を表す java.lang.String を返します。 |
+
+ **Result:**
+文字列
+
+
+---
+
+
+### angleBetween{#angleBetween}
+
+| 名前 | 説明 |
+| --- | --- |
+| angleBetween(dir, up) | 2つの方向間の内部角度を計算します。2つの方向は正規化されていないベクトルでも構いません。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| dir | Vector3 | 比較対象となる方向ベクトル |
+| up | Vector3 | 2つの方向が共有する平面の上方向ベクトル |
+
+ **Result:**
+数
+
+
+---
+
+
+### angleBetween{#angleBetween}
+
+| 名前 | 説明 |
+| --- | --- |
+| angleBetween(dir) | 2つの方向間の内部角度を計算します。2つの方向は正規化されていないベクトルでも構いません。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| dir | Vector3 | 比較対象となる方向ベクトル |
+
+ **Result:**
+数
+
+
+---
+
+
+### compareTo{#compareTo}
+
+| 名前 | 説明 |
+| --- | --- |
+| compareTo(other) | 現在のベクトルを別のインスタンスと比較します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| othe | Vector3 | null |
+
+ **Result:**
+数
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/vector4/_index.md
+++ b/japanese/nodejs-java/aspose.threed/vector4/_index.md
@@ -1,0 +1,246 @@
+---
+title: "Vector4"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/vector4/
+---
+## Vector4 class
+
+4 つの成分を持つベクトル。
+
+
+## プロパティ
+
+| 名前 | 説明 |
+| --- | --- |
+| x | x 成分。 |
+| y | y 成分。 |
+| z | z 成分。 |
+| w | w コンポーネントです。 |
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload(vec, w) | Vector4 構造体の新しいインスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| vec | Vector3 | Vec. |
+| w | 数 | 幅。 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload2(vec) | Vector4 構造体の新しいインスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| vec | Vector3 | Vec. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload3{#constructor_overload3}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload3(vec) | Vector4 構造体の新しいインスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| vec | FVector4 | Vec. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload4{#constructor_overload4}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload4(x, y, z) | Vector4 構造体の新しいインスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| x | 数 | x座標。 |
+| y | 数 | y座標。 |
+| z | 数 | z座標。 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload5{#constructor_overload5}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload5(x, y, z, w) | Vector4 構造体の新しいインスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| x | 数 | x座標。 |
+| y | 数 | y座標。 |
+| z | 数 | z座標。 |
+| w | 数 | 幅。 |
+
+ **Result:**
+
+
+
+---
+
+
+### set{#set}
+
+| 名前 | 説明 |
+| --- | --- |
+| set(newX, newY, newZ) | ベクトルの xyz 成分を一度に設定します。w は 1 に設定されます。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| newX | 数 | 新しい X 成分。 |
+| newY | 数 | 新しい Y 成分。 |
+| newZ | 数 | 新しい Z 成分。 |
+
+ **Result:**
+
+
+
+---
+
+
+### equals{#equals}
+
+| 名前 | 説明 |
+| --- | --- |
+| equals(obj) | 2つのベクトルが等しいか確認します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| ob | オブジェクト | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### hashCode{#hashCode}
+
+| 名前 | 説明 |
+| --- | --- |
+| hashCode() | このベクトルのハッシュコードを取得します |
+
+ **Result:**
+数
+
+
+---
+
+
+### set{#set}
+
+| 名前 | 説明 |
+| --- | --- |
+| set(newX, newY, newZ, newW) | ベクトルのすべての成分を一度に設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| newX | 数 | 新しい X 成分。 |
+| newY | 数 | 新しい Y 成分。 |
+| newZ | 数 | 新しい Z 成分。 |
+| newW | 数 | 新しい W コンポーネントです。 |
+
+ **Result:**
+数
+
+
+---
+
+
+### toString{#toString}
+
+| 名前 | 説明 |
+| --- | --- |
+| toString() | 現在の Vector4 を表す java.lang.String を返します。 |
+
+ **Result:**
+文字列
+
+
+---
+
+
+### compareTo{#compareTo}
+
+| 名前 | 説明 |
+| --- | --- |
+| compareTo(other) | 現在のベクトルを別のインスタンスと比較します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| othe | Vector4 | null |
+
+ **Result:**
+数
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/vertex/_index.md
+++ b/japanese/nodejs-java/aspose.threed/vertex/_index.md
@@ -1,0 +1,187 @@
+---
+title: "頂点"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/vertex/
+---
+## Vertex class
+
+TriMesh の生の頂点にアクセスするために使用される頂点参照。  @hideconstructor
+
+
+## メソッド
+
+### compareTo{#compareTo}
+
+| 名前 | 説明 |
+| --- | --- |
+| compareTo(other) | 頂点を別の頂点インスタンスと比較します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| othe | 頂点 | null |
+
+ **Result:**
+数
+
+
+---
+
+
+### readVector4{#readVector4}
+
+| 名前 | 説明 |
+| --- | --- |
+| readVector4(field) | vector4 フィールドを読み取ります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| フィールド | VertexField | Vector4/FVector4 データ型を持つフィールド |
+
+ **Result:**
+Vector4
+
+
+---
+
+
+### readFVector4{#readFVector4}
+
+| 名前 | 説明 |
+| --- | --- |
+| readFVector4(field) | vector4 フィールドを読み取ります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| フィールド | VertexField | Vector4/FVector4 データ型を持つフィールド |
+
+ **Result:**
+FVector4
+
+
+---
+
+
+### readVector3{#readVector3}
+
+| 名前 | 説明 |
+| --- | --- |
+| readVector3(field) | vector3 フィールドを読み取ります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| フィールド | VertexField | Vector3/FVector3 データ型のフィールド |
+
+ **Result:**
+Vector3
+
+
+---
+
+
+### readFVector3{#readFVector3}
+
+| 名前 | 説明 |
+| --- | --- |
+| readFVector3(field) | vector3 フィールドを読み取ります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| フィールド | VertexField | Vector3/FVector3 データ型のフィールド |
+
+ **Result:**
+FVector3
+
+
+---
+
+
+### readVector2{#readVector2}
+
+| 名前 | 説明 |
+| --- | --- |
+| readVector2(field) | vector2 フィールドを読み取ります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| フィールド | VertexField | Vector2/FVector2 データ型のフィールド |
+
+ **Result:**
+Vector2
+
+
+---
+
+
+### readFVector2{#readFVector2}
+
+| 名前 | 説明 |
+| --- | --- |
+| readFVector2(field) | vector2 フィールドを読み取ります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| フィールド | VertexField | Vector2/FVector2 データ型のフィールド |
+
+ **Result:**
+FVector2
+
+
+---
+
+
+### readDouble{#readDouble}
+
+| 名前 | 説明 |
+| --- | --- |
+| readDouble(field) | double フィールドを読み取ります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| フィールド | VertexField | float/double 互換データ型のフィールド |
+
+ **Result:**
+数
+
+
+---
+
+
+### readFloat{#readFloat}
+
+| 名前 | 説明 |
+| --- | --- |
+| readFloat(field) | float フィールドを読み取ります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| フィールド | VertexField | float/double 互換データ型のフィールド |
+
+ **Result:**
+数
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/vertexdeclaration/_index.md
+++ b/japanese/nodejs-java/aspose.threed/vertexdeclaration/_index.md
@@ -1,0 +1,201 @@
+---
+title: "VertexDeclaration"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/vertexdeclaration/
+---
+## VertexDeclaration class
+
+カスタム定義された頂点構造の宣言
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getSealed{#getSealed}
+
+| 名前 | 説明 |
+| --- | --- |
+| getSealed() | VertexDeclaration は com.aspose.threed.TriMesh`1 または TriMesh に使用されたときにシールドされ、これ以上の変更は許可されません。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getCount{#getCount}
+
+| 名前 | 説明 |
+| --- | --- |
+| getCount() | この VertexDeclaration で定義されたすべてのフィールドの数を取得します |
+
+ **Result:**
+
+
+
+---
+
+
+### getSize{#getSize}
+
+| 名前 | 説明 |
+| --- | --- |
+| getSize() | 頂点構造体のバイト単位のサイズです。 |
+
+ **Result:**
+
+
+
+---
+
+
+### get{#get}
+
+| 名前 | 説明 |
+| --- | --- |
+| get(index) |  |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| 名前 | 説明 |
+| --- | --- |
+| clear() | すべてのフィールドをクリアします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### addField{#addField}
+
+| 名前 | 説明 |
+| --- | --- |
+| addField(dataType, semantic, index, alias) | 新しい頂点フィールドを追加します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| dataType | 数 | VertexFieldDataType |
+| semantic | VertexFieldSemantic | VertexFieldSemantic |
+| index | 数 | 同じフィールドのセマンティックのインデックス、-1 は自動生成を意味します |
+| alias | 文字列 | フィールドのエイリアス名です |
+
+ **Result:**
+
+
+
+---
+
+
+### fromGeometry{#fromGeometry}
+
+| 名前 | 説明 |
+| --- | --- |
+| fromGeometry(geometry, useFloat) | Geometry のレイアウトに基づいて VertexDeclaration を作成します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| geometr | ジオメトリ | null |
+| useFloat | boolean | double 型の代わりに float を使用します |
+
+ **Result:**
+VertexDeclaration
+
+
+---
+
+
+### compareTo{#compareTo}
+
+| 名前 | 説明 |
+| --- | --- |
+| compareTo(other) | このインスタンスを指定されたオブジェクトと比較し、相対的な値の指標を返します。 |
+
+ **Result:**
+VertexDeclaration
+
+
+---
+
+
+### toString{#toString}
+
+| 名前 | 説明 |
+| --- | --- |
+| toString() |  |
+
+ **Result:**
+文字列
+
+
+---
+
+
+### hashCode{#hashCode}
+
+| 名前 | 説明 |
+| --- | --- |
+| hashCode() |  |
+
+ **Result:**
+数
+
+
+---
+
+
+### equals{#equals}
+
+| 名前 | 説明 |
+| --- | --- |
+| equals(obj) | このインスタンスと、VertexDeclaration オブジェクトである必要がある指定されたオブジェクトが同じ値かどうかを判断します。 |
+
+ **Result:**
+数
+
+
+---
+
+
+### iterator{#iterator}
+
+| 名前 | 説明 |
+| --- | --- |
+| iterator() | 内部使用のために予約されています。 |
+
+ **Result:**
+数
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/vertexelement/_index.md
+++ b/japanese/nodejs-java/aspose.threed/vertexelement/_index.md
@@ -1,0 +1,165 @@
+---
+title: "VertexElement"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/vertexelement/
+---
+## VertexElement class
+
+頂点要素の基底クラス。頂点要素のタイプは VertexElementType によって識別されます。VertexElement は頂点要素がジオメトリ表面にどのようにマッピングされ、マッピング情報がメモリ上でどのように配置されるかを記述します。VertexElement は Normals、UVs、またはその他の情報を含みます。  @hideconstructor
+
+
+## メソッド
+
+### getVertexElementType{#getVertexElementType}
+
+| 名前 | 説明 |
+| --- | --- |
+| getVertexElementType() | VertexElement のタイプを取得します。プロパティの値は VertexElementType の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getMappingMode() | 要素がどのようにマッピングされるかを取得または設定します。プロパティの値は MappingMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setMappingMode(value) | 要素がどのようにマッピングされるかを取得または設定します。プロパティの値は MappingMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getReferenceMode() | 要素がどのように参照されるかを取得または設定します。プロパティの値は ReferenceMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setReferenceMode(value) | 要素がどのように参照されるかを取得または設定します。プロパティの値は ReferenceMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| 名前 | 説明 |
+| --- | --- |
+| getIndices() | インデックスデータを取得します。インデックス配列です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| 名前 | 説明 |
+| --- | --- |
+| setIndices(data) | インデックスをロードします |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| dat | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| 名前 | 説明 |
+| --- | --- |
+| clear() | この頂点要素のすべてのデータをクリアします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| 名前 | 説明 |
+| --- | --- |
+| toString() | 頂点要素の文字列表現です。 |
+
+ **Result:**
+文字列
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/vertexelementbinormal/_index.md
+++ b/japanese/nodejs-java/aspose.threed/vertexelementbinormal/_index.md
@@ -1,0 +1,229 @@
+---
+title: "VertexElementBinormal"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/vertexelementbinormal/
+---
+## VertexElementBinormal class
+
+指定された成分の従法線ベクトルを定義します。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | VertexElementBinormal クラスの新しいインスタンスを初期化します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getData{#getData}
+
+| 名前 | 説明 |
+| --- | --- |
+| getData() | 頂点データを取得します |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| 名前 | 説明 |
+| --- | --- |
+| getVertexElementType() | VertexElement のタイプを取得します。プロパティの値は VertexElementType の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getMappingMode() | 要素がどのようにマッピングされるかを取得または設定します。プロパティの値は MappingMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setMappingMode(value) | 要素がどのようにマッピングされるかを取得または設定します。プロパティの値は MappingMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getReferenceMode() | 要素がどのように参照されるかを取得または設定します。プロパティの値は ReferenceMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setReferenceMode(value) | 要素がどのように参照されるかを取得または設定します。プロパティの値は ReferenceMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| 名前 | 説明 |
+| --- | --- |
+| getIndices() | インデックスデータを取得します。インデックス配列です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### copyTo{#copyTo}
+
+| 名前 | 説明 |
+| --- | --- |
+| copyTo(target) | 指定された要素にデータをコピーします |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| ターゲット | VertexElementVector4 | ターゲット。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setData{#setData}
+
+| 名前 | 説明 |
+| --- | --- |
+| setData(data) | データをロードします |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| dat | Vector4[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| 名前 | 説明 |
+| --- | --- |
+| clear() | 直接配列とインデックス配列からすべての要素を削除します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| 名前 | 説明 |
+| --- | --- |
+| setIndices(data) | インデックスをロードします |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| dat | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| 名前 | 説明 |
+| --- | --- |
+| toString() | 頂点要素の文字列表現です。 |
+
+ **Result:**
+文字列
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/vertexelementdoublestemplate/_index.md
+++ b/japanese/nodejs-java/aspose.threed/vertexelementdoublestemplate/_index.md
@@ -1,0 +1,216 @@
+---
+title: "VertexElementDoublesTemplate"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/vertexelementdoublestemplate/
+---
+## VertexElementDoublesTemplate class
+
+具体的な VertexElement 実装を定義するためのヘルパークラス。  @hideconstructor
+
+
+## メソッド
+
+### getData{#getData}
+
+| 名前 | 説明 |
+| --- | --- |
+| getData() | 頂点データを取得します |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| 名前 | 説明 |
+| --- | --- |
+| getVertexElementType() | VertexElement のタイプを取得します。プロパティの値は VertexElementType の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getMappingMode() | 要素がどのようにマッピングされるかを取得または設定します。プロパティの値は MappingMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setMappingMode(value) | 要素がどのようにマッピングされるかを取得または設定します。プロパティの値は MappingMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getReferenceMode() | 要素がどのように参照されるかを取得または設定します。プロパティの値は ReferenceMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setReferenceMode(value) | 要素がどのように参照されるかを取得または設定します。プロパティの値は ReferenceMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| 名前 | 説明 |
+| --- | --- |
+| getIndices() | インデックスデータを取得します。インデックス配列です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### copyTo{#copyTo}
+
+| 名前 | 説明 |
+| --- | --- |
+| copyTo(target) | 指定された要素にデータをコピーします |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| ターゲット | VertexElementDoublesTemplate | ターゲット。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setData{#setData}
+
+| 名前 | 説明 |
+| --- | --- |
+| setData(data) | データをロードします |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| dat | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| 名前 | 説明 |
+| --- | --- |
+| clear() | 直接配列とインデックス配列からすべての要素を削除します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| 名前 | 説明 |
+| --- | --- |
+| setIndices(data) | インデックスをロードします |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| dat | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| 名前 | 説明 |
+| --- | --- |
+| toString() | 頂点要素の文字列表現です。 |
+
+ **Result:**
+文字列
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/vertexelementedgecrease/_index.md
+++ b/japanese/nodejs-java/aspose.threed/vertexelementedgecrease/_index.md
@@ -1,0 +1,229 @@
+---
+title: "VertexElementEdgeCrease"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/vertexelementedgecrease/
+---
+## VertexElementEdgeCrease class
+
+指定された成分のエッジクレーズを定義します
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | VertexElementEdgeCrease クラスの新しいインスタンスを初期化します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getData{#getData}
+
+| 名前 | 説明 |
+| --- | --- |
+| getData() | 頂点データを取得します |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| 名前 | 説明 |
+| --- | --- |
+| getVertexElementType() | VertexElement のタイプを取得します。プロパティの値は VertexElementType の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getMappingMode() | 要素がどのようにマッピングされるかを取得または設定します。プロパティの値は MappingMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setMappingMode(value) | 要素がどのようにマッピングされるかを取得または設定します。プロパティの値は MappingMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getReferenceMode() | 要素がどのように参照されるかを取得または設定します。プロパティの値は ReferenceMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setReferenceMode(value) | 要素がどのように参照されるかを取得または設定します。プロパティの値は ReferenceMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| 名前 | 説明 |
+| --- | --- |
+| getIndices() | インデックスデータを取得します。インデックス配列です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### copyTo{#copyTo}
+
+| 名前 | 説明 |
+| --- | --- |
+| copyTo(target) | 指定された要素にデータをコピーします |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| ターゲット | VertexElementDoublesTemplate | ターゲット。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setData{#setData}
+
+| 名前 | 説明 |
+| --- | --- |
+| setData(data) | データをロードします |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| dat | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| 名前 | 説明 |
+| --- | --- |
+| clear() | 直接配列とインデックス配列からすべての要素を削除します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| 名前 | 説明 |
+| --- | --- |
+| setIndices(data) | インデックスをロードします |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| dat | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| 名前 | 説明 |
+| --- | --- |
+| toString() | 頂点要素の文字列表現です。 |
+
+ **Result:**
+文字列
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/vertexelementhole/_index.md
+++ b/japanese/nodejs-java/aspose.threed/vertexelementhole/_index.md
@@ -1,0 +1,191 @@
+---
+title: "VertexElementHole"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/vertexelementhole/
+---
+## VertexElementHole class
+
+指定されたポリゴンが穴であるかどうかを定義します
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | VertexElementHole クラスの新しいインスタンスを初期化します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getData{#getData}
+
+| 名前 | 説明 |
+| --- | --- |
+| getData() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| 名前 | 説明 |
+| --- | --- |
+| getVertexElementType() | VertexElement のタイプを取得します。プロパティの値は VertexElementType の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getMappingMode() | 要素がどのようにマッピングされるかを取得または設定します。プロパティの値は MappingMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setMappingMode(value) | 要素がどのようにマッピングされるかを取得または設定します。プロパティの値は MappingMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getReferenceMode() | 要素がどのように参照されるかを取得または設定します。プロパティの値は ReferenceMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setReferenceMode(value) | 要素がどのように参照されるかを取得または設定します。プロパティの値は ReferenceMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| 名前 | 説明 |
+| --- | --- |
+| getIndices() | インデックスデータを取得します。インデックス配列です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| 名前 | 説明 |
+| --- | --- |
+| clear() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| 名前 | 説明 |
+| --- | --- |
+| setIndices(data) | インデックスをロードします |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| dat | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| 名前 | 説明 |
+| --- | --- |
+| toString() | 頂点要素の文字列表現です。 |
+
+ **Result:**
+文字列
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/vertexelementintstemplate/_index.md
+++ b/japanese/nodejs-java/aspose.threed/vertexelementintstemplate/_index.md
@@ -1,0 +1,216 @@
+---
+title: "VertexElementIntsTemplate"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/vertexelementintstemplate/
+---
+## VertexElementIntsTemplate class
+
+具体的な VertexElement 実装を定義するためのヘルパークラス。  @hideconstructor
+
+
+## メソッド
+
+### getData{#getData}
+
+| 名前 | 説明 |
+| --- | --- |
+| getData() | 頂点データを取得します |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| 名前 | 説明 |
+| --- | --- |
+| getVertexElementType() | VertexElement のタイプを取得します。プロパティの値は VertexElementType の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getMappingMode() | 要素がどのようにマッピングされるかを取得または設定します。プロパティの値は MappingMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setMappingMode(value) | 要素がどのようにマッピングされるかを取得または設定します。プロパティの値は MappingMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getReferenceMode() | 要素がどのように参照されるかを取得または設定します。プロパティの値は ReferenceMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setReferenceMode(value) | 要素がどのように参照されるかを取得または設定します。プロパティの値は ReferenceMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| 名前 | 説明 |
+| --- | --- |
+| getIndices() | インデックスデータを取得します。インデックス配列です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### copyTo{#copyTo}
+
+| 名前 | 説明 |
+| --- | --- |
+| copyTo(target) | 指定された要素にデータをコピーします |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| ターゲット | VertexElementIntsTemplate | ターゲット。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setData{#setData}
+
+| 名前 | 説明 |
+| --- | --- |
+| setData(data) | データをロードします |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| dat | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| 名前 | 説明 |
+| --- | --- |
+| clear() | 直接配列とインデックス配列からすべての要素を削除します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| 名前 | 説明 |
+| --- | --- |
+| setIndices(data) | インデックスをロードします |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| dat | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| 名前 | 説明 |
+| --- | --- |
+| toString() | 頂点要素の文字列表現です。 |
+
+ **Result:**
+文字列
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/vertexelementmaterial/_index.md
+++ b/japanese/nodejs-java/aspose.threed/vertexelementmaterial/_index.md
@@ -1,0 +1,178 @@
+---
+title: "VertexElementMaterial"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/vertexelementmaterial/
+---
+## VertexElementMaterial class
+
+指定された成分のマテリアルインデックスを定義します。ノードは複数のマテリアルを持つことができ、VertexElementMaterial はジオメトリの異なる部分を異なるマテリアルでレンダリングするために使用されます。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | VertexElementMaterial クラスの新しいインスタンスを初期化します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| 名前 | 説明 |
+| --- | --- |
+| getVertexElementType() | VertexElement のタイプを取得します。プロパティの値は VertexElementType の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getMappingMode() | 要素がどのようにマッピングされるかを取得または設定します。プロパティの値は MappingMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setMappingMode(value) | 要素がどのようにマッピングされるかを取得または設定します。プロパティの値は MappingMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getReferenceMode() | 要素がどのように参照されるかを取得または設定します。プロパティの値は ReferenceMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setReferenceMode(value) | 要素がどのように参照されるかを取得または設定します。プロパティの値は ReferenceMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| 名前 | 説明 |
+| --- | --- |
+| getIndices() | インデックスデータを取得します。インデックス配列です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| 名前 | 説明 |
+| --- | --- |
+| clear() | 直接配列とインデックス配列からすべての要素を削除します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| 名前 | 説明 |
+| --- | --- |
+| setIndices(data) | インデックスをロードします |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| dat | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| 名前 | 説明 |
+| --- | --- |
+| toString() | 頂点要素の文字列表現です。 |
+
+ **Result:**
+文字列
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/vertexelementnormal/_index.md
+++ b/japanese/nodejs-java/aspose.threed/vertexelementnormal/_index.md
@@ -1,0 +1,229 @@
+---
+title: "VertexElementNormal"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/vertexelementnormal/
+---
+## VertexElementNormal class
+
+指定された成分の法線ベクトルを定義します。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | VertexElementNormal クラスの新しいインスタンスを初期化します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getData{#getData}
+
+| 名前 | 説明 |
+| --- | --- |
+| getData() | 頂点データを取得します |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| 名前 | 説明 |
+| --- | --- |
+| getVertexElementType() | VertexElement のタイプを取得します。プロパティの値は VertexElementType の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getMappingMode() | 要素がどのようにマッピングされるかを取得または設定します。プロパティの値は MappingMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setMappingMode(value) | 要素がどのようにマッピングされるかを取得または設定します。プロパティの値は MappingMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getReferenceMode() | 要素がどのように参照されるかを取得または設定します。プロパティの値は ReferenceMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setReferenceMode(value) | 要素がどのように参照されるかを取得または設定します。プロパティの値は ReferenceMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| 名前 | 説明 |
+| --- | --- |
+| getIndices() | インデックスデータを取得します。インデックス配列です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### copyTo{#copyTo}
+
+| 名前 | 説明 |
+| --- | --- |
+| copyTo(target) | 指定された要素にデータをコピーします |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| ターゲット | VertexElementVector4 | ターゲット。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setData{#setData}
+
+| 名前 | 説明 |
+| --- | --- |
+| setData(data) | データをロードします |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| dat | Vector4[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| 名前 | 説明 |
+| --- | --- |
+| clear() | 直接配列とインデックス配列からすべての要素を削除します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| 名前 | 説明 |
+| --- | --- |
+| setIndices(data) | インデックスをロードします |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| dat | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| 名前 | 説明 |
+| --- | --- |
+| toString() | 頂点要素の文字列表現です。 |
+
+ **Result:**
+文字列
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/vertexelementpolygongroup/_index.md
+++ b/japanese/nodejs-java/aspose.threed/vertexelementpolygongroup/_index.md
@@ -1,0 +1,229 @@
+---
+title: "VertexElementPolygonGroup"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/vertexelementpolygongroup/
+---
+## VertexElementPolygonGroup class
+
+指定された成分のポリゴングループを定義し、関連するポリゴンをまとめます。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | VertexElementPolygonGroup クラスの新しいインスタンスを初期化します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getData{#getData}
+
+| 名前 | 説明 |
+| --- | --- |
+| getData() | 頂点データを取得します |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| 名前 | 説明 |
+| --- | --- |
+| getVertexElementType() | VertexElement のタイプを取得します。プロパティの値は VertexElementType の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getMappingMode() | 要素がどのようにマッピングされるかを取得または設定します。プロパティの値は MappingMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setMappingMode(value) | 要素がどのようにマッピングされるかを取得または設定します。プロパティの値は MappingMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getReferenceMode() | 要素がどのように参照されるかを取得または設定します。プロパティの値は ReferenceMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setReferenceMode(value) | 要素がどのように参照されるかを取得または設定します。プロパティの値は ReferenceMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| 名前 | 説明 |
+| --- | --- |
+| getIndices() | インデックスデータを取得します。インデックス配列です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### copyTo{#copyTo}
+
+| 名前 | 説明 |
+| --- | --- |
+| copyTo(target) | 指定された要素にデータをコピーします |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| ターゲット | VertexElementIntsTemplate | ターゲット。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setData{#setData}
+
+| 名前 | 説明 |
+| --- | --- |
+| setData(data) | データをロードします |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| dat | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| 名前 | 説明 |
+| --- | --- |
+| clear() | 直接配列とインデックス配列からすべての要素を削除します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| 名前 | 説明 |
+| --- | --- |
+| setIndices(data) | インデックスをロードします |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| dat | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| 名前 | 説明 |
+| --- | --- |
+| toString() | 頂点要素の文字列表現です。 |
+
+ **Result:**
+文字列
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/vertexelementsmoothinggroup/_index.md
+++ b/japanese/nodejs-java/aspose.threed/vertexelementsmoothinggroup/_index.md
@@ -1,0 +1,229 @@
+---
+title: "VertexElementSmoothingGroup"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/vertexelementsmoothinggroup/
+---
+## VertexElementSmoothingGroup class
+
+スムージンググループは、滑らかな表面を形成するように見えるポリゴンメッシュ内のポリゴンの集合です。DOS 用 3D Studio Max のような初期の 3D モデリングソフトウェアは、各メッシュ頂点の法線ベクトルの保存を回避するためにスムージンググループを使用していました。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | VertexElementSmoothingGroup クラスの新しいインスタンスを初期化します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getData{#getData}
+
+| 名前 | 説明 |
+| --- | --- |
+| getData() | 頂点データを取得します |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| 名前 | 説明 |
+| --- | --- |
+| getVertexElementType() | VertexElement のタイプを取得します。プロパティの値は VertexElementType の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getMappingMode() | 要素がどのようにマッピングされるかを取得または設定します。プロパティの値は MappingMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setMappingMode(value) | 要素がどのようにマッピングされるかを取得または設定します。プロパティの値は MappingMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getReferenceMode() | 要素がどのように参照されるかを取得または設定します。プロパティの値は ReferenceMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setReferenceMode(value) | 要素がどのように参照されるかを取得または設定します。プロパティの値は ReferenceMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| 名前 | 説明 |
+| --- | --- |
+| getIndices() | インデックスデータを取得します。インデックス配列です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### copyTo{#copyTo}
+
+| 名前 | 説明 |
+| --- | --- |
+| copyTo(target) | 指定された要素にデータをコピーします |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| ターゲット | VertexElementIntsTemplate | ターゲット。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setData{#setData}
+
+| 名前 | 説明 |
+| --- | --- |
+| setData(data) | データをロードします |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| dat | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| 名前 | 説明 |
+| --- | --- |
+| clear() | 直接配列とインデックス配列からすべての要素を削除します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| 名前 | 説明 |
+| --- | --- |
+| setIndices(data) | インデックスをロードします |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| dat | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| 名前 | 説明 |
+| --- | --- |
+| toString() | 頂点要素の文字列表現です。 |
+
+ **Result:**
+文字列
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/vertexelementspecular/_index.md
+++ b/japanese/nodejs-java/aspose.threed/vertexelementspecular/_index.md
@@ -1,0 +1,229 @@
+---
+title: "VertexElementSpecular"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/vertexelementspecular/
+---
+## VertexElementSpecular class
+
+指定された成分の鏡面色を定義します。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | VertexElementSpecular クラスの新しいインスタンスを初期化します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getData{#getData}
+
+| 名前 | 説明 |
+| --- | --- |
+| getData() | 頂点データを取得します |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| 名前 | 説明 |
+| --- | --- |
+| getVertexElementType() | VertexElement のタイプを取得します。プロパティの値は VertexElementType の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getMappingMode() | 要素がどのようにマッピングされるかを取得または設定します。プロパティの値は MappingMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setMappingMode(value) | 要素がどのようにマッピングされるかを取得または設定します。プロパティの値は MappingMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getReferenceMode() | 要素がどのように参照されるかを取得または設定します。プロパティの値は ReferenceMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setReferenceMode(value) | 要素がどのように参照されるかを取得または設定します。プロパティの値は ReferenceMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| 名前 | 説明 |
+| --- | --- |
+| getIndices() | インデックスデータを取得します。インデックス配列です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### copyTo{#copyTo}
+
+| 名前 | 説明 |
+| --- | --- |
+| copyTo(target) | 指定された要素にデータをコピーします |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| ターゲット | VertexElementVector4 | ターゲット。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setData{#setData}
+
+| 名前 | 説明 |
+| --- | --- |
+| setData(data) | データをロードします |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| dat | Vector4[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| 名前 | 説明 |
+| --- | --- |
+| clear() | 直接配列とインデックス配列からすべての要素を削除します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| 名前 | 説明 |
+| --- | --- |
+| setIndices(data) | インデックスをロードします |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| dat | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| 名前 | 説明 |
+| --- | --- |
+| toString() | 頂点要素の文字列表現です。 |
+
+ **Result:**
+文字列
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/vertexelementtangent/_index.md
+++ b/japanese/nodejs-java/aspose.threed/vertexelementtangent/_index.md
@@ -1,0 +1,229 @@
+---
+title: "VertexElementTangent"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/vertexelementtangent/
+---
+## VertexElementTangent class
+
+指定された成分の接線ベクトルを定義します。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | VertexElementTangentクラスの新しいインスタンスを初期化します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getData{#getData}
+
+| 名前 | 説明 |
+| --- | --- |
+| getData() | 頂点データを取得します |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| 名前 | 説明 |
+| --- | --- |
+| getVertexElementType() | VertexElement のタイプを取得します。プロパティの値は VertexElementType の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getMappingMode() | 要素がどのようにマッピングされるかを取得または設定します。プロパティの値は MappingMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setMappingMode(value) | 要素がどのようにマッピングされるかを取得または設定します。プロパティの値は MappingMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getReferenceMode() | 要素がどのように参照されるかを取得または設定します。プロパティの値は ReferenceMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setReferenceMode(value) | 要素がどのように参照されるかを取得または設定します。プロパティの値は ReferenceMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| 名前 | 説明 |
+| --- | --- |
+| getIndices() | インデックスデータを取得します。インデックス配列です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### copyTo{#copyTo}
+
+| 名前 | 説明 |
+| --- | --- |
+| copyTo(target) | 指定された要素にデータをコピーします |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| ターゲット | VertexElementVector4 | ターゲット。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setData{#setData}
+
+| 名前 | 説明 |
+| --- | --- |
+| setData(data) | データをロードします |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| dat | Vector4[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| 名前 | 説明 |
+| --- | --- |
+| clear() | 直接配列とインデックス配列からすべての要素を削除します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| 名前 | 説明 |
+| --- | --- |
+| setIndices(data) | インデックスをロードします |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| dat | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| 名前 | 説明 |
+| --- | --- |
+| toString() | 頂点要素の文字列表現です。 |
+
+ **Result:**
+文字列
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/vertexelementuserdata/_index.md
+++ b/japanese/nodejs-java/aspose.threed/vertexelementuserdata/_index.md
@@ -1,0 +1,204 @@
+---
+title: "VertexElementUserData"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/vertexelementuserdata/
+---
+## VertexElementUserData class
+
+指定された成分のカスタムユーザーデータを定義します。通常、これは特定の目的のためのアプリケーション固有データです。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | VertexElementUserData クラスの新しいインスタンスを初期化します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getData{#getData}
+
+| 名前 | 説明 |
+| --- | --- |
+| getData() | この要素に添付されたユーザーデータ |
+
+ **Result:**
+
+
+
+---
+
+
+### setData{#setData}
+
+| 名前 | 説明 |
+| --- | --- |
+| setData(value) | この要素に添付されたユーザーデータ |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| 名前 | 説明 |
+| --- | --- |
+| getVertexElementType() | VertexElement のタイプを取得します。プロパティの値は VertexElementType の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getMappingMode() | 要素がどのようにマッピングされるかを取得または設定します。プロパティの値は MappingMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setMappingMode(value) | 要素がどのようにマッピングされるかを取得または設定します。プロパティの値は MappingMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getReferenceMode() | 要素がどのように参照されるかを取得または設定します。プロパティの値は ReferenceMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setReferenceMode(value) | 要素がどのように参照されるかを取得または設定します。プロパティの値は ReferenceMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| 名前 | 説明 |
+| --- | --- |
+| getIndices() | インデックスデータを取得します。インデックス配列です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| 名前 | 説明 |
+| --- | --- |
+| clear() | この頂点要素のすべてのデータをクリアします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| 名前 | 説明 |
+| --- | --- |
+| setIndices(data) | インデックスをロードします |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| dat | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| 名前 | 説明 |
+| --- | --- |
+| toString() | 頂点要素の文字列表現です。 |
+
+ **Result:**
+文字列
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/vertexelementuv/_index.md
+++ b/japanese/nodejs-java/aspose.threed/vertexelementuv/_index.md
@@ -1,0 +1,248 @@
+---
+title: "VertexElementUV"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/vertexelementuv/
+---
+## VertexElementUV class
+
+指定された成分の UV 座標を定義します。ジオメトリは複数の VertexElementUV 要素を持つことができ、各要素は異なる TextureMappings を持ちます。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | VertexElementUV クラスの新しいインスタンスを初期化します。デフォルトのテクスチャマッピングタイプは TextureMapping.DIFFUSE です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor_overload(textureMapping) | VertexElementUV クラスの新しいインスタンスを初期化します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| textureMapping | TextureMapping | TextureMapping |
+
+ **Result:**
+
+
+
+---
+
+
+### getData{#getData}
+
+| 名前 | 説明 |
+| --- | --- |
+| getData() | 頂点データを取得します |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| 名前 | 説明 |
+| --- | --- |
+| getVertexElementType() | VertexElement のタイプを取得します。プロパティの値は VertexElementType の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getMappingMode() | 要素がどのようにマッピングされるかを取得または設定します。プロパティの値は MappingMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setMappingMode(value) | 要素がどのようにマッピングされるかを取得または設定します。プロパティの値は MappingMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getReferenceMode() | 要素がどのように参照されるかを取得または設定します。プロパティの値は ReferenceMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setReferenceMode(value) | 要素がどのように参照されるかを取得または設定します。プロパティの値は ReferenceMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| 名前 | 説明 |
+| --- | --- |
+| getIndices() | インデックスデータを取得します。インデックス配列です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### copyTo{#copyTo}
+
+| 名前 | 説明 |
+| --- | --- |
+| copyTo(target) | 指定された要素にデータをコピーします |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| ターゲット | VertexElementVector4 | ターゲット。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setData{#setData}
+
+| 名前 | 説明 |
+| --- | --- |
+| setData(data) | データをロードします |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| dat | Vector4[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| 名前 | 説明 |
+| --- | --- |
+| clear() | 直接配列とインデックス配列からすべての要素を削除します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| 名前 | 説明 |
+| --- | --- |
+| setIndices(data) | インデックスをロードします |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| dat | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| 名前 | 説明 |
+| --- | --- |
+| toString() | 頂点要素の文字列表現です。 |
+
+ **Result:**
+文字列
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/vertexelementvector4/_index.md
+++ b/japanese/nodejs-java/aspose.threed/vertexelementvector4/_index.md
@@ -1,0 +1,216 @@
+---
+title: "VertexElementVector4"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/vertexelementvector4/
+---
+## VertexElementVector4 class
+
+具体的な VertexElement 実装を定義するためのヘルパークラス。  @hideconstructor
+
+
+## メソッド
+
+### getData{#getData}
+
+| 名前 | 説明 |
+| --- | --- |
+| getData() | 頂点データを取得します |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| 名前 | 説明 |
+| --- | --- |
+| getVertexElementType() | VertexElement のタイプを取得します。プロパティの値は VertexElementType の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getMappingMode() | 要素がどのようにマッピングされるかを取得または設定します。プロパティの値は MappingMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setMappingMode(value) | 要素がどのようにマッピングされるかを取得または設定します。プロパティの値は MappingMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getReferenceMode() | 要素がどのように参照されるかを取得または設定します。プロパティの値は ReferenceMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setReferenceMode(value) | 要素がどのように参照されるかを取得または設定します。プロパティの値は ReferenceMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| 名前 | 説明 |
+| --- | --- |
+| getIndices() | インデックスデータを取得します。インデックス配列です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### copyTo{#copyTo}
+
+| 名前 | 説明 |
+| --- | --- |
+| copyTo(target) | 指定された要素にデータをコピーします |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| ターゲット | VertexElementVector4 | ターゲット。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setData{#setData}
+
+| 名前 | 説明 |
+| --- | --- |
+| setData(data) | データをロードします |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| dat | Vector4[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| 名前 | 説明 |
+| --- | --- |
+| clear() | 直接配列とインデックス配列からすべての要素を削除します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| 名前 | 説明 |
+| --- | --- |
+| setIndices(data) | インデックスをロードします |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| dat | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| 名前 | 説明 |
+| --- | --- |
+| toString() | 頂点要素の文字列表現です。 |
+
+ **Result:**
+文字列
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/vertexelementvertexcolor/_index.md
+++ b/japanese/nodejs-java/aspose.threed/vertexelementvertexcolor/_index.md
@@ -1,0 +1,229 @@
+---
+title: "VertexElementVertexColor"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/vertexelementvertexcolor/
+---
+## VertexElementVertexColor class
+
+指定された成分の頂点カラーを定義します
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | VertexElementVertexColor クラスの新しいインスタンスを初期化します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getData{#getData}
+
+| 名前 | 説明 |
+| --- | --- |
+| getData() | 頂点データを取得します |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| 名前 | 説明 |
+| --- | --- |
+| getVertexElementType() | VertexElement のタイプを取得します。プロパティの値は VertexElementType の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getMappingMode() | 要素がどのようにマッピングされるかを取得または設定します。プロパティの値は MappingMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setMappingMode(value) | 要素がどのようにマッピングされるかを取得または設定します。プロパティの値は MappingMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getReferenceMode() | 要素がどのように参照されるかを取得または設定します。プロパティの値は ReferenceMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setReferenceMode(value) | 要素がどのように参照されるかを取得または設定します。プロパティの値は ReferenceMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| 名前 | 説明 |
+| --- | --- |
+| getIndices() | インデックスデータを取得します。インデックス配列です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### copyTo{#copyTo}
+
+| 名前 | 説明 |
+| --- | --- |
+| copyTo(target) | 指定された要素にデータをコピーします |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| ターゲット | VertexElementVector4 | ターゲット。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setData{#setData}
+
+| 名前 | 説明 |
+| --- | --- |
+| setData(data) | データをロードします |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| dat | Vector4[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| 名前 | 説明 |
+| --- | --- |
+| clear() | 直接配列とインデックス配列からすべての要素を削除します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| 名前 | 説明 |
+| --- | --- |
+| setIndices(data) | インデックスをロードします |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| dat | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| 名前 | 説明 |
+| --- | --- |
+| toString() | 頂点要素の文字列表現です。 |
+
+ **Result:**
+文字列
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/vertexelementvertexcrease/_index.md
+++ b/japanese/nodejs-java/aspose.threed/vertexelementvertexcrease/_index.md
@@ -1,0 +1,229 @@
+---
+title: "VertexElementVertexCrease"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/vertexelementvertexcrease/
+---
+## VertexElementVertexCrease class
+
+指定された成分の頂点クレーズを定義します
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | VertexElementVertexCrease クラスの新しいインスタンスを初期化します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getData{#getData}
+
+| 名前 | 説明 |
+| --- | --- |
+| getData() | 頂点データを取得します |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| 名前 | 説明 |
+| --- | --- |
+| getVertexElementType() | VertexElement のタイプを取得します。プロパティの値は VertexElementType の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getMappingMode() | 要素がどのようにマッピングされるかを取得または設定します。プロパティの値は MappingMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setMappingMode(value) | 要素がどのようにマッピングされるかを取得または設定します。プロパティの値は MappingMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getReferenceMode() | 要素がどのように参照されるかを取得または設定します。プロパティの値は ReferenceMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setReferenceMode(value) | 要素がどのように参照されるかを取得または設定します。プロパティの値は ReferenceMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| 名前 | 説明 |
+| --- | --- |
+| getIndices() | インデックスデータを取得します。インデックス配列です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### copyTo{#copyTo}
+
+| 名前 | 説明 |
+| --- | --- |
+| copyTo(target) | 指定された要素にデータをコピーします |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| ターゲット | VertexElementDoublesTemplate | ターゲット。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setData{#setData}
+
+| 名前 | 説明 |
+| --- | --- |
+| setData(data) | データをロードします |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| dat | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| 名前 | 説明 |
+| --- | --- |
+| clear() | 直接配列とインデックス配列からすべての要素を削除します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| 名前 | 説明 |
+| --- | --- |
+| setIndices(data) | インデックスをロードします |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| dat | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| 名前 | 説明 |
+| --- | --- |
+| toString() | 頂点要素の文字列表現です。 |
+
+ **Result:**
+文字列
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/vertexelementvisibility/_index.md
+++ b/japanese/nodejs-java/aspose.threed/vertexelementvisibility/_index.md
@@ -1,0 +1,191 @@
+---
+title: "VertexElementVisibility"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/vertexelementvisibility/
+---
+## VertexElementVisibility class
+
+指定された成分が表示されるかどうかを定義します
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | VertexElementVisibility クラスの新しいインスタンスを初期化します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getData{#getData}
+
+| 名前 | 説明 |
+| --- | --- |
+| getData() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| 名前 | 説明 |
+| --- | --- |
+| getVertexElementType() | VertexElement のタイプを取得します。プロパティの値は VertexElementType の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getMappingMode() | 要素がどのようにマッピングされるかを取得または設定します。プロパティの値は MappingMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setMappingMode(value) | 要素がどのようにマッピングされるかを取得または設定します。プロパティの値は MappingMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getReferenceMode() | 要素がどのように参照されるかを取得または設定します。プロパティの値は ReferenceMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setReferenceMode(value) | 要素がどのように参照されるかを取得または設定します。プロパティの値は ReferenceMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| 名前 | 説明 |
+| --- | --- |
+| getIndices() | インデックスデータを取得します。インデックス配列です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| 名前 | 説明 |
+| --- | --- |
+| clear() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| 名前 | 説明 |
+| --- | --- |
+| setIndices(data) | インデックスをロードします |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| dat | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| 名前 | 説明 |
+| --- | --- |
+| toString() | 頂点要素の文字列表現です。 |
+
+ **Result:**
+文字列
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/vertexelementweight/_index.md
+++ b/japanese/nodejs-java/aspose.threed/vertexelementweight/_index.md
@@ -1,0 +1,229 @@
+---
+title: "VertexElementWeight"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/vertexelementweight/
+---
+## VertexElementWeight class
+
+指定された成分のブレンドウェイトを定義します。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | VertexElementWeightクラスの新しいインスタンスを初期化します |
+
+ **Result:**
+
+
+
+---
+
+
+### getData{#getData}
+
+| 名前 | 説明 |
+| --- | --- |
+| getData() | 頂点データを取得します |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| 名前 | 説明 |
+| --- | --- |
+| getVertexElementType() | VertexElement のタイプを取得します。プロパティの値は VertexElementType の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getMappingMode() | 要素がどのようにマッピングされるかを取得または設定します。プロパティの値は MappingMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setMappingMode(value) | 要素がどのようにマッピングされるかを取得または設定します。プロパティの値は MappingMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getReferenceMode() | 要素がどのように参照されるかを取得または設定します。プロパティの値は ReferenceMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setReferenceMode(value) | 要素がどのように参照されるかを取得または設定します。プロパティの値は ReferenceMode の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| 名前 | 説明 |
+| --- | --- |
+| getIndices() | インデックスデータを取得します。インデックス配列です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### copyTo{#copyTo}
+
+| 名前 | 説明 |
+| --- | --- |
+| copyTo(target) | 指定された要素にデータをコピーします |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| ターゲット | VertexElementDoublesTemplate | ターゲット。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setData{#setData}
+
+| 名前 | 説明 |
+| --- | --- |
+| setData(data) | データをロードします |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| dat | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| 名前 | 説明 |
+| --- | --- |
+| clear() | 直接配列とインデックス配列からすべての要素を削除します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| 名前 | 説明 |
+| --- | --- |
+| setIndices(data) | インデックスをロードします |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| dat | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| 名前 | 説明 |
+| --- | --- |
+| toString() | 頂点要素の文字列表現です。 |
+
+ **Result:**
+文字列
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/vertexfield/_index.md
+++ b/japanese/nodejs-java/aspose.threed/vertexfield/_index.md
@@ -1,0 +1,146 @@
+---
+title: "VertexField"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/vertexfield/
+---
+## VertexField class
+
+頂点のフィールドメモリレイアウトの説明。  @hideconstructor
+
+
+## メソッド
+
+### getDataType{#getDataType}
+
+| 名前 | 説明 |
+| --- | --- |
+| getDataType() | このフィールドのデータ型。プロパティの値は VertexFieldDataType の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getSemantic{#getSemantic}
+
+| 名前 | 説明 |
+| --- | --- |
+| getSemantic() | このフィールドの使用セマンティクス。プロパティの値は VertexFieldSemantic の整数定数です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getAlias{#getAlias}
+
+| 名前 | 説明 |
+| --- | --- |
+| getAlias() | 属性 com.aspose.threed.SemanticAttribute によって注釈されたエイリアス |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndex{#getIndex}
+
+| 名前 | 説明 |
+| --- | --- |
+| getIndex() | 同じセマンティクスを持つ頂点レイアウト内におけるこのフィールドのインデックス。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getOffset{#getOffset}
+
+| 名前 | 説明 |
+| --- | --- |
+| getOffset() | このフィールドのバイト単位のオフセット。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getSize{#getSize}
+
+| 名前 | 説明 |
+| --- | --- |
+| getSize() | このフィールドのバイト単位のサイズ |
+
+ **Result:**
+
+
+
+---
+
+
+### hashCode{#hashCode}
+
+| 名前 | 説明 |
+| --- | --- |
+| hashCode() |  |
+
+ **Result:**
+数
+
+
+---
+
+
+### equals{#equals}
+
+| 名前 | 説明 |
+| --- | --- |
+| equals(obj) | このインスタンスと、VertexField オブジェクトである必要がある指定されたオブジェクトが同じ値かどうかを判定します。 |
+
+ **Result:**
+数
+
+
+---
+
+
+### compareTo{#compareTo}
+
+| 名前 | 説明 |
+| --- | --- |
+| compareTo(other) | このインスタンスを指定されたオブジェクトと比較し、相対的な値の指標を返します。 |
+
+ **Result:**
+数
+
+
+---
+
+
+### toString{#toString}
+
+| 名前 | 説明 |
+| --- | --- |
+| toString() |  |
+
+ **Result:**
+文字列
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/viewport/_index.md
+++ b/japanese/nodejs-java/aspose.threed/viewport/_index.md
@@ -1,0 +1,185 @@
+---
+title: "Viewport"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/viewport/
+---
+## Viewport class
+
+com.aspose.threed.IRenderTarget はシーンをレンダリングするためのビューポートを少なくとも 1 つ含みます。  @hideconstructor
+
+
+## メソッド
+
+### getFrustum{#getFrustum}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFrustum() | この Viewport のカメラを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFrustum{#setFrustum}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFrustum(value) | この Viewport のカメラを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEnabled{#getEnabled}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEnabled() | このビューポートを有効または無効にします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setEnabled{#setEnabled}
+
+| 名前 | 説明 |
+| --- | --- |
+| setEnabled(value) | このビューポートを有効または無効にします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getRenderTarget{#getRenderTarget}
+
+| 名前 | 説明 |
+| --- | --- |
+| getRenderTarget() | このビューポートを作成したレンダーターゲットを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getArea{#getArea}
+
+| 名前 | 説明 |
+| --- | --- |
+| getArea() | レンダーターゲット内のビューポートの領域を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setArea{#setArea}
+
+| 名前 | 説明 |
+| --- | --- |
+| setArea(value) | レンダーターゲット内のビューポートの領域を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getZOrder{#getZOrder}
+
+| 名前 | 説明 |
+| --- | --- |
+| getZOrder() | ビューポートの Z オーダーを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setZOrder{#setZOrder}
+
+| 名前 | 説明 |
+| --- | --- |
+| setZOrder(value) | ビューポートの Z オーダーを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getBackgroundColor{#getBackgroundColor}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBackgroundColor() | ビューポートの背景色を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setBackgroundColor{#setBackgroundColor}
+
+| 名前 | 説明 |
+| --- | --- |
+| setBackgroundColor(value) | ビューポートの背景色を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getDepthClear{#getDepthClear}
+
+| 名前 | 説明 |
+| --- | --- |
+| getDepthClear() | 深度バッファビットが設定された状態でビューポートをクリアする際に使用される深度値を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setDepthClear{#setDepthClear}
+
+| 名前 | 説明 |
+| --- | --- |
+| setDepthClear(value) | 深度バッファビットが設定された状態でビューポートをクリアする際に使用される深度値を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/watermark/_index.md
+++ b/japanese/nodejs-java/aspose.threed/watermark/_index.md
@@ -1,0 +1,96 @@
+---
+title: "Watermark"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/watermark/
+---
+## Watermark class
+
+メッシュへの/からブラインドウォーターマークをエンコード/デコードするユーティリティです。  @hideconstructor
+
+
+## メソッド
+
+### encodeWatermark{#encodeWatermark}
+
+| 名前 | 説明 |
+| --- | --- |
+| encodeWatermark(input, text) | テキストをメッシュのブラインドウォーターマークにエンコードします。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| 入力 | Mesh | ブラインドウォーターマークをエコードするメッシュ |
+| text | 文字列 | メッシュにエンコードするテキスト |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### encodeWatermark{#encodeWatermark}
+
+| 名前 | 説明 |
+| --- | --- |
+| encodeWatermark(input, text, password) | テキストをメッシュのブラインドウォーターマークにエンコードします。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| 入力 | Mesh | ブラインドウォーターマークをエコードするメッシュ |
+| text | 文字列 | メッシュにエンコードするテキスト |
+| password | 文字列 | ウォーターマークを保護するパスワード（オプション） |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### decodeWatermark{#decodeWatermark}
+
+| 名前 | 説明 |
+| --- | --- |
+| decodeWatermark(input) | メッシュからウォーターマークをデコードします |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| 入力 | Mesh | ウォーターマークを抽出するメッシュ |
+
+ **Result:**
+文字列
+
+
+---
+
+
+### decodeWatermark{#decodeWatermark}
+
+| 名前 | 説明 |
+| --- | --- |
+| decodeWatermark(input, password) | メッシュからウォーターマークをデコードします |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| 入力 | Mesh | ウォーターマークを抽出するメッシュ |
+| password | 文字列 | ウォーターマークを復号化するパスワード |
+
+ **Result:**
+文字列
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/windowhandle/_index.md
+++ b/japanese/nodejs-java/aspose.threed/windowhandle/_index.md
@@ -1,0 +1,13 @@
+---
+title: "WindowHandle"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/windowhandle/
+---
+## WindowHandle class
+
+異なるプラットフォーム用にカプセル化されたウィンドウハンドルです。  @hideconstructor
+
+

--- a/japanese/nodejs-java/aspose.threed/xloadoptions/_index.md
+++ b/japanese/nodejs-java/aspose.threed/xloadoptions/_index.md
@@ -1,0 +1,152 @@
+---
+title: "XLoadOptions"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/xloadoptions/
+---
+## XLoadOptions class
+
+DirectX X ファイルのロードオプションです。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor(contentType) | XLoadOptions のコンストラクタ |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| contentType | FileContentType | FileContentType |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlipCoordinateSystem{#getFlipCoordinateSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFlipCoordinateSystem() | 座標系を反転します。デフォルトでは true です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlipCoordinateSystem{#setFlipCoordinateSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFlipCoordinateSystem(value) | 座標系を反転します。デフォルトでは true です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileFormat() | 現在の保存/読み込みオプションで指定されたファイル形式を取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEncoding() | テキストベースのファイルのデフォルトエンコーディングを取得または設定します。デフォルト値は null で、インポーター/エクスポーターが使用するエンコーディングを決定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileSystem() | ロード/セーブ時に外部依存関係を管理する方法をユーザーが処理できるようにします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFileSystem(value) | ロード/セーブ時に外部依存関係を管理する方法をユーザーが処理できるようにします。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| 名前 | 説明 |
+| --- | --- |
+| getLookupPaths() | OBJ のような一部のファイルは外部ファイルに依存しており、検索パスにより Aspose.3D が外部ファイルを探してロードできるようになります。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFileName() | エクスポート/インポートシーンのファイル名です。これはオプションですが、OBJ のマテリアルなど外部アセットをシリアライズする際に便利です。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFileName(value) | エクスポート/インポートシーンのファイル名です。これはオプションですが、OBJ のマテリアルなど外部アセットをシリアライズする際に便利です。 |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/ziparchivefilesystem/_index.md
+++ b/japanese/nodejs-java/aspose.threed/ziparchivefilesystem/_index.md
@@ -1,0 +1,75 @@
+---
+title: "ZipArchiveFileSystem"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/ziparchivefilesystem/
+---
+## ZipArchiveFileSystem class
+
+指定された zip ファイルまたは zip ストリームへの読み取り専用アクセスを提供するファイルシステムです。ファイルシステムは開く/保存する操作の後に破棄されます。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor(fileName) | ファイル名を使用して ZipArchiveFileSystem を構築します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| fileNam | 文字列 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### readFile{#readFile}
+
+| 名前 | 説明 |
+| --- | --- |
+| readFile(fileName, options) | 読み取り用にファイルを開く |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| fileNam | 文字列 | null |
+| オプション | IOConfig | null |
+
+ **Result:**
+Stream
+
+
+---
+
+
+### writeFile{#writeFile}
+
+| 名前 | 説明 |
+| --- | --- |
+| writeFile(fileName, options) | 書き込み用にファイルを開く（このクラスでは実装されていません）。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| fileNam | 文字列 | null |
+| オプション | IOConfig | null |
+
+ **Result:**
+Stream
+
+
+---
+
+
+

--- a/japanese/nodejs-java/aspose.threed/zshape/_index.md
+++ b/japanese/nodejs-java/aspose.threed/zshape/_index.md
@@ -1,0 +1,437 @@
+---
+title: "ZShape"
+second_title: "Node.js 用 Java 経由の Aspose.3D API リファレンス"
+description: 
+type: docs
+
+url: /ja/nodejs-java/aspose.threed/zshape/
+---
+## ZShape class
+
+パラメータで定義された IFC 互換の Z 形状プロファイルです。
+
+
+## メソッド
+
+### constructor{#constructor}
+
+| 名前 | 説明 |
+| --- | --- |
+| constructor() | ZShape のコンストラクタ |
+
+ **Result:**
+
+
+
+---
+
+
+### getDepth{#getDepth}
+
+| 名前 | 説明 |
+| --- | --- |
+| getDepth() | ウェブの長さを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setDepth{#setDepth}
+
+| 名前 | 説明 |
+| --- | --- |
+| setDepth(value) | ウェブの長さを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlangeWidth{#getFlangeWidth}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFlangeWidth() | フランジの長さを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlangeWidth{#setFlangeWidth}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFlangeWidth(value) | フランジの長さを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getWebThickness{#getWebThickness}
+
+| 名前 | 説明 |
+| --- | --- |
+| getWebThickness() | 壁の厚さを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setWebThickness{#setWebThickness}
+
+| 名前 | 説明 |
+| --- | --- |
+| setWebThickness(value) | 壁の厚さを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlangeThickness{#getFlangeThickness}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFlangeThickness() | フランジの厚さを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlangeThickness{#setFlangeThickness}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFlangeThickness(value) | フランジの厚さを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFilletRadius{#getFilletRadius}
+
+| 名前 | 説明 |
+| --- | --- |
+| getFilletRadius() | フランジとウェブの間のフィレット半径を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFilletRadius{#setFilletRadius}
+
+| 名前 | 説明 |
+| --- | --- |
+| setFilletRadius(value) | フランジとウェブの間のフィレット半径を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEdgeRadius{#getEdgeRadius}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEdgeRadius() | フランジエッジの半径を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setEdgeRadius{#setEdgeRadius}
+
+| 名前 | 説明 |
+| --- | --- |
+| setEdgeRadius(value) | フランジエッジの半径を取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNodes() | すべての親ノードを取得します。エンティティはジオメトリインスタンシングのために複数の親ノードにアタッチできます。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExcluded() | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 名前 | 説明 |
+| --- | --- |
+| setExcluded(value) | エクスポート時にこのエンティティを除外するかどうかを取得または設定します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| getParentNode() | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 名前 | 説明 |
+| --- | --- |
+| setParentNode(value) | 最初の親ノードを取得または設定します。最初の親ノードを設定すると、このエンティティは他の親ノードから切り離されます。親ノード。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 名前 | 説明 |
+| --- | --- |
+| getScene() | このオブジェクトが属するシーンを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 名前 | 説明 |
+| --- | --- |
+| getName() | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 名前 | 説明 |
+| --- | --- |
+| setName(value) | 名前を取得または設定します。名前。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperties() | すべてのプロパティのコレクションを取得します。 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtent{#getExtent}
+
+| 名前 | 説明 |
+| --- | --- |
+| getExtent() | x と y の次元での範囲を取得します |
+
+ **Result:**
+Vector2
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 名前 | 説明 |
+| --- | --- |
+| getEntityRendererKey() | レンダラーに登録されたエンティティレンダラーのキーを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 名前 | 説明 |
+| --- | --- |
+| getBoundingBox() | 現在のエンティティのオブジェクト空間座標系におけるバウンディングボックスを取得します。 |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 動的プロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | Property | 削除するプロパティはどれですか |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| removeProperty(property) | 名前で識別された指定されたプロパティを削除します。 |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propert | 文字列 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| getProperty(property) | 指定されたプロパティの値を取得します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| setProperty(property, value) | 指定されたプロパティの値を設定します |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| property | 文字列 | プロパティ名 |
+| 値 | オブジェクト | プロパティの値 |
+
+ **Result:**
+オブジェクト
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 名前 | 説明 |
+| --- | --- |
+| findProperty(propertyName) | プロパティを検索します。動的プロパティ（CreateDynamicProperty/SetProperty によって作成）またはネイティブプロパティ（名前で識別）になる可能性があります |
+
+ **Parameters:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| propertyName | 文字列 | プロパティ名。 |
+
+ **Result:**
+Property
+
+
+---
+
+
+


### PR DESCRIPTION
Automated translation of the NODEJS-JAVA API Reference to **Japanese** (`ja`) generated by RDA.

- Pages translated: 204/204
- Errors: 0
- Source: `english/nodejs-java`
- Output: `japanese/nodejs-java`

🤖 Generated by RDA