### PR TITLE
[auto] Translate NODEJS-JAVA API Reference to Korean

### DIFF
--- a/korean/nodejs-java/_index.md
+++ b/korean/nodejs-java/_index.md
@@ -1,0 +1,13 @@
+---
+title: "Java를 통해 Node.js용 Aspose.3D"
+type: docs
+weight: 11
+url: /ko/nodejs-java/
+description: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스에는 예제, 코드 스니펫 및 API 문서가 포함되어 있습니다. 패키지, 클래스, 인터페이스 및 기타 API 세부 정보를 제공합니다."
+is_root: true
+---
+
+## Packages
+| 패키지 | 설명 |
+| --- | --- |
+| [aspose.threed](./aspose.threed) |  |

--- a/korean/nodejs-java/aspose.threed/_index.md
+++ b/korean/nodejs-java/aspose.threed/_index.md
@@ -1,0 +1,217 @@
+---
+title: "aspose.threed"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+keywords: "Aspose.3D for Node.js via Java, Aspose.3D, STL, OBJ, Aspose API Reference."
+type: docs
+weight: 10
+url: /ko/nodejs-java/aspose.threed/
+---
+
+
+## 클래스
+
+| 클래스 | 설명 |
+| --- | --- |
+| [A3DObject](../aspose.threed/a3dobject) | 모든 Aspose.ThreeD 객체의 기본 클래스이며, 모든 하위 클래스는 동적 속성을 지원합니다. |
+| [A3dwSaveOptions](../aspose.threed/a3dwsaveoptions) | A3DW 형식에 대한 저장 옵션. |
+| [AmfSaveOptions](../aspose.threed/amfsaveoptions) | AMF에 대한 저장 옵션 |
+| [AnimationChannel](../aspose.threed/animationchannel) | 채널은 속성의 구성 요소 필드를 일련의 키프레임 시퀀스로 매핑합니다  @hideconstructor |
+| [AnimationClip](../aspose.threed/animationclip) | Animation 클립은 애니메이션의 컬렉션입니다. 씬은 하나 이상의 애니메이션 클립을 가질 수 있습니다. |
+| [AnimationNode](../aspose.threed/animationnode) | Aspose.3D는 애니메이션 계층 구조를 지원하며, 각 애니메이션은 여러 애니메이션 및 애니메이션의 키프레임 정의로 구성될 수 있습니다. AnimationNode는 시간에 따라 속성 값의 변환을 정의합니다. 예를 들어, animation node는 노드의 변환이나 다른 A3DObject 객체의 수치 속성을 제어하는 데 사용할 수 있습니다. |
+| [ArbitraryProfile](../aspose.threed/arbitraryprofile) | 이 클래스는 임의의 곡선으로부터 직접 2D 프로파일을 구성할 수 있게 합니다. |
+| [AssetInfo](../aspose.threed/assetinfo) | 자산 정보. 자산 정보는 Scene에 첨부될 수 있습니다. 자식 Scene은 자체 AssetInfo를 가지고 부모의 정의를 재정의할 수 있습니다. |
+| [BindPoint](../aspose.threed/bindpoint) | BindPoint는 일반적으로 객체의 속성에 생성되며, 일부 속성 유형은 여러 구성 요소 필드(예: Vector3 필드)를 포함합니다. BindPoint는 각 구성 요소 필드에 대해 채널을 생성하고, 해당 필드를 하나 이상의 키프레임 시퀀스 인스턴스와 채널을 통해 연결합니다. |
+| [Bone](../aspose.threed/bone) | Bone은 지오메트리의 컨트롤 포인트 하위 집합을 정의하고, 각 컨트롤 포인트에 대한 블렌드 가중치를 정의합니다. Bone 객체는 직접 사용할 수 없으며, SkinDeformer 인스턴스를 사용하여 지오메트리를 변형합니다. SkinDeformer는 여러 Bone을 포함하며, 각 Bone은 노드에 연결됩니다. NOTE: 지오메트리의 컨트롤 포인트는 둘 이상의 Bone에 바인딩될 수 있습니다. |
+| [BonePose](../aspose.threed/bonepose) | BonePose는 bone 노드에 대한 변환 행렬을 포함합니다. |
+| [BoundingBox](../aspose.threed/boundingbox) | 축 정렬 경계 상자 |
+| [BoundingBox2D](../aspose.threed/boundingbox2d) | Vector2에 대한 축 정렬 경계 상자 |
+| [Box](../aspose.threed/box) | 박스. |
+| [Camera](../aspose.threed/camera) | 카메라는 씬을 바라보는 뷰어의 눈 위치를 설명합니다. |
+| [Circle](../aspose.threed/circle) | Circle 곡선은 원 형태의 가장자리에 있는 일련의 점으로 구성됩니다. |
+| [CircleShape](../aspose.threed/circleshape) | IFC 호환 원형 프로파일로, LinearExtrusion을 통해 메쉬를 구성하는 데 사용할 수 있습니다. |
+| [ColladaSaveOptions](../aspose.threed/colladasaveoptions) | Collada 저장 옵션 |
+| [CompositeCurve](../aspose.threed/compositecurve) | CompositeCurve는 여러 곡선 세그먼트로 구성됩니다. |
+| [CShape](../aspose.threed/cshape) | 매개변수로 정의된 IFC 호환 C형 프로파일. 프로파일의 중심 위치는 경계 상자의 중앙에 있습니다. |
+| [Curve](../aspose.threed/curve) | 모든 곡선 구현의 기본 클래스.  @hideconstructor |
+| [CustomObject](../aspose.threed/customobject) | 3D 파일에서 사용되는 메타 데이터 또는 사용자 정의 객체는 이 클래스에서 관리됩니다. 모든 사용자 정의 속성은 동적 속성으로 저장됩니다. |
+| [Cylinder](../aspose.threed/cylinder) | 매개변수화된 실린더. radiusTop 또는 radiusBottom 중 하나가 0일 때 원뿔을 나타내는 데에도 사용할 수 있습니다. |
+| [Deformer](../aspose.threed/deformer) | SkinDeformer와 MorphTargetDeformer의 기본 클래스 |
+| [DescriptorSetUpdater](../aspose.threed/descriptorsetupdater) | 이 클래스는 체인 작업에서 com.aspose.threed.IDescriptorSet을 업데이트할 수 있게 합니다.  @hideconstructor |
+| [Discreet3dsLoadOptions](../aspose.threed/discreet3dsloadoptions) | 3DS 파일 로드 옵션. |
+| [Discreet3dsSaveOptions](../aspose.threed/discreet3dssaveoptions) | 3DS 파일 저장 옵션. |
+| [Dish](../aspose.threed/dish) | 매개변수화된 접시. |
+| [DracoFormat](../aspose.threed/dracoformat) | Google Draco 형식  @hideconstructor |
+| [DracoSaveOptions](../aspose.threed/dracosaveoptions) | Google Draco 파일 저장 옵션 |
+| [DriverException](../aspose.threed/driverexception) | 내부 렌더링 드라이버에서 발생한 예외.  @hideconstructor |
+| [DummyFileSystem](../aspose.threed/dummyfilesystem) | 읽기/쓰기 작업은 더미 작업입니다. |
+| [Ellipse](../aspose.threed/ellipse) | Ellipse는 타원의 형태를 이루는 점들의 집합을 정의합니다. |
+| [EllipseShape](../aspose.threed/ellipseshape) | 매개변수로 정의된 IFC 호환 타원 형태. 프로파일의 중심 위치는 경계 상자의 중앙에 있습니다. |
+| [EndPoint](../aspose.threed/endpoint) | 곡선을 자를 끝점으로, 매개변수 값이거나 직교 좌표점일 수 있습니다. |
+| [Entity](../aspose.threed/entity) | 모든 엔터티의 기본 클래스. Entity는 Light/Geometry와 같은 노드 아래에 부착되는 구체적인 객체를 나타냅니다. |
+| [EntityRenderer](../aspose.threed/entityrenderer) | 다양한 종류의 엔터티에 대한 렌더링을 구현하려면 이 클래스를 서브클래스화하십시오. |
+| [EntityRendererKey](../aspose.threed/entityrendererkey) | 등록된 엔터티 렌더러의 키 |
+| [ExportException](../aspose.threed/exportexception) | Aspose.3D가 씬을 파일로 내보내지 못했을 때 발생하는 예외 |
+| [Extrapolation](../aspose.threed/extrapolation) | Extrapolation은 샘플링된 값이 첫 번째와 마지막 키프레임으로 정의된 범위를 벗어났을 때 어떻게 처리할지를 정의합니다.  @hideconstructor |
+| [FbxLoadOptions](../aspose.threed/fbxloadoptions) | Fbx 형식 로드 옵션. |
+| [FbxSaveOptions](../aspose.threed/fbxsaveoptions) | Fbx 파일 저장 옵션. |
+| [FileFormat](../aspose.threed/fileformat) | 파일 형식 정의  @hideconstructor |
+| [FileFormatType](../aspose.threed/fileformattype) | 파일 형식 유형  @hideconstructor |
+| [FileSystem](../aspose.threed/filesystem) | 파일 시스템 캡슐화.  Aspose.3D는 이를 사용하여 종속성을 읽고/쓸 수 있습니다.  @hideconstructor |
+| [FMatrix4](../aspose.threed/fmatrix4) | 모든 구성 요소가 float 타입인 4x4 행렬 |
+| [FontFile](../aspose.threed/fontfile) | 폰트 파일에는 글리프 정의가 포함되어 있으며, 이는 텍스트 프로파일을 만드는 데 사용됩니다.  @hideconstructor |
+| [Frustum](../aspose.threed/frustum) | Camera와 Light의 기본 클래스  @hideconstructor |
+| [FVector2](../aspose.threed/fvector2) | 두 개 구성 요소를 가진 float 벡터. |
+| [FVector3](../aspose.threed/fvector3) | 세 개 구성 요소를 가진 float 벡터. |
+| [FVector4](../aspose.threed/fvector4) | 네 개 구성 요소를 가진 float 벡터. |
+| [Geometry](../aspose.threed/geometry) | 렌더링 가능한 모든 기하학 객체(예: Mesh, NurbsSurface, Patch 등)의 기본 클래스입니다. Geometry 기본 클래스는 다음을 지원합니다: 제어점 관리, 제어점은 기하학의 기본 3D 공간 구조를 정의하며, 다양한 기하학 유형마다 구체적인 3D 모델을 정의하는 방식이 다릅니다. 정점 요소 정의, 정점 요소는 노멀/uv 좌표/정점 색상과 같은 추가 정보를 기하학에 적용합니다. 자세한 내용은 VertexElement를 참조하십시오. 객체 변형, Deformer는 기하학 형태를 애니메이션화하기 위해 결합될 수 있습니다. |
+| [GlobalTransform](../aspose.threed/globaltransform) | Global transform은 Transform과 유사하지만 최종 평가된 변환을 나타내는 동안 불변입니다. 전역 변환을 평가할 때 오른손 좌표계가 사용됩니다.  @hideconstructor |
+| [GLSLSource](../aspose.threed/glslsource) | GLSL에서 쉐이더의 소스 코드 |
+| [GltfLoadOptions](../aspose.threed/gltfloadoptions) | glTF 형식에 대한 로드 옵션 |
+| [GltfSaveOptions](../aspose.threed/gltfsaveoptions) | glTF 형식에 대한 저장 옵션. |
+| [HollowCircleShape](../aspose.threed/hollowcircleshape) | IFC 호환 중공 원형 프로파일. |
+| [HollowRectangleShape](../aspose.threed/hollowrectangleshape) | 내부/외부 모서리 라운딩이 모두 적용된 IFC 호환 중공 직사각형 형태. |
+| [HShape](../aspose.threed/hshape) | HShape는 'H' 또는 'I' 형태의 정의 매개변수를 제공합니다. |
+| [Html5SaveOptions](../aspose.threed/html5saveoptions) | HTML5에 대한 저장 옵션 |
+| [ImageRenderOptions](../aspose.threed/imagerenderoptions) | Scene.render(com.aspose.threed.Camera, java.lang.String, com.aspose.threed.Vector2, java.lang.String, com.aspose.threed.ImageRenderOptions) 및 Scene.render(com.aspose.threed.Camera, com.aspose.threed.TextureData, com.aspose.threed.ImageRenderOptions)의 옵션 |
+| [ImportException](../aspose.threed/importexception) | Aspose.3D가 지정된 소스를 열지 못했을 때 발생하는 예외 |
+| [InitializationException](../aspose.threed/initializationexception) | 렌더 파이프라인 초기화 중 예외 |
+| [IOConfig](../aspose.threed/ioconfig) | 직렬화/역직렬화를 위한 IO 구성. 사용자는 종속성 조회 경로와 같은 상세 구성을 지정하거나 여기에서 형식 관련 구성을 지정할 수 있습니다.  @hideconstructor |
+| [IOUtils](../aspose.threed/ioutils) | 행렬/벡터를 바이너리 라이터에 쓰기 위한 유틸리티  @hideconstructor |
+| [KeyFrame](../aspose.threed/keyframe) | 키 프레임은 주로 시간과 값으로 정의되며, 일부 보간 유형에서는 최종 샘플 값을 계산할 때 접선/텐션/바이어스/연속성도 사용됩니다. 키 프레임이 아닌 시간 위치의 샘플 값은 이전 및 다음 키 프레임 사이의 키 프레임에 의해 보간됩니다. 첫 번째/마지막 키 프레임 이전/이후의 값은 Extrapolation 클래스에 의해 계산됩니다. |
+| [KeyframeSequence](../aspose.threed/keyframesequence) | 키 프레임의 시퀀스로, 시간에 따라 샘플 값의 변환을 설명합니다. |
+| [LambertMaterial](../aspose.threed/lambertmaterial) | Lambert 셰이딩 모델을 위한 재질 |
+| [License](../aspose.threed/license) | 구성 요소에 대한 라이선스 부여 메서드를 제공합니다. |
+| [Light](../aspose.threed/light) | 빛이 장면을 비춥니다.  빛의 전체 감쇠를 계산하는 공식은 다음과 같습니다:  A = ConstantAttenuation + (Dist  LinearAttenuation) + ((Dist^2)  QuadraticAttenuation) |
+| [Line](../aspose.threed/line) | 폴리라인은 Geometry.ControlPoints 로 정의된 점 집합으로 구성된 경로이며, Segments 로 연결됩니다. 이는 연결된 선분 집합이 될 수도 있음을 의미합니다. 라인은 일반적으로 선형 객체이므로 곡선을 표현할 수 없으며, 곡선을 표현하려면 NurbsCurve 를 사용합니다. |
+| [LinearExtrusion](../aspose.threed/linearextrusion) | 선형 압출은 2D 형태를 입력으로 받아 3차원으로 형태를 확장합니다. |
+| [LoadOptions](../aspose.threed/loadoptions) | 다양한 유형에 대한 파일 로드 옵션을 구성하기 위한 기본 클래스  @hideconstructor |
+| [LocalFileSystem](../aspose.threed/localfilesystem) | LocalFileSystem 은 읽기/쓰기 작업을 로컬 디렉터리에 매핑합니다. |
+| [LShape](../aspose.threed/lshape) | 파라미터로 정의된 IFC 호환 L자형 프로파일. |
+| [Material](../aspose.threed/material) | Material 은 기하학의 시각적 외관에 필요한 매개변수를 정의합니다.  Aspose.3D 는 LambertMaterial, PhongMaterial 및 ShaderMaterial 에 대한 셰이딩 모델을 제공합니다  @hideconstructor |
+| [MathUtils](../aspose.threed/mathutils) | 유용한 수학 유틸리티 집합입니다.  @hideconstructor |
+| [Matrix4](../aspose.threed/matrix4) | 4x4 행렬 구현. |
+| [MemoryFileSystem](../aspose.threed/memoryfilesystem) | MemoryFileSystem 은 읽기/쓰기 작업을 메모리로 매핑합니다. |
+| [Mesh](../aspose.threed/mesh) | 메시는 다수의 n각형으로 구성됩니다. |
+| [Metered](../aspose.threed/metered) | metered key 를 설정하는 메서드를 제공합니다. |
+| [MirroredProfile](../aspose.threed/mirroredprofile) | IFC 호환 미러 프로파일.  이 프로파일은 y축을 기준으로 기본 프로파일을 반사하여 새로운 프로파일을 정의합니다. |
+| [MorphTargetChannel](../aspose.threed/morphtargetchannel) | MorphTargetChannel 은 MorphTargetDeformer 가 대상 기하학을 정리하는 데 사용됩니다.  FBX 와 같은 일부 파일 형식은 여러 채널을 동시에 지원합니다.  가중치는 0에서 1.0 사이이며, 대상의 기본 가중치는 0.0입니다; |
+| [MorphTargetDeformer](../aspose.threed/morphtargetdeformer) | MorphTargetDeformer 는 정점별 애니메이션을 제공합니다.  MorphTargetDeformer 는 모든 대상을 MorphTargetChannel 을 통해 조직하며, 각 채널은 여러 대상을 조직할 수 있습니다.  morph target deformer 의 일반적인 사용 사례는 캐릭터에 얼굴 표정을 적용하는 것입니다.  자세한 내용은 https://en.wikipedia.org/wiki/Morph_target_animation 에서 확인할 수 있습니다. |
+| [Node](../aspose.threed/node) | 씬 그래프의 요소를 나타냅니다. 씬 그래프는 Node 객체들의 트리 구조입니다. 트리 관리 서비스는 이 클래스에 자체적으로 포함되어 있습니다. Aspose.3D SDK 가 구성된 씬 그래프의 유효성을 검사하지 않음을 유의하십시오. 호출자는 노드 계층 구조에서 순환 그래프가 생성되지 않도록 책임을 져야 합니다. 트리 관리 외에도, 이 클래스는 씬 내 객체의 위치를 설명하는 데 필요한 모든 속성을 정의합니다. 이 정보에는 기본적인 Translation, Rotation, Scaling 속성뿐만 아니라 피벗, 제한, IK 조인트 속성(예: 강성 및 감쇠)과 같은 고급 옵션이 포함됩니다. 처음 생성될 때 Node 객체는 \"empty\"(즉, 그래픽 표현이 없고 위치 정보만 포함하는 객체) 상태입니다. 이 상태에서는 노드 트리 구조에서 부모를 나타내는 데 사용할 수 있지만 그 이상은 사용할 수 없습니다. 이러한 유형의 객체의 일반적인 사용 방법은 노드를 특화시킬 엔티티를 추가하는 것입니다(예: \"Entity\" 참조). 엔티티 자체가 객체이며 Node와 연결됩니다. 이는 동일한 엔티티를 여러 노드가 공유할 수 있음을 의미합니다. Camera, Light, Mesh 등은 모두 엔티티이며 모두 기본 클래스 Entity에서 파생됩니다. |
+| [NurbsCurve](../aspose.threed/nurbscurve) | NURBS 곡선은 NURBS(Non-uniform rational basis spline) 로 표현되는 곡선이며, NURBS 곡선은 Order, 가중치가 적용된 Geometry.ControlPoints 집합 및 KnotVectors 로 정의됩니다. 컨트롤 포인트의 w 구성 요소는 해당 포인트의 가중치로 사용되며, CurveDimension.TWO_DIMENSIONAL 이든 CurveDimension.THREE_DIMENSIONAL 이든 동일합니다. |
+| [NurbsDirection](../aspose.threed/nurbsdirection) | 3D NurbsSurface는 두 방향, 즉 NurbsSurface.U와 NurbsSurface.V를 가지고 있으며, NurbsDirection은 각 방향에 대한 데이터를 정의합니다. 방향은 실제로 NURBS 곡선이며, 따라서 Order, KnotVectors 및 가중치가 적용된 컨트롤 포인트 집합( NurbsSurface 에 정의됨) 으로도 정의됩니다. |
+| [NurbsSurface](../aspose.threed/nurbssurface) | NurbsSurface는 NURBS(Non-uniform rational basis spline) 로 표현되는 서피스이며, NurbsSurface는 두 개의 NurbsDirectionU와 V 로 정의됩니다. 컨트롤 포인트의 w 구성 요소는 해당 포인트의 가중치로 사용되며, 방향의 유형이 CurveDimension.TWO_DIMENSIONAL 이든 CurveDimension.THREE_DIMENSIONAL 이든 관계없이 적용됩니다. |
+| [ObjLoadOptions](../aspose.threed/objloadoptions) | Wavefront OBJ 로드 옵션 |
+| [ObjSaveOptions](../aspose.threed/objsaveoptions) | Wavefront OBJ 파일 저장 옵션 |
+| [ParameterizedProfile](../aspose.threed/parameterizedprofile) | 모든 매개변수화된 프로파일의 기본 클래스.  @hideconstructor |
+| [ParseException](../aspose.threed/parseexception) | Aspose.3D 가 입력을 파싱하지 못했을 때 발생하는 예외. |
+| [Patch](../aspose.threed/patch) | Patch는 매개변수 모델링 표면으로, NurbsSurface와 유사하며, 두 개의 PatchDirection, U와 V에 의해 정의됩니다. 그러나 Patch와 NurbsSurface의 차이점은 PatchDirection 곡선이 PatchDirectionType.BEZIER, PatchDirectionType.QUADRATIC_BEZIER, PatchDirectionType.BASIS_SPLINE, PatchDirectionType.CARDINAL_SPLINE 및 PatchDirectionType.LINEAR 중 하나가 될 수 있다는 것입니다. |
+| [PatchDirection](../aspose.threed/patchdirection) | Patch의 U 및 V 방향. |
+| [PbrMaterial](../aspose.threed/pbrmaterial) | 알베도 색상/메탈릭/거칠기를 기반으로 하는 물리 기반 렌더링용 Material |
+| [PbrSpecularMaterial](../aspose.threed/pbrspecularmaterial) | 확산 색상/스페큘러/광택을 기반으로 하는 물리 기반 렌더링용 Material |
+| [PdfFormat](../aspose.threed/pdfformat) | Adobe의 Portable Document Format  @hideconstructor |
+| [PdfLoadOptions](../aspose.threed/pdfloadoptions) | PDF 로딩 옵션 |
+| [PdfSaveOptions](../aspose.threed/pdfsaveoptions) | PDF 내보내기 시 저장 옵션. |
+| [PhongMaterial](../aspose.threed/phongmaterial) | blinn-phong 셰이딩 모델용 Material. |
+| [PixelMapping](../aspose.threed/pixelmapping) | @hideconstructor |
+| [Plane](../aspose.threed/plane) | 매개변수화된 평면. |
+| [PlyFormat](../aspose.threed/plyformat) | PLY 형식.  @hideconstructor |
+| [PlyLoadOptions](../aspose.threed/plyloadoptions) | PLY 파일 로드 옵션 |
+| [PlySaveOptions](../aspose.threed/plysaveoptions) | 씬을 PLY 파일로 내보내기 위한 저장 옵션. |
+| [PointCloud](../aspose.threed/pointcloud) | 포인트 클라우드에는 토폴로지 정보가 없고 제어점과 정점 요소만 포함됩니다. |
+| [PolygonBuilder](../aspose.threed/polygonbuilder) | Mesh용 폴리곤을 구축하기 위한 헬퍼 클래스 |
+| [PolygonModifier](../aspose.threed/polygonmodifier) | 폴리곤을 수정하기 위한 유틸리티  @hideconstructor |
+| [Pose](../aspose.threed/pose) | 포즈는 지오메트리가 스키닝될 때 변환 행렬을 저장하는 데 사용됩니다. 포즈는 BonePose의 집합이며, 각 BonePose는 본 노드의 구체적인 변환 정보를 저장합니다. |
+| [PostProcessing](../aspose.threed/postprocessing) | 후처리 효과  @hideconstructor |
+| [Primitive](../aspose.threed/primitive) | 모든 프리미티브의 기본 클래스 |
+| [Profile](../aspose.threed/profile) | xy 평면의 2D 프로파일  @hideconstructor |
+| [Property](../aspose.threed/property) | 사용자 정의 속성을 보유하는 클래스.  @hideconstructor |
+| [PropertyCollection](../aspose.threed/propertycollection) | 속성 컬렉션  @hideconstructor |
+| [PushConstant](../aspose.threed/pushconstant) | 푸시 상수를 통해 셰이더에 데이터를 제공하는 유틸리티. |
+| [Pyramid](../aspose.threed/pyramid) | 매개변수화된 피라미드. |
+| [Quaternion](../aspose.threed/quaternion) | Quaternion은 일반적으로 컴퓨터 그래픽스에서 회전을 수행하는 데 사용됩니다. |
+| [Rect](../aspose.threed/rect) | 사각형을 나타내는 클래스 |
+| [RectangleShape](../aspose.threed/rectangleshape) | 코너가 둥근 IFC 호환 사각형 형태. |
+| [RectangularTorus](../aspose.threed/rectangulartorus) | 매개변수화된 사각형 토러스. |
+| [RelativeRectangle](../aspose.threed/relativerectangle) | 상대 사각형  상대 구성 요소와 절대 값 사이의 공식은:  Scale (Reference Width) + offset  따라서 절대 값을 나타내려면 모든 scale 필드를 0으로 두고, offset 필드를 대신 사용하십시오. |
+| [Renderer](../aspose.threed/renderer) | 렌더러에 대한 컨텍스트.  @hideconstructor |
+| [RendererVariableManager](../aspose.threed/renderervariablemanager) | 이 클래스는 렌더링에 사용되는 변수를 관리합니다  @hideconstructor |
+| [RenderFactory](../aspose.threed/renderfactory) | RenderFactory는 렌더링 파이프라인에 표시되는 모든 리소스를 생성합니다.  @hideconstructor |
+| [RenderParameters](../aspose.threed/renderparameters) | 렌더 타깃의 매개변수를 설명합니다 |
+| [RenderResource](../aspose.threed/renderresource) | 모든 렌더 리소스의 추상 클래스  렌더러가 해제될 때 모든 렌더 리소스가 폐기됩니다.  Mesh/Texture와 같은 클래스는 해당하는 RenderResource를 가집니다  @hideconstructor |
+| [RenderState](../aspose.threed/renderstate) | 파이프라인 구축을 위한 렌더 상태  렌더 상태에 대한 변경은 생성된 파이프라인 인스턴스에 영향을 주지 않습니다. |
+| [RevolvedAreaSolid](../aspose.threed/revolvedareasolid) | 이 클래스는 프로파일이 제공하는 단면을 축을 중심으로 회전시켜 고체 모델을 나타냅니다. |
+| [RvmFormat](../aspose.threed/rvmformat) | RVM 포맷  @hideconstructor |
+| [RvmLoadOptions](../aspose.threed/rvmloadoptions) | AVEVA Plant Design Management System의 RVM 파일에 대한 로드 옵션. |
+| [RvmSaveOptions](../aspose.threed/rvmsaveoptions) | Aveva PDMS RVM 파일에 대한 저장 옵션. |
+| [SaveOptions](../aspose.threed/saveoptions) | 다양한 유형에 대한 파일 저장 옵션을 구성하기 위한 기본 클래스  @hideconstructor |
+| [Scene](../aspose.threed/scene) | Scene은 노드, 기하학, 재질, 텍스처, 애니메이션, 포즈, 서브 씬 등을 포함하는 최상위 객체입니다.  Scene은 서브 씬을 가질 수 있으며, collada/blender/fbx와 같은 파일에서 다중 문서 지원 역할을 합니다.  Node 계층 구조는 RootNodeLibrary를 통해 접근할 수 있으며, 직렬화 중에 연결되지 않은 객체(메타 데이터 또는 사용자 정의 객체 등)의 참조를 유지하기 위해 사용되어 라이브러리로 활용됩니다. |
+| [SceneObject](../aspose.threed/sceneobject) | Scene 내부에 저장될 객체들의 루트 클래스. |
+| [ShaderException](../aspose.threed/shaderexception) | 셰이더 관련 예외 |
+| [ShaderMaterial](../aspose.threed/shadermaterial) | 셰이더 머티리얼은 외부 렌더링 엔진이나 셰이더 언어를 사용하여 머티리얼을 설명할 수 있게 합니다.  ShaderMaterial은 구체적인 렌더링 세부 사항을 설명하기 위해 ShaderTechnique을 사용하며, 최종 렌더링 플랫폼에 따라 가장 적합한 것이 사용됩니다.  예를 들어, ShaderMaterial 인스턴스는 두 개의 technique을 가질 수 있는데, 하나는 HLSL로 정의되고 다른 하나는 GLSL로 정의됩니다.  비윈도우 플랫폼에서는 HLSL 대신 GLSL을 사용해야 합니다. |
+| [ShaderProgram](../aspose.threed/shaderprogram) | 셰이더 프로그램  @hideconstructor |
+| [ShaderSet](../aspose.threed/shaderset) | 각 종류의 머티리얼에 대한 셰이더 프로그램 |
+| [ShaderSource](../aspose.threed/shadersource) | 셰이더의 소스 코드  @hideconstructor |
+| [ShaderTechnique](../aspose.threed/shadertechnique) | Shader technique은 구체적인 렌더링 구현을 나타냅니다. |
+| [ShaderVariable](../aspose.threed/shadervariable) | 셰이더 변수 |
+| [Shape](../aspose.threed/shape) | Shape은 일련의 컨트롤 포인트에 대한 변형을 설명하며, 이는 Maya의 클러스터 디포머와 유사합니다.  예를 들어, 생성된 기하학에 Shape을 추가할 수 있습니다.  Shape과 기하학은 동일한 토폴로지 정보를 가지지만 컨트롤 포인트의 위치는 다릅니다.  영향 정도가 다르게 적용되어 기하학은 변형 효과를 수행합니다. |
+| [Skeleton](../aspose.threed/skeleton) | Skeleton은 주로 CAD 소프트웨어에서 디자이너가 골격 구조의 변환을 조작하도록 돕기 위해 사용되며, CAD 소프트웨어 외부에서는 보통 쓸모가 없습니다. Skeleton 계층을 CAD 소프트웨어에서 하나의 객체처럼 동작하게 하려면, 최상위 Skeleton 노드를 Type을 SkeletonType.SKELETON으로 설정하여 루트로 표시하고, 모든 자식은 SkeletonType.BONE으로 설정해야 합니다. |
+| [SkinDeformer](../aspose.threed/skindeformer) | 스킨 디포머는 여러 개의 본을 포함하며, 각 본은 컨트롤 포인트 가중치를 통해 기하학의 일부를 블렌딩합니다. |
+| [Sphere](../aspose.threed/sphere) | 파라미터화된 구. |
+| [SPIRVSource](../aspose.threed/spirvsource) | SPIR-V 형식의 컴파일된 셰이더. |
+| [StencilState](../aspose.threed/stencilstate) | 각 면에 대한 스텐실 상태.  @hideconstructor |
+| [StlLoadOptions](../aspose.threed/stlloadoptions) | STL 로드 옵션 |
+| [StlSaveOptions](../aspose.threed/stlsaveoptions) | STL 저장 옵션 |
+| [SweptAreaSolid](../aspose.threed/sweptareasolid) | SweptAreaSolid은 프로파일을 직접선(directrix)을 따라 스윕하여 기하학을 구성합니다. |
+| [Text](../aspose.threed/text) | 텍스트 프로파일은 폰트와 텍스트를 사용하여 윤곽을 설명합니다. |
+| [Texture](../aspose.threed/texture) | 이 클래스는 외부 파일에서 텍스처를 정의합니다. |
+| [TextureBase](../aspose.threed/texturebase) | 구체적인 모든 텍스처의 기본 클래스입니다.  Texture는 기하학 표면의 외관과 느낌을 정의합니다. |
+| [TextureCodec](../aspose.threed/texturecodec) | 텍스처용 인코더와 디코더를 관리하는 클래스입니다. |
+| [TextureData](../aspose.threed/texturedata) | 이 클래스는 텍스처의 원시 데이터와 포맷 정의를 포함합니다. |
+| [TextureSlot](../aspose.threed/textureslot) | Material의 텍스처 슬롯으로, material 인스턴스를 통해 열거할 수 있습니다.  @hideconstructor |
+| [Torus](../aspose.threed/torus) | 파라미터화된 토러스. |
+| [Transform](../aspose.threed/transform) | Transform은 객체의 이동/스케일/회전 또는 변환 행렬에 최소 비용으로 접근할 수 있는 정보를 포함합니다. 이는 로컬 변환에 사용됩니다.  @hideconstructor |
+| [TransformBuilder](../aspose.threed/transformbuilder) | TransformBuilder는 일련의 변환을 통해 변환 행렬을 구축하는 데 사용됩니다. |
+| [TransformedCurve](../aspose.threed/transformedcurve) | TransformedCurve는 변환 행렬을 사용하여 곡선에 위치를 부여합니다. 이를 통해 TrimmedCurve 또는 CompositeCurve 내부에서 변환을 수행할 수 있습니다. |
+| [TrapeziumShape](../aspose.threed/trapeziumshape) | 파라미터로 정의된 IFC 호환 트라페지움 형태. |
+| [TrialException](../aspose.threed/trialexception) | 라이선스가 적용되지 않은 경우 Scene.Open/Scene.Save에서 이 예외가 발생합니다. SuppressTrialException을 true로 설정하면 이 예외를 끌 수 있습니다. |
+| [TriMesh](../aspose.threed/trimesh) | TriMesh는 GPU에서 직접 사용할 수 있는 원시 데이터를 포함합니다. 이 클래스는 정점당 데이터만 포함하는 메쉬를 구성하는 데 도움이 되는 유틸리티입니다. |
+| [TrimmedCurve](../aspose.threed/trimmedcurve) | 양쪽 끝에서 기본 곡선을 잘라낸 제한된 곡선. |
+| [TShape](../aspose.threed/tshape) | 파라미터로 정의된 IFC 호환 T형. |
+| [U3dLoadOptions](../aspose.threed/u3dloadoptions) | 유니버설 3D 로드 옵션 |
+| [U3dSaveOptions](../aspose.threed/u3dsaveoptions) | 유니버설 3D 저장 옵션 |
+| [UsdSaveOptions](../aspose.threed/usdsaveoptions) | USD/USDZ 형식에 대한 저장 옵션. |
+| [UShape](../aspose.threed/ushape) | 매개변수로 정의된 IFC 호환 U-형. |
+| [Vector2](../aspose.threed/vector2) | 두 개의 구성 요소를 가진 벡터. |
+| [Vector3](../aspose.threed/vector3) | 세 개의 구성 요소를 가진 벡터. |
+| [Vector4](../aspose.threed/vector4) | 네 개의 구성 요소를 가진 벡터. |
+| [Vertex](../aspose.threed/vertex) | TriMesh에서 원시 정점을 액세스하는 데 사용되는 정점 참조.  @hideconstructor |
+| [VertexDeclaration](../aspose.threed/vertexdeclaration) | 사용자 정의 정점 구조의 선언 |
+| [VertexElement](../aspose.threed/vertexelement) | 정점 요소의 기본 클래스.  정점 요소 유형은 VertexElementType으로 식별됩니다.  VertexElement는 정점 요소가 기하학 표면에 어떻게 매핑되는지와 매핑 정보가 메모리에 어떻게 배치되는지를 설명합니다.  VertexElement는 Normals, UVs 또는 기타 종류의 정보를 포함합니다.  @hideconstructor |
+| [VertexElementBinormal](../aspose.threed/vertexelementbinormal) | 지정된 구성 요소에 대한 이중법선 벡터를 정의합니다. |
+| [VertexElementDoublesTemplate](../aspose.threed/vertexelementdoublestemplate) | 구체적인 VertexElement 구현을 정의하기 위한 도우미 클래스.  @hideconstructor |
+| [VertexElementEdgeCrease](../aspose.threed/vertexelementedgecrease) | 지정된 구성 요소에 대한 에지 크리스를 정의합니다. |
+| [VertexElementHole](../aspose.threed/vertexelementhole) | 지정된 폴리곤이 구멍인지 여부를 정의합니다. |
+| [VertexElementIntsTemplate](../aspose.threed/vertexelementintstemplate) | 구체적인 VertexElement 구현을 정의하기 위한 도우미 클래스.  @hideconstructor |
+| [VertexElementMaterial](../aspose.threed/vertexelementmaterial) | 지정된 구성 요소에 대한 재질 인덱스를 정의합니다.  노드는 여러 재질을 가질 수 있으며, VertexElementMaterial은 기하학의 다른 부분을 서로 다른 재질로 렌더링하는 데 사용됩니다. |
+| [VertexElementNormal](../aspose.threed/vertexelementnormal) | 지정된 구성 요소에 대한 법선 벡터를 정의합니다. |
+| [VertexElementPolygonGroup](../aspose.threed/vertexelementpolygongroup) | 관련 폴리곤을 함께 묶기 위해 지정된 구성 요소에 대한 폴리곤 그룹을 정의합니다. |
+| [VertexElementSmoothingGroup](../aspose.threed/vertexelementsmoothinggroup) | 스무딩 그룹은 매끄러운 표면을 형성하는 것처럼 보이는 폴리곤 메시의 폴리곤 그룹입니다.  DOS용 3D Studio Max와 같은 초기 3D 모델링 소프트웨어는 각 메시 정점에 대한 법선 벡터 저장을 피하기 위해 스무딩 그룹을 사용했습니다. |
+| [VertexElementSpecular](../aspose.threed/vertexelementspecular) | 지정된 구성 요소에 대한 반사광 색상을 정의합니다. |
+| [VertexElementTangent](../aspose.threed/vertexelementtangent) | 지정된 구성 요소에 대한 접선 벡터를 정의합니다. |
+| [VertexElementUserData](../aspose.threed/vertexelementuserdata) | 지정된 구성 요소에 대한 사용자 정의 데이터를 정의합니다.  일반적으로 이는 특수 목적을 위한 애플리케이션 전용 데이터입니다. |
+| [VertexElementUV](../aspose.threed/vertexelementuv) | 지정된 구성 요소에 대한 UV 좌표를 정의합니다.  기하학은 여러 VertexElementUV 요소를 가질 수 있으며, 각 요소는 서로 다른 TextureMappings를 가집니다. |
+| [VertexElementVector4](../aspose.threed/vertexelementvector4) | 구체적인 VertexElement 구현을 정의하기 위한 도우미 클래스.  @hideconstructor |
+| [VertexElementVertexColor](../aspose.threed/vertexelementvertexcolor) | 지정된 구성 요소에 대한 정점 색상을 정의합니다 |
+| [VertexElementVertexCrease](../aspose.threed/vertexelementvertexcrease) | 지정된 구성 요소에 대한 정점 크리스를 정의합니다 |
+| [VertexElementVisibility](../aspose.threed/vertexelementvisibility) | 지정된 구성 요소가 보이는지 여부를 정의합니다 |
+| [VertexElementWeight](../aspose.threed/vertexelementweight) | 지정된 구성 요소에 대한 블렌드 가중치를 정의합니다. |
+| [VertexField](../aspose.threed/vertexfield) | 정점 필드 메모리 레이아웃 설명.  @hideconstructor |
+| [Viewport](../aspose.threed/viewport) | com.aspose.threed.IRenderTarget은 장면을 렌더링하기 위해 최소 하나의 뷰포트를 포함합니다.  @hideconstructor |
+| [Watermark](../aspose.threed/watermark) | 메시에서 블라인드 워터마크를 인코딩/디코딩하기 위한 유틸리티.  @hideconstructor |
+| [WindowHandle](../aspose.threed/windowhandle) | 다양한 플랫폼용 캡슐화된 윈도우 핸들.  @hideconstructor |
+| [XLoadOptions](../aspose.threed/xloadoptions) | DirectX X 파일에 대한 로드 옵션. |
+| [ZipArchiveFileSystem](../aspose.threed/ziparchivefilesystem) | 지정된 zip 파일 또는 zip 스트림에 대한 읽기 전용 액세스를 제공하는 파일 시스템. 파일 시스템은 열기/저장 작업 후에 해제됩니다. |
+| [ZShape](../aspose.threed/zshape) | 매개변수로 정의된 IFC 호환 Z형 프로파일. |
+| [CubeFace](../aspose.threed/cubeface) | 상수들을 포함하는 유틸리티 클래스. 큐브 맵 텍스처의 각 면  @hideconstructor |
+| [IndexDataType](../aspose.threed/indexdatatype) | 상수들을 포함하는 유틸리티 클래스. com.aspose.threed.IIndexBuffer의 요소 데이터 타입  @hideconstructor |

--- a/korean/nodejs-java/aspose.threed/a3dobject/_index.md
+++ b/korean/nodejs-java/aspose.threed/a3dobject/_index.md
@@ -1,0 +1,183 @@
+---
+title: "A3DObject"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/a3dobject/
+---
+## A3DObject class
+
+모든 Aspose.ThreeD 객체의 기본 클래스이며, 모든 하위 클래스는 동적 속성을 지원합니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor(name) | A3DObject 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| name | String | 이름 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload() | 이름 없이 A3DObject 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/a3dwsaveoptions/_index.md
+++ b/korean/nodejs-java/aspose.threed/a3dwsaveoptions/_index.md
@@ -1,0 +1,198 @@
+---
+title: "A3dwSaveOptions"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/a3dwsaveoptions/
+---
+## A3dwSaveOptions class
+
+A3DW 형식에 대한 저장 옵션.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | A3dwSaveOptions의 생성자 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportMetaData{#getExportMetaData}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExportMetaData() | Scene/Node와 연결된 메타 데이터를 클라이언트에 내보냅니다. 기본값은 true입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportMetaData{#setExportMetaData}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExportMetaData(value) | Scene/Node와 연결된 메타 데이터를 클라이언트에 내보냅니다. 기본값은 true입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMetaDataPrefix{#getMetaDataPrefix}
+
+| 이름 | 설명 |
+| --- | --- |
+| getMetaDataPrefix() | 이 속성이 null이 아니면, 이 접두사로 시작하는 Scene/Node의 속성만 내보내지며, 접두사는 제거됩니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMetaDataPrefix{#setMetaDataPrefix}
+
+| 이름 | 설명 |
+| --- | --- |
+| setMetaDataPrefix(value) | 이 속성이 null이 아니면, 이 접두사로 시작하는 Scene/Node의 속성만 내보내지며, 접두사는 제거됩니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportTextures{#getExportTextures}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExportTextures() | 씬에서 사용된 텍스처를 출력 디렉터리로 복사합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextures{#setExportTextures}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExportTextures(value) | 씬에서 사용된 텍스처를 출력 디렉터리로 복사합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileFormat() | 현재 저장/로드 옵션에 지정된 파일 형식을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEncoding() | 텍스트 기반 파일에 대한 기본 인코딩을 가져오거나 설정합니다. 기본값은 null이며, 이는 가져오기/내보내기 프로그램이 사용할 인코딩을 결정함을 의미합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileSystem() | 로드/저장 중 외부 종속성을 관리하는 방법을 사용자가 처리하도록 허용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFileSystem(value) | 로드/저장 중 외부 종속성을 관리하는 방법을 사용자가 처리하도록 허용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| 이름 | 설명 |
+| --- | --- |
+| getLookupPaths() | OBJ와 같은 일부 파일은 외부 파일에 의존하며, 조회 경로를 통해 Aspose.3D가 외부 파일을 찾아 로드할 수 있도록 합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileName() | 내보내기/가져오기 씬의 파일 이름입니다. 선택 사항이지만 OBJ의 재질과 같은 외부 자산을 직렬화할 때 유용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFileName(value) | 내보내기/가져오기 씬의 파일 이름입니다. 선택 사항이지만 OBJ의 재질과 같은 외부 자산을 직렬화할 때 유용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/amfsaveoptions/_index.md
+++ b/korean/nodejs-java/aspose.threed/amfsaveoptions/_index.md
@@ -1,0 +1,172 @@
+---
+title: "AmfSaveOptions"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/amfsaveoptions/
+---
+## AmfSaveOptions class
+
+AMF에 대한 저장 옵션
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | AmfSaveOptions의 생성자 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEnableCompression{#getEnableCompression}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEnableCompression() | 최종 파일 크기를 줄이기 위해 압축을 사용할지 여부이며, 기본값은 true입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setEnableCompression{#setEnableCompression}
+
+| 이름 | 설명 |
+| --- | --- |
+| setEnableCompression(value) | 최종 파일 크기를 줄이기 위해 압축을 사용할지 여부이며, 기본값은 true입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportTextures{#getExportTextures}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExportTextures() | 씬에서 사용된 텍스처를 출력 디렉터리로 복사합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextures{#setExportTextures}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExportTextures(value) | 씬에서 사용된 텍스처를 출력 디렉터리로 복사합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileFormat() | 현재 저장/로드 옵션에 지정된 파일 형식을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEncoding() | 텍스트 기반 파일에 대한 기본 인코딩을 가져오거나 설정합니다. 기본값은 null이며, 이는 가져오기/내보내기 프로그램이 사용할 인코딩을 결정함을 의미합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileSystem() | 로드/저장 중 외부 종속성을 관리하는 방법을 사용자가 처리하도록 허용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFileSystem(value) | 로드/저장 중 외부 종속성을 관리하는 방법을 사용자가 처리하도록 허용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| 이름 | 설명 |
+| --- | --- |
+| getLookupPaths() | OBJ와 같은 일부 파일은 외부 파일에 의존하며, 조회 경로를 통해 Aspose.3D가 외부 파일을 찾아 로드할 수 있도록 합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileName() | 내보내기/가져오기 씬의 파일 이름입니다. 선택 사항이지만 OBJ의 재질과 같은 외부 자산을 직렬화할 때 유용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFileName(value) | 내보내기/가져오기 씬의 파일 이름입니다. 선택 사항이지만 OBJ의 재질과 같은 외부 자산을 직렬화할 때 유용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/animationchannel/_index.md
+++ b/korean/nodejs-java/aspose.threed/animationchannel/_index.md
@@ -1,0 +1,113 @@
+---
+title: "AnimationChannel"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/animationchannel/
+---
+## AnimationChannel class
+
+채널은 속성의 구성 요소 필드를 일련의 키프레임 시퀀스로 매핑합니다  @hideconstructor
+
+
+## 메서드
+
+### getComponentType{#getComponentType}
+
+| 이름 | 설명 |
+| --- | --- |
+| getComponentType() | 구성 요소 필드의 유형을 가져옵니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 채널의 이름을 가져옵니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getDefaultValue{#getDefaultValue}
+
+| 이름 | 설명 |
+| --- | --- |
+| getDefaultValue() | 채널의 기본값을 가져오거나 설정합니다. 채널에 키프레임 시퀀스가 연결되지 않은 경우, 애니메이션 평가 중에 기본값이 사용됩니다. 실제 시나리오: 애니메이션이 노드의 x 좌표만 애니메이션하고 y와 z는 변경되지 않을 때, 전체 변환 평가 중에 기본값이 사용됩니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDefaultValue{#setDefaultValue}
+
+| 이름 | 설명 |
+| --- | --- |
+| setDefaultValue(value) | 채널의 기본값을 가져오거나 설정합니다. 채널에 키프레임 시퀀스가 연결되지 않은 경우, 애니메이션 평가 중에 기본값이 사용됩니다. 실제 시나리오: 애니메이션이 노드의 x 좌표만 애니메이션하고 y와 z는 변경되지 않을 때, 전체 변환 평가 중에 기본값이 사용됩니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getKeyframeSequences{#getKeyframeSequences}
+
+| 이름 | 설명 |
+| --- | --- |
+| getKeyframeSequences() | 이 채널 내부의 모든 키프레임 시퀀스를 가져옵니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### addKeyframeSequence{#addKeyframeSequence}
+
+| 이름 | 설명 |
+| --- | --- |
+| addKeyframeSequence(sequence) | 키프레임 시퀀스를 이 채널에 추가합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| sequence | KeyframeSequence | 추가할 키프레임 시퀀스입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### iterator{#iterator}
+
+| 이름 | 설명 |
+| --- | --- |
+| iterator() | 내부 사용을 위해 예약되었습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/animationclip/_index.md
+++ b/korean/nodejs-java/aspose.threed/animationclip/_index.md
@@ -1,0 +1,306 @@
+---
+title: "AnimationClip"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/animationclip/
+---
+## AnimationClip class
+
+Animation 클립은 애니메이션의 컬렉션입니다. 씬은 하나 이상의 애니메이션 클립을 가질 수 있습니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | AnimationClip 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload(name) | AnimationClip 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| name | String | 이름 |
+
+ **Result:**
+
+
+
+---
+
+
+### getAnimations{#getAnimations}
+
+| 이름 | 설명 |
+| --- | --- |
+| getAnimations() | 클립에 포함된 애니메이션을 가져옵니다. 레이어. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDescription{#getDescription}
+
+| 이름 | 설명 |
+| --- | --- |
+| getDescription() | 이 애니메이션 클립의 설명을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDescription{#setDescription}
+
+| 이름 | 설명 |
+| --- | --- |
+| setDescription(value) | 이 애니메이션 클립의 설명을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getStart{#getStart}
+
+| 이름 | 설명 |
+| --- | --- |
+| getStart() | 클립 시작 시점의 시간을 초 단위로 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setStart{#setStart}
+
+| 이름 | 설명 |
+| --- | --- |
+| setStart(value) | 클립 시작 시점의 시간을 초 단위로 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getStop{#getStop}
+
+| 이름 | 설명 |
+| --- | --- |
+| getStop() | 클립 종료 시점의 시간을 초 단위로 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setStop{#setStop}
+
+| 이름 | 설명 |
+| --- | --- |
+| setStop(value) | 클립 종료 시점의 시간을 초 단위로 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 이름 | 설명 |
+| --- | --- |
+| getScene() | 이 객체가 속한 씬을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### createAnimationNode{#createAnimationNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| createAnimationNode(nodeName) | 현재 클립에 애니메이션 노드를 생성하고 등록하는 단축 함수입니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| nodeName | String | 새 애니메이션 노드의 이름 |
+
+ **Result:**
+AnimationNode
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/animationnode/_index.md
+++ b/korean/nodejs-java/aspose.threed/animationnode/_index.md
@@ -1,0 +1,312 @@
+---
+title: "AnimationNode"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/animationnode/
+---
+## AnimationNode class
+
+Aspose.3D는 애니메이션 계층 구조를 지원하며, 각 애니메이션은 여러 애니메이션 및 애니메이션의 키프레임 정의로 구성될 수 있습니다. AnimationNode는 시간에 따라 속성 값의 변환을 정의합니다. 예를 들어, animation node는 노드의 변환이나 다른 A3DObject 객체의 수치 속성을 제어하는 데 사용할 수 있습니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor(name) | AnimationNode 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| name | String | 이름 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload() | AnimationNode 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getBindPoints{#getBindPoints}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBindPoints() | 현재 속성 바인드 포인트를 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getSubAnimations{#getSubAnimations}
+
+| 이름 | 설명 |
+| --- | --- |
+| getSubAnimations() | 현재 애니메이션 아래의 서브 애니메이션 노드를 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### findBindPoint{#findBindPoint}
+
+| 이름 | 설명 |
+| --- | --- |
+| findBindPoint(name) | 이름으로 바인드 포인트를 찾습니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| name | String | 찾을 바인드 포인트의 이름. |
+
+ **Result:**
+BindPoint
+
+
+---
+
+
+### getBindPoint{#getBindPoint}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBindPoint(target, propName, create) | 주어진 속성에 대한 애니메이션 바인드 포인트를 가져옵니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 대상 | A3DObject | 바인드 포인트를 생성할 객체를 지정합니다. |
+| propName | String | 속성의 이름입니다. |
+| 생성 | boolean | 설정된 경우 |
+
+ **Result:**
+BindPoint
+
+
+---
+
+
+### getKeyframeSequence{#getKeyframeSequence}
+
+| 이름 | 설명 |
+| --- | --- |
+| getKeyframeSequence(target, propName, channelName, create) | 주어진 속성 및 채널에 대한 키프레임 시퀀스를 가져옵니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 대상 | A3DObject | 키프레임 시퀀스를 생성할 인스턴스를 지정합니다. |
+| propName | String | 속성의 이름입니다. |
+| channelName | String | 채널 이름입니다. |
+| 생성 | boolean | 설정된 경우 |
+
+ **Result:**
+KeyframeSequence
+
+
+---
+
+
+### getKeyframeSequence{#getKeyframeSequence}
+
+| 이름 | 설명 |
+| --- | --- |
+| getKeyframeSequence(target, propName, create) | 주어진 속성에 대한 키프레임 시퀀스를 가져옵니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 대상 | A3DObject | 키프레임 시퀀스를 생성할 인스턴스를 지정합니다. |
+| propName | String | 속성의 이름입니다. |
+| 생성 | boolean | 설정된 경우 |
+
+ **Result:**
+KeyframeSequence
+
+
+---
+
+
+### createBindPoint{#createBindPoint}
+
+| 이름 | 설명 |
+| --- | --- |
+| createBindPoint(obj, propName) | 속성 데이터 유형을 기반으로 BindPoint를 생성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| obj | A3DObject | 객체. |
+| propName | String | 속성 이름. |
+
+ **Result:**
+BindPoint
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/arbitraryprofile/_index.md
+++ b/korean/nodejs-java/aspose.threed/arbitraryprofile/_index.md
@@ -1,0 +1,313 @@
+---
+title: "ArbitraryProfile"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/arbitraryprofile/
+---
+## ArbitraryProfile class
+
+이 클래스는 임의의 곡선으로부터 직접 2D 프로파일을 구성할 수 있게 합니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | ArbitraryProfile의 생성자 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload(curve) | 초기 곡선을 사용한 ArbitraryProfile의 생성자. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| curv | 곡선 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### getCurve{#getCurve}
+
+| 이름 | 설명 |
+| --- | --- |
+| getCurve() | 프로파일을 구성하는 데 사용된 Curve |
+
+ **Result:**
+
+
+
+---
+
+
+### setCurve{#setCurve}
+
+| 이름 | 설명 |
+| --- | --- |
+| setCurve(value) | 프로파일을 구성하는 데 사용된 Curve |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNodes() | 모든 부모 노드를 가져옵니다. 엔터티는 기하학 인스턴싱을 위해 여러 부모 노드에 부착될 수 있습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExcluded() | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExcluded(value) | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNode() | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setParentNode(value) | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 이름 | 설명 |
+| --- | --- |
+| getScene() | 이 객체가 속한 씬을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEntityRendererKey() | 렌더러에 등록된 엔터티 렌더러의 키를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBoundingBox() | 현재 엔터티의 객체 공간 좌표계에서 경계 상자를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/assetinfo/_index.md
+++ b/korean/nodejs-java/aspose.threed/assetinfo/_index.md
@@ -1,0 +1,586 @@
+---
+title: "AssetInfo"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/assetinfo/
+---
+## AssetInfo class
+
+자산 정보. 자산 정보는 Scene에 첨부될 수 있습니다. 자식 Scene은 자체 AssetInfo를 가지고 부모의 정의를 재정의할 수 있습니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | AssetInfo 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload(name) | AssetInfo 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| name | String | 이름 |
+
+ **Result:**
+
+
+
+---
+
+
+### getCreationTime{#getCreationTime}
+
+| 이름 | 설명 |
+| --- | --- |
+| getCreationTime() | 이 자산의 생성 시간을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getModificationTime{#getModificationTime}
+
+| 이름 | 설명 |
+| --- | --- |
+| getModificationTime() | 이 자산의 수정 시간을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAmbient{#getAmbient}
+
+| 이름 | 설명 |
+| --- | --- |
+| getAmbient() | 이 자산의 기본 주변 색상을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getUrl{#getUrl}
+
+| 이름 | 설명 |
+| --- | --- |
+| getUrl() | 이 자산의 URL을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setUrl{#setUrl}
+
+| 이름 | 설명 |
+| --- | --- |
+| setUrl(value) | 이 자산의 URL을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getApplicationVendor{#getApplicationVendor}
+
+| 이름 | 설명 |
+| --- | --- |
+| getApplicationVendor() | 애플리케이션 공급업체의 이름을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setApplicationVendor{#setApplicationVendor}
+
+| 이름 | 설명 |
+| --- | --- |
+| setApplicationVendor(value) | 애플리케이션 공급업체의 이름을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getCopyright{#getCopyright}
+
+| 이름 | 설명 |
+| --- | --- |
+| getCopyright() | 문서의 저작권 정보를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setCopyright{#setCopyright}
+
+| 이름 | 설명 |
+| --- | --- |
+| setCopyright(value) | 문서의 저작권 정보를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getApplicationName{#getApplicationName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getApplicationName() | 이 자산을 만든 애플리케이션을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setApplicationName{#setApplicationName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setApplicationName(value) | 이 자산을 만든 애플리케이션을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getApplicationVersion{#getApplicationVersion}
+
+| 이름 | 설명 |
+| --- | --- |
+| getApplicationVersion() | 이 자산을 만든 애플리케이션의 버전을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setApplicationVersion{#setApplicationVersion}
+
+| 이름 | 설명 |
+| --- | --- |
+| setApplicationVersion(value) | 이 자산을 만든 애플리케이션의 버전을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTitle{#getTitle}
+
+| 이름 | 설명 |
+| --- | --- |
+| getTitle() | 이 자산의 제목을 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### setTitle{#setTitle}
+
+| 이름 | 설명 |
+| --- | --- |
+| setTitle(value) | 이 자산의 제목을 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getSubject{#getSubject}
+
+| 이름 | 설명 |
+| --- | --- |
+| getSubject() | 이 자산의 주제를 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### setSubject{#setSubject}
+
+| 이름 | 설명 |
+| --- | --- |
+| setSubject(value) | 이 자산의 주제를 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getAuthor{#getAuthor}
+
+| 이름 | 설명 |
+| --- | --- |
+| getAuthor() | 이 자산의 저자를 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### setAuthor{#setAuthor}
+
+| 이름 | 설명 |
+| --- | --- |
+| setAuthor(value) | 이 자산의 저자를 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getKeywords{#getKeywords}
+
+| 이름 | 설명 |
+| --- | --- |
+| getKeywords() | 이 자산의 키워드를 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### setKeywords{#setKeywords}
+
+| 이름 | 설명 |
+| --- | --- |
+| setKeywords(value) | 이 자산의 키워드를 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getRevision{#getRevision}
+
+| 이름 | 설명 |
+| --- | --- |
+| getRevision() | 이 자산의 리비전 번호를 가져오거나 설정합니다. 일반적으로 버전 관리 시스템에서 사용됩니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRevision{#setRevision}
+
+| 이름 | 설명 |
+| --- | --- |
+| setRevision(value) | 이 자산의 리비전 번호를 가져오거나 설정합니다. 일반적으로 버전 관리 시스템에서 사용됩니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getComment{#getComment}
+
+| 이름 | 설명 |
+| --- | --- |
+| getComment() | 이 자산의 주석을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setComment{#setComment}
+
+| 이름 | 설명 |
+| --- | --- |
+| setComment(value) | 이 자산의 주석을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getUnitName{#getUnitName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getUnitName() | 이 자산에서 사용되는 길이 단위를 가져오거나 설정합니다. 예: cm/m/km/inch/feet |
+
+ **Result:**
+
+
+
+---
+
+
+### setUnitName{#setUnitName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setUnitName(value) | 이 자산에서 사용되는 길이 단위를 가져오거나 설정합니다. 예: cm/m/km/inch/feet |
+
+ **Result:**
+
+
+
+---
+
+
+### getUnitScaleFactor{#getUnitScaleFactor}
+
+| 이름 | 설명 |
+| --- | --- |
+| getUnitScaleFactor() | 실제 미터에 대한 스케일 팩터를 가져오거나 설정합니다. 단위 이름이 null인 경우 직렬화 중에 무시됩니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setUnitScaleFactor{#setUnitScaleFactor}
+
+| 이름 | 설명 |
+| --- | --- |
+| setUnitScaleFactor(value) | 실제 미터에 대한 스케일 팩터를 가져오거나 설정합니다. 단위 이름이 null인 경우 직렬화 중에 무시됩니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getCoordinatedSystem{#getCoordinatedSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| getCoordinatedSystem() | 이 자산에서 사용되는 좌표계를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getUpVector{#getUpVector}
+
+| 이름 | 설명 |
+| --- | --- |
+| getUpVector() | 이 자산에서 사용되는 업 벡터를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/bindpoint/_index.md
+++ b/korean/nodejs-java/aspose.threed/bindpoint/_index.md
@@ -1,0 +1,386 @@
+---
+title: "BindPoint"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/bindpoint/
+---
+## BindPoint class
+
+BindPoint는 일반적으로 객체의 속성에 생성되며, 일부 속성 유형은 여러 구성 요소 필드(예: Vector3 필드)를 포함합니다. BindPoint는 각 구성 요소 필드에 대해 채널을 생성하고, 해당 필드를 하나 이상의 키프레임 시퀀스 인스턴스와 채널을 통해 연결합니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor(scene, prop) | BindPoint 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| scene | Scene | 애니메이션을 포함하는 씬입니다. |
+| prop | 속성 | 속성. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty() | CurveMapping과 연결된 속성을 가져옵니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(value) | CurveMapping과 연결된 속성을 가져옵니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getChannelsCount{#getChannelsCount}
+
+| 이름 | 설명 |
+| --- | --- |
+| getChannelsCount() | 이 애니메이션 커브 매핑에 정의된 속성 채널의 총 개수를 가져옵니다. |
+
+ **Result:**
+숫자
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+숫자
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+숫자
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+숫자
+
+
+---
+
+
+### get{#get}
+
+| 이름 | 설명 |
+| --- | --- |
+| get(channelName) |  |
+
+ **Result:**
+숫자
+
+
+---
+
+
+### getKeyframeSequence{#getKeyframeSequence}
+
+| 이름 | 설명 |
+| --- | --- |
+| getKeyframeSequence(channelName) | 지정된 채널에서 첫 번째 키프레임 시퀀스를 가져옵니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| channelName | String | 찾을 채널 이름 |
+
+ **Result:**
+KeyframeSequence
+
+
+---
+
+
+### getKeyframeSequences{#getKeyframeSequences}
+
+| 이름 | 설명 |
+| --- | --- |
+| getKeyframeSequences(channelName) | 지정된 채널의 모든 키프레임 시퀀스를 가져옵니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| channelName | String | 찾을 채널 이름 |
+
+ **Result:**
+0, Culture=neutral, PublicKeyToken=f071c641d0b4582b]]
+
+
+---
+
+
+### createKeyframeSequence{#createKeyframeSequence}
+
+| 이름 | 설명 |
+| --- | --- |
+| createKeyframeSequence(name) | 새 곡선을 생성하고 곡선 매핑의 첫 번째 채널에 연결합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| name | String | 새 시퀀스의 이름입니다. |
+
+ **Result:**
+KeyframeSequence
+
+
+---
+
+
+### bindKeyframeSequence{#bindKeyframeSequence}
+
+| 이름 | 설명 |
+| --- | --- |
+| bindKeyframeSequence(channelName, sequence) | 키프레임 시퀀스를 지정된 채널에 바인드합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| channelName | String | 키프레임 시퀀스가 바인드될 채널 |
+| sequence | KeyframeSequence | 바인드할 키프레임 시퀀스 |
+
+ **Result:**
+KeyframeSequence
+
+
+---
+
+
+### getChannel{#getChannel}
+
+| 이름 | 설명 |
+| --- | --- |
+| getChannel(channelName) | 주어진 이름으로 채널을 가져옵니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| channelName | String | 찾을 채널 이름 |
+
+ **Result:**
+AnimationChannel
+
+
+---
+
+
+### addChannel{#addChannel}
+
+| 이름 | 설명 |
+| --- | --- |
+| addChannel(name, value) | 지정된 채널 속성을 추가합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| name | String | 이름. |
+| value | Object | 값. |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### addChannel{#addChannel}
+
+| 이름 | 설명 |
+| --- | --- |
+| addChannel(name, type, value) | 지정된 채널 속성을 추가합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| name | String | 이름. |
+| type | 클래스 | 유형. |
+| value | Object | 값. |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### resetChannels{#resetChannels}
+
+| 이름 | 설명 |
+| --- | --- |
+| resetChannels() | 이 애니메이션 곡선 매핑의 속성 채널을 비웁니다. |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### toString{#toString}
+
+| 이름 | 설명 |
+| --- | --- |
+| toString() | 객체를 문자열로 포맷합니다. |
+
+ **Result:**
+String
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/bone/_index.md
+++ b/korean/nodejs-java/aspose.threed/bone/_index.md
@@ -1,0 +1,339 @@
+---
+title: "본"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/bone/
+---
+## Bone class
+
+Bone은 지오메트리의 컨트롤 포인트 하위 집합을 정의하고, 각 컨트롤 포인트에 대한 블렌드 가중치를 정의합니다. Bone 객체는 직접 사용할 수 없으며, SkinDeformer 인스턴스를 사용하여 지오메트리를 변형합니다. SkinDeformer는 여러 Bone을 포함하며, 각 Bone은 노드에 연결됩니다. NOTE: 지오메트리의 컨트롤 포인트는 둘 이상의 Bone에 바인딩될 수 있습니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor(name) | Bone 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| name | String | 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload() | Bone 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getWeightCount{#getWeightCount}
+
+| 이름 | 설명 |
+| --- | --- |
+| getWeightCount() | 가중치 수를 가져옵니다. 이는 setWeight(int, double)로 자동으로 확장됩니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTransform{#getTransform}
+
+| 이름 | 설명 |
+| --- | --- |
+| getTransform() | 본을 포함하는 노드의 변환 행렬을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTransform{#setTransform}
+
+| 이름 | 설명 |
+| --- | --- |
+| setTransform(value) | 본을 포함하는 노드의 변환 행렬을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getBoneTransform{#getBoneTransform}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBoneTransform() | 본의 변환 행렬을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setBoneTransform{#setBoneTransform}
+
+| 이름 | 설명 |
+| --- | --- |
+| setBoneTransform(value) | 본의 변환 행렬을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getNode{#getNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getNode() | 노드를 가져오거나 설정합니다. 본 노드는 스킨이 부착되는 본이며, SkinDeformer는 본 노드를 사용하여 컨트롤 포인트의 변위를 영향을 줍니다. 본 노드에는 일반적으로 Skeleton이 연결되어 있지만 필수는 아닙니다. 연결된 Skeleton은 보통 DCC 소프트웨어에서 사용자가 스켈레톤을 볼 수 있도록 사용됩니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setNode{#setNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setNode(value) | 노드를 가져오거나 설정합니다. 본 노드는 스킨이 부착되는 본이며, SkinDeformer는 본 노드를 사용하여 컨트롤 포인트의 변위를 영향을 줍니다. 본 노드에는 일반적으로 Skeleton이 연결되어 있지만 필수는 아닙니다. 연결된 Skeleton은 보통 DCC 소프트웨어에서 사용자가 스켈레톤을 볼 수 있도록 사용됩니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### get{#get}
+
+| 이름 | 설명 |
+| --- | --- |
+| get(index) |  |
+
+ **Result:**
+
+
+
+---
+
+
+### set{#set}
+
+| 이름 | 설명 |
+| --- | --- |
+| set(index, value) |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getWeight{#getWeight}
+
+| 이름 | 설명 |
+| --- | --- |
+| getWeight(index) | 인덱스로 지정된 컨트롤 포인트의 가중치를 가져옵니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 인덱스 | 숫자 | 컨트롤 포인트 인덱스 |
+
+ **Result:**
+숫자
+
+
+---
+
+
+### setWeight{#setWeight}
+
+| 이름 | 설명 |
+| --- | --- |
+| setWeight(index, weight) | 인덱스로 지정된 컨트롤 포인트의 가중치를 설정합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 인덱스 | 숫자 | 컨트롤 포인트 인덱스 |
+| 무게 | 숫자 | 새 무게 |
+
+ **Result:**
+숫자
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/bonepose/_index.md
+++ b/korean/nodejs-java/aspose.threed/bonepose/_index.md
@@ -1,0 +1,107 @@
+---
+title: "BonePose"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/bonepose/
+---
+## BonePose class
+
+BonePose는 bone 노드에 대한 변환 행렬을 포함합니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getNode{#getNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getNode() | 씬 노드를 가져오거나 설정합니다. 스킨된 스켈레톤 노드를 가리킵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setNode{#setNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setNode(value) | 씬 노드를 가져오거나 설정합니다. 스킨된 스켈레톤 노드를 가리킵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMatrix{#getMatrix}
+
+| 이름 | 설명 |
+| --- | --- |
+| getMatrix() | 현재 포즈에서 노드의 변환 행렬을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMatrix{#setMatrix}
+
+| 이름 | 설명 |
+| --- | --- |
+| setMatrix(value) | 현재 포즈에서 노드의 변환 행렬을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### isLocal{#isLocal}
+
+| 이름 | 설명 |
+| --- | --- |
+| isLocal() | 행렬이 로컬 좌표계에 정의되어 있는지 가져오거나 설정합니다. 이 인스턴스가 로컬 공간이면 true; 그렇지 않으면 false는 전역 공간을 의미합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setLocal{#setLocal}
+
+| 이름 | 설명 |
+| --- | --- |
+| setLocal(value) | 행렬이 로컬 좌표계에 정의되어 있는지 가져오거나 설정합니다. 이 인스턴스가 로컬 공간이면 true; 그렇지 않으면 false는 전역 공간을 의미합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/boundingbox/_index.md
+++ b/korean/nodejs-java/aspose.threed/boundingbox/_index.md
@@ -1,0 +1,198 @@
+---
+title: "BoundingBox"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/boundingbox/
+---
+## BoundingBox class
+
+축 정렬 경계 상자
+
+
+## Properties
+
+| 이름 | 설명 |
+| --- | --- |
+| NULL | null 경계 상자 |
+| INFINITE | 무한 경계 상자 |
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload(minimum, maximum) | 주어진 최소 및 최대 코너로 유한 경계 상자를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| minimum | Vector3 | 최소 코너 |
+| maximum | Vector3 | 최대 코너 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload2(minX, minY, minZ, maxX, maxY, maxZ) | 주어진 최소 및 최대 코너로 유한 경계 상자를 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtent{#getExtent}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExtent() | 경계 상자의 범위를 가져옵니다. 해당 속성의 값은 BoundingBoxExtent 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMinimum{#getMinimum}
+
+| 이름 | 설명 |
+| --- | --- |
+| getMinimum() | 경계 상자의 최소 코너 |
+
+ **Result:**
+
+
+
+---
+
+
+### getMaximum{#getMaximum}
+
+| 이름 | 설명 |
+| --- | --- |
+| getMaximum() | 경계 상자의 최대 코너 |
+
+ **Result:**
+
+
+
+---
+
+
+### getSize{#getSize}
+
+| 이름 | 설명 |
+| --- | --- |
+| getSize() | 경계 상자의 크기 |
+
+ **Result:**
+
+
+
+---
+
+
+### getCenter{#getCenter}
+
+| 이름 | 설명 |
+| --- | --- |
+| getCenter() | 경계 상자의 중심. |
+
+ **Result:**
+
+
+
+---
+
+
+### fromGeometry{#fromGeometry}
+
+| 이름 | 설명 |
+| --- | --- |
+| fromGeometry(geometry) | 주어진 기하학으로부터 경계 상자를 구성합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| geometr | Geometry | null |
+
+ **Result:**
+BoundingBox
+
+
+---
+
+
+### toString{#toString}
+
+| 이름 | 설명 |
+| --- | --- |
+| toString() | 경계 상자의 문자열 표현을 가져옵니다. |
+
+ **Result:**
+String
+
+
+---
+
+
+### hashCode{#hashCode}
+
+| 이름 | 설명 |
+| --- | --- |
+| hashCode() | 이 인스턴스의 해시 코드를 반환합니다 |
+
+ **Result:**
+숫자
+
+
+---
+
+
+### equals{#equals}
+
+| 이름 | 설명 |
+| --- | --- |
+| equals(obj) | 두 객체가 같은지 판단합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| ob | Object | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/boundingbox2d/_index.md
+++ b/korean/nodejs-java/aspose.threed/boundingbox2d/_index.md
@@ -1,0 +1,146 @@
+---
+title: "BoundingBox2D"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/boundingbox2d/
+---
+## BoundingBox2D class
+
+Vector2에 대한 축 정렬 경계 상자
+
+
+## Properties
+
+| 이름 | 설명 |
+| --- | --- |
+| NULL | null 경계 상자 |
+| INFINITE | 무한 경계 상자 |
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload(minimum, maximum) | 주어진 최소 및 최대 코너로 유한 경계 상자를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| minimum | Vector2 | 최소 코너 |
+| maximum | Vector2 | 최대 코너 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtent{#getExtent}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExtent() | 경계 상자의 범위를 가져옵니다. 해당 속성의 값은 BoundingBoxExtent 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMinimum{#getMinimum}
+
+| 이름 | 설명 |
+| --- | --- |
+| getMinimum() | 경계 상자의 최소 코너 |
+
+ **Result:**
+
+
+
+---
+
+
+### getMaximum{#getMaximum}
+
+| 이름 | 설명 |
+| --- | --- |
+| getMaximum() | 경계 상자의 최대 코너 |
+
+ **Result:**
+
+
+
+---
+
+
+### merge{#merge}
+
+| 이름 | 설명 |
+| --- | --- |
+| merge(pt) | 새 상자를 현재 경계 상자에 병합합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| p | Vector2 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### merge{#merge}
+
+| 이름 | 설명 |
+| --- | --- |
+| merge(bb) | 새 상자를 현재 경계 상자에 병합합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| b | BoundingBox2D | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| 이름 | 설명 |
+| --- | --- |
+| toString() | 경계 상자의 문자열 표현을 가져옵니다. |
+
+ **Result:**
+String
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/box/_index.md
+++ b/korean/nodejs-java/aspose.threed/box/_index.md
@@ -1,0 +1,535 @@
+---
+title: "Box"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/box/
+---
+## Box class
+
+박스.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | Box 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload(length, width, height) | Box 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 길이 | 숫자 | z축에 정렬된 박스의 길이. |
+| 너비 | 숫자 | x축에 정렬된 박스의 너비. |
+| height | 숫자 | y축에 정렬된 박스의 높이. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload2(name, length, width, height, lengthSegments, widthSegments, heightSegments) | Box 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| name | String | 박스의 이름. |
+| 길이 | 숫자 | z축에 정렬된 박스의 길이. |
+| 너비 | 숫자 | x축에 정렬된 박스의 너비. |
+| height | 숫자 | y축에 정렬된 박스의 높이. |
+| lengthSegments | 숫자 | 길이 세그먼트. |
+| widthSegments | 숫자 | 너비 세그먼트. |
+| heightSegments | 숫자 | 세로 세그먼트. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLengthSegments{#getLengthSegments}
+
+| 이름 | 설명 |
+| --- | --- |
+| getLengthSegments() | 길이 세그먼트를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setLengthSegments{#setLengthSegments}
+
+| 이름 | 설명 |
+| --- | --- |
+| setLengthSegments(value) | 길이 세그먼트를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getWidthSegments{#getWidthSegments}
+
+| 이름 | 설명 |
+| --- | --- |
+| getWidthSegments() | 너비 세그먼트를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setWidthSegments{#setWidthSegments}
+
+| 이름 | 설명 |
+| --- | --- |
+| setWidthSegments(value) | 너비 세그먼트를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getHeightSegments{#getHeightSegments}
+
+| 이름 | 설명 |
+| --- | --- |
+| getHeightSegments() | 높이 세그먼트를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setHeightSegments{#setHeightSegments}
+
+| 이름 | 설명 |
+| --- | --- |
+| setHeightSegments(value) | 높이 세그먼트를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLength{#getLength}
+
+| 이름 | 설명 |
+| --- | --- |
+| getLength() | z축에 정렬된 박스의 길이를 가져오거나 설정합니다. z축에 정렬된 길이. |
+
+ **Result:**
+
+
+
+---
+
+
+### setLength{#setLength}
+
+| 이름 | 설명 |
+| --- | --- |
+| setLength(value) | z축에 정렬된 박스의 길이를 가져오거나 설정합니다. z축에 정렬된 길이. |
+
+ **Result:**
+
+
+
+---
+
+
+### getWidth{#getWidth}
+
+| 이름 | 설명 |
+| --- | --- |
+| getWidth() | x축에 정렬된 상자의 너비를 가져오거나 설정합니다. x축에 정렬된 너비. |
+
+ **Result:**
+
+
+
+---
+
+
+### setWidth{#setWidth}
+
+| 이름 | 설명 |
+| --- | --- |
+| setWidth(value) | x축에 정렬된 상자의 너비를 가져오거나 설정합니다. x축에 정렬된 너비. |
+
+ **Result:**
+
+
+
+---
+
+
+### getHeight{#getHeight}
+
+| 이름 | 설명 |
+| --- | --- |
+| getHeight() | y축에 정렬된 상자의 높이를 가져오거나 설정합니다. y축에 정렬된 높이. |
+
+ **Result:**
+
+
+
+---
+
+
+### setHeight{#setHeight}
+
+| 이름 | 설명 |
+| --- | --- |
+| setHeight(value) | y축에 정렬된 상자의 높이를 가져오거나 설정합니다. y축에 정렬된 높이. |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastShadows{#getCastShadows}
+
+| 이름 | 설명 |
+| --- | --- |
+| getCastShadows() | 이 지오메트리가 그림자를 드리울 수 있는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastShadows{#setCastShadows}
+
+| 이름 | 설명 |
+| --- | --- |
+| setCastShadows(value) | 이 지오메트리가 그림자를 드리울 수 있는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReceiveShadows{#getReceiveShadows}
+
+| 이름 | 설명 |
+| --- | --- |
+| getReceiveShadows() | 이 지오메트리가 그림자를 받을 수 있는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReceiveShadows{#setReceiveShadows}
+
+| 이름 | 설명 |
+| --- | --- |
+| setReceiveShadows(value) | 이 지오메트리가 그림자를 받을 수 있는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNodes() | 모든 부모 노드를 가져옵니다. 엔터티는 기하학 인스턴싱을 위해 여러 부모 노드에 부착될 수 있습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExcluded() | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExcluded(value) | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNode() | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setParentNode(value) | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 이름 | 설명 |
+| --- | --- |
+| getScene() | 이 객체가 속한 씬을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### toMesh{#toMesh}
+
+| 이름 | 설명 |
+| --- | --- |
+| toMesh() | 현재 객체를 메시로 변환합니다 |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBoundingBox() | 현재 엔터티의 객체 공간 좌표계에서 경계 상자를 가져옵니다. |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEntityRendererKey() | 렌더러에 등록된 엔터티 렌더러의 키를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/camera/_index.md
+++ b/korean/nodejs-java/aspose.threed/camera/_index.md
@@ -1,0 +1,813 @@
+---
+title: "카메라"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/camera/
+---
+## Camera class
+
+카메라는 씬을 바라보는 뷰어의 눈 위치를 설명합니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | Camera 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload(projectionType) | Camera 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| projectionType | ProjectionType | ProjectionType |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload2(name) | Camera 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| name | String | 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload3{#constructor_overload3}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload3(name, projectionType) | Camera 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| name | String | 이름. |
+| projectionType | ProjectionType | ProjectionType |
+
+ **Result:**
+
+
+
+---
+
+
+### getApertureMode{#getApertureMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getApertureMode() | 카메라의 조리개 모드를 가져오거나 설정합니다. 이 속성의 값은 ApertureMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setApertureMode{#setApertureMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setApertureMode(value) | 카메라의 조리개 모드를 가져오거나 설정합니다. 이 속성의 값은 ApertureMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFieldOfView{#getFieldOfView}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFieldOfView() | 카메라의 시야각을 도 단위로 가져오거나 설정합니다. 이 속성은 ApertureMode가 ApertureMode.HORIZONTAL 또는 ApertureMode.VERTICAL인 경우에만 사용됩니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFieldOfView{#setFieldOfView}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFieldOfView(value) | 카메라의 시야각을 도 단위로 가져오거나 설정합니다. 이 속성은 ApertureMode가 ApertureMode.HORIZONTAL 또는 ApertureMode.VERTICAL인 경우에만 사용됩니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFieldOfViewX{#getFieldOfViewX}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFieldOfViewX() | 카메라의 수평 시야각을 도 단위로 가져오거나 설정합니다. 이 속성은 ApertureMode가 ApertureMode.HORIZ_AND_VERT인 경우에만 사용됩니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFieldOfViewX{#setFieldOfViewX}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFieldOfViewX(value) | 카메라의 수평 시야각을 도 단위로 가져오거나 설정합니다. 이 속성은 ApertureMode가 ApertureMode.HORIZ_AND_VERT인 경우에만 사용됩니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFieldOfViewY{#getFieldOfViewY}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFieldOfViewY() | 카메라의 수직 시야각을 도 단위로 가져오거나 설정합니다. 이 속성은 ApertureMode가 ApertureMode.HORIZ_AND_VERT인 경우에만 사용됩니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFieldOfViewY{#setFieldOfViewY}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFieldOfViewY(value) | 카메라의 수직 시야각을 도 단위로 가져오거나 설정합니다. 이 속성은 ApertureMode가 ApertureMode.HORIZ_AND_VERT인 경우에만 사용됩니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getWidth{#getWidth}
+
+| 이름 | 설명 |
+| --- | --- |
+| getWidth() | 뷰 평면의 너비를 인치 단위로 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setWidth{#setWidth}
+
+| 이름 | 설명 |
+| --- | --- |
+| setWidth(value) | 뷰 평면의 너비를 인치 단위로 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getHeight{#getHeight}
+
+| 이름 | 설명 |
+| --- | --- |
+| getHeight() | 뷰 평면의 높이를 인치 단위로 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setHeight{#setHeight}
+
+| 이름 | 설명 |
+| --- | --- |
+| setHeight(value) | 뷰 평면의 높이를 인치 단위로 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAspectRatio{#getAspectRatio}
+
+| 이름 | 설명 |
+| --- | --- |
+| getAspectRatio() | 뷰 평면의 종횡비를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setAspectRatio{#setAspectRatio}
+
+| 이름 | 설명 |
+| --- | --- |
+| setAspectRatio(value) | 뷰 평면의 종횡비를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMagnification{#getMagnification}
+
+| 이름 | 설명 |
+| --- | --- |
+| getMagnification() | 정사영 카메라에서 사용되는 배율을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMagnification{#setMagnification}
+
+| 이름 | 설명 |
+| --- | --- |
+| setMagnification(value) | 정사영 카메라에서 사용되는 배율을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProjectionType{#getProjectionType}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProjectionType() | 카메라의 투영 유형을 가져오거나 설정합니다. 기본적으로 원근 투영이 사용됩니다. 속성 값은 ProjectionType 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setProjectionType{#setProjectionType}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProjectionType(value) | 카메라의 투영 유형을 가져오거나 설정합니다. 기본적으로 원근 투영이 사용됩니다. 속성 값은 ProjectionType 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getRotationMode{#getRotationMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getRotationMode() | 프러스텀의 방향 모드를 가져오거나 설정합니다. 이 속성은 Target이 null인 경우에만 작동합니다. 값이 RotationMode.FIXED_TARGET이면 방향은 항상 LookAt 속성에 의해 계산됩니다. 그렇지 않으면 LookAt은 항상 Direction에 의해 계산됩니다. 이 속성의 값은 RotationMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRotationMode{#setRotationMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setRotationMode(value) | 프러스텀의 방향 모드를 가져오거나 설정합니다. 이 속성은 Target이 null인 경우에만 작동합니다. 값이 RotationMode.FIXED_TARGET이면 방향은 항상 LookAt 속성에 의해 계산됩니다. 그렇지 않으면 LookAt은 항상 Direction에 의해 계산됩니다. 이 속성의 값은 RotationMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getNearPlane{#getNearPlane}
+
+| 이름 | 설명 |
+| --- | --- |
+| getNearPlane() | 프러스텀의 근접 평면 거리를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setNearPlane{#setNearPlane}
+
+| 이름 | 설명 |
+| --- | --- |
+| setNearPlane(value) | 프러스텀의 근접 평면 거리를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFarPlane{#getFarPlane}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFarPlane() | 프러스텀의 원거리 평면 거리를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFarPlane{#setFarPlane}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFarPlane(value) | 프러스텀의 원거리 평면 거리를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAspect{#getAspect}
+
+| 이름 | 설명 |
+| --- | --- |
+| getAspect() | 프러스텀의 종횡비를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setAspect{#setAspect}
+
+| 이름 | 설명 |
+| --- | --- |
+| setAspect(value) | 프러스텀의 종횡비를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getOrthoHeight{#getOrthoHeight}
+
+| 이름 | 설명 |
+| --- | --- |
+| getOrthoHeight() | 프러스텀을 직교 투영으로 사용할 때 높이를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setOrthoHeight{#setOrthoHeight}
+
+| 이름 | 설명 |
+| --- | --- |
+| setOrthoHeight(value) | 프러스텀을 직교 투영으로 사용할 때 높이를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getUp{#getUp}
+
+| 이름 | 설명 |
+| --- | --- |
+| getUp() | 카메라의 위쪽 방향을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setUp{#setUp}
+
+| 이름 | 설명 |
+| --- | --- |
+| setUp(value) | 카메라의 위쪽 방향을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookAt{#getLookAt}
+
+| 이름 | 설명 |
+| --- | --- |
+| getLookAt() | 카메라가 바라보는 관심 위치를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setLookAt{#setLookAt}
+
+| 이름 | 설명 |
+| --- | --- |
+| setLookAt(value) | 카메라가 바라보는 관심 위치를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDirection{#getDirection}
+
+| 이름 | 설명 |
+| --- | --- |
+| getDirection() | 카메라가 바라보는 방향을 가져오거나 설정합니다. 이 속성의 변경은 LookAt 및 Target에도 영향을 줍니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDirection{#setDirection}
+
+| 이름 | 설명 |
+| --- | --- |
+| setDirection(value) | 카메라가 바라보는 방향을 가져오거나 설정합니다. 이 속성의 변경은 LookAt 및 Target에도 영향을 줍니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTarget{#getTarget}
+
+| 이름 | 설명 |
+| --- | --- |
+| getTarget() | 카메라가 바라보는 대상을 가져오거나 설정합니다. 사용자가 이 속성을 지원하는 경우 LookAt 속성보다 먼저 설정해야 합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTarget{#setTarget}
+
+| 이름 | 설명 |
+| --- | --- |
+| setTarget(value) | 카메라가 바라보는 대상을 가져오거나 설정합니다. 사용자가 이 속성을 지원하는 경우 LookAt 속성보다 먼저 설정해야 합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNodes() | 모든 부모 노드를 가져옵니다. 엔터티는 기하학 인스턴싱을 위해 여러 부모 노드에 부착될 수 있습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExcluded() | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExcluded(value) | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNode() | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setParentNode(value) | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 이름 | 설명 |
+| --- | --- |
+| getScene() | 이 객체가 속한 씬을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### moveForward{#moveForward}
+
+| 이름 | 설명 |
+| --- | --- |
+| moveForward(distance) | 카메라를 방향 또는 목표를 향해 앞으로 이동합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 거리 | 숫자 | 앞으로 이동할 거리 |
+
+ **Result:**
+
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBoundingBox() | 현재 엔터티의 객체 공간 좌표계에서 경계 상자를 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEntityRendererKey() | 렌더러에 등록된 엔터티 렌더러의 키를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/circle/_index.md
+++ b/korean/nodejs-java/aspose.threed/circle/_index.md
@@ -1,0 +1,339 @@
+---
+title: "Circle"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/circle/
+---
+## Circle class
+
+Circle 곡선은 원 형태의 가장자리에 있는 일련의 점으로 구성됩니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | Circle 생성자 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload(radius) | Circle 생성자 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 반경 | 숫자 | 원 곡선의 반경입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getRadius{#getRadius}
+
+| 이름 | 설명 |
+| --- | --- |
+| getRadius() | 원 곡선의 반경이며, 기본값은 10입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRadius{#setRadius}
+
+| 이름 | 설명 |
+| --- | --- |
+| setRadius(value) | 원 곡선의 반경이며, 기본값은 10입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getColor{#getColor}
+
+| 이름 | 설명 |
+| --- | --- |
+| getColor() | 선의 색상을 가져오거나 설정합니다. 기본값은 흰색(1, 1, 1)입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setColor{#setColor}
+
+| 이름 | 설명 |
+| --- | --- |
+| setColor(value) | 선의 색상을 가져오거나 설정합니다. 기본값은 흰색(1, 1, 1)입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNodes() | 모든 부모 노드를 가져옵니다. 엔터티는 기하학 인스턴싱을 위해 여러 부모 노드에 부착될 수 있습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExcluded() | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExcluded(value) | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNode() | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setParentNode(value) | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 이름 | 설명 |
+| --- | --- |
+| getScene() | 이 객체가 속한 씬을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEntityRendererKey() | 렌더러에 등록된 엔터티 렌더러의 키를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBoundingBox() | 현재 엔터티의 객체 공간 좌표계에서 경계 상자를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/circleshape/_index.md
+++ b/korean/nodejs-java/aspose.threed/circleshape/_index.md
@@ -1,0 +1,326 @@
+---
+title: "CircleShape"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/circleshape/
+---
+## CircleShape class
+
+IFC 호환 원형 프로파일로, LinearExtrusion을 통해 메쉬를 구성하는 데 사용할 수 있습니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | 기본 반경(5)으로 CircleShape 프로파일을 생성합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload(radius) | 지정된 반경으로 CircleShape 프로파일을 생성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| radiu | 숫자 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### getRadius{#getRadius}
+
+| 이름 | 설명 |
+| --- | --- |
+| getRadius() | 원의 반경을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRadius{#setRadius}
+
+| 이름 | 설명 |
+| --- | --- |
+| setRadius(value) | 원의 반경을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNodes() | 모든 부모 노드를 가져옵니다. 엔터티는 기하학 인스턴싱을 위해 여러 부모 노드에 부착될 수 있습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExcluded() | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExcluded(value) | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNode() | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setParentNode(value) | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 이름 | 설명 |
+| --- | --- |
+| getScene() | 이 객체가 속한 씬을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtent{#getExtent}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExtent() | x 및 y 차원에서의 범위를 가져옵니다. |
+
+ **Result:**
+Vector2
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEntityRendererKey() | 렌더러에 등록된 엔터티 렌더러의 키를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBoundingBox() | 현재 엔터티의 객체 공간 좌표계에서 경계 상자를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/colladasaveoptions/_index.md
+++ b/korean/nodejs-java/aspose.threed/colladasaveoptions/_index.md
@@ -1,0 +1,198 @@
+---
+title: "ColladaSaveOptions"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/colladasaveoptions/
+---
+## ColladaSaveOptions class
+
+Collada 저장 옵션
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | ColladaSaveOptions의 생성자 |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndented{#getIndented}
+
+| 이름 | 설명 |
+| --- | --- |
+| getIndented() | 내보낸 XML 문서가 들여쓰기 되는지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndented{#setIndented}
+
+| 이름 | 설명 |
+| --- | --- |
+| setIndented(value) | 내보낸 XML 문서가 들여쓰기 되는지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTransformStyle{#getTransformStyle}
+
+| 이름 | 설명 |
+| --- | --- |
+| getTransformStyle() | 노드 변환 스타일을 가져오거나 설정합니다. 속성 값은 ColladaTransformStyle 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTransformStyle{#setTransformStyle}
+
+| 이름 | 설명 |
+| --- | --- |
+| setTransformStyle(value) | 노드 변환 스타일을 가져오거나 설정합니다. 속성 값은 ColladaTransformStyle 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportTextures{#getExportTextures}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExportTextures() | 씬에서 사용된 텍스처를 출력 디렉터리로 복사합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextures{#setExportTextures}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExportTextures(value) | 씬에서 사용된 텍스처를 출력 디렉터리로 복사합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileFormat() | 현재 저장/로드 옵션에 지정된 파일 형식을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEncoding() | 텍스트 기반 파일에 대한 기본 인코딩을 가져오거나 설정합니다. 기본값은 null이며, 이는 가져오기/내보내기 프로그램이 사용할 인코딩을 결정함을 의미합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileSystem() | 로드/저장 중 외부 종속성을 관리하는 방법을 사용자가 처리하도록 허용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFileSystem(value) | 로드/저장 중 외부 종속성을 관리하는 방법을 사용자가 처리하도록 허용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| 이름 | 설명 |
+| --- | --- |
+| getLookupPaths() | OBJ와 같은 일부 파일은 외부 파일에 의존하며, 조회 경로를 통해 Aspose.3D가 외부 파일을 찾아 로드할 수 있도록 합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileName() | 내보내기/가져오기 씬의 파일 이름입니다. 선택 사항이지만 OBJ의 재질과 같은 외부 자산을 직렬화할 때 유용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFileName(value) | 내보내기/가져오기 씬의 파일 이름입니다. 선택 사항이지만 OBJ의 재질과 같은 외부 자산을 직렬화할 때 유용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/compositecurve/_index.md
+++ b/korean/nodejs-java/aspose.threed/compositecurve/_index.md
@@ -1,0 +1,327 @@
+---
+title: "CompositeCurve"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/compositecurve/
+---
+## CompositeCurve class
+
+CompositeCurve는 여러 곡선 세그먼트로 구성됩니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | CompositeCurve의 생성자 |
+
+ **Result:**
+
+
+
+---
+
+
+### getSegments{#getSegments}
+
+| 이름 | 설명 |
+| --- | --- |
+| getSegments() | 곡선의 세그먼트. |
+
+ **Result:**
+
+
+
+---
+
+
+### getColor{#getColor}
+
+| 이름 | 설명 |
+| --- | --- |
+| getColor() | 선의 색상을 가져오거나 설정합니다. 기본값은 흰색(1, 1, 1)입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setColor{#setColor}
+
+| 이름 | 설명 |
+| --- | --- |
+| setColor(value) | 선의 색상을 가져오거나 설정합니다. 기본값은 흰색(1, 1, 1)입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNodes() | 모든 부모 노드를 가져옵니다. 엔터티는 기하학 인스턴싱을 위해 여러 부모 노드에 부착될 수 있습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExcluded() | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExcluded(value) | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNode() | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setParentNode(value) | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 이름 | 설명 |
+| --- | --- |
+| getScene() | 이 객체가 속한 씬을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### addSegment{#addSegment}
+
+| 이름 | 설명 |
+| --- | --- |
+| addSegment(curve, sameDirection) | 그 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| curv | 곡선 | null |
+| sameDirectio | boolean | null |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEntityRendererKey() | 렌더러에 등록된 엔터티 렌더러의 키를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBoundingBox() | 현재 엔터티의 객체 공간 좌표계에서 경계 상자를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/cshape/_index.md
+++ b/korean/nodejs-java/aspose.threed/cshape/_index.md
@@ -1,0 +1,411 @@
+---
+title: "CShape"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/cshape/
+---
+## CShape class
+
+매개변수로 정의된 IFC 호환 C형 프로파일. 프로파일의 중심 위치는 경계 상자의 중앙에 있습니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | CShape의 생성자 |
+
+ **Result:**
+
+
+
+---
+
+
+### getDepth{#getDepth}
+
+| 이름 | 설명 |
+| --- | --- |
+| getDepth() | 프로필의 깊이를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDepth{#setDepth}
+
+| 이름 | 설명 |
+| --- | --- |
+| setDepth(value) | 프로필의 깊이를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getWidth{#getWidth}
+
+| 이름 | 설명 |
+| --- | --- |
+| getWidth() | 프로필의 너비를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setWidth{#setWidth}
+
+| 이름 | 설명 |
+| --- | --- |
+| setWidth(value) | 프로필의 너비를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getGirth{#getGirth}
+
+| 이름 | 설명 |
+| --- | --- |
+| getGirth() | 둘레의 길이를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setGirth{#setGirth}
+
+| 이름 | 설명 |
+| --- | --- |
+| setGirth(value) | 둘레의 길이를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getWallThickness{#getWallThickness}
+
+| 이름 | 설명 |
+| --- | --- |
+| getWallThickness() | 벽의 두께를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setWallThickness{#setWallThickness}
+
+| 이름 | 설명 |
+| --- | --- |
+| setWallThickness(value) | 벽의 두께를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getInternalFilletRadius{#getInternalFilletRadius}
+
+| 이름 | 설명 |
+| --- | --- |
+| getInternalFilletRadius() | 내부 필릿 반경을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setInternalFilletRadius{#setInternalFilletRadius}
+
+| 이름 | 설명 |
+| --- | --- |
+| setInternalFilletRadius(value) | 내부 필릿 반경을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNodes() | 모든 부모 노드를 가져옵니다. 엔터티는 기하학 인스턴싱을 위해 여러 부모 노드에 부착될 수 있습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExcluded() | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExcluded(value) | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNode() | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setParentNode(value) | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 이름 | 설명 |
+| --- | --- |
+| getScene() | 이 객체가 속한 씬을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtent{#getExtent}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExtent() | x 및 y 차원에서의 범위를 가져옵니다. |
+
+ **Result:**
+Vector2
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEntityRendererKey() | 렌더러에 등록된 엔터티 렌더러의 키를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBoundingBox() | 현재 엔터티의 객체 공간 좌표계에서 경계 상자를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/cubeface/_index.md
+++ b/korean/nodejs-java/aspose.threed/cubeface/_index.md
@@ -1,0 +1,13 @@
+---
+title: "CubeFace"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/cubeface/
+---
+## CubeFace class
+
+상수들을 포함하는 유틸리티 클래스. 큐브 맵 텍스처의 각 면  @hideconstructor
+
+

--- a/korean/nodejs-java/aspose.threed/curve/_index.md
+++ b/korean/nodejs-java/aspose.threed/curve/_index.md
@@ -1,0 +1,281 @@
+---
+title: "곡선"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/curve/
+---
+## Curve class
+
+모든 곡선 구현의 기본 클래스.  @hideconstructor
+
+
+## 메서드
+
+### getColor{#getColor}
+
+| 이름 | 설명 |
+| --- | --- |
+| getColor() | 선의 색상을 가져오거나 설정합니다. 기본값은 흰색(1, 1, 1)입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setColor{#setColor}
+
+| 이름 | 설명 |
+| --- | --- |
+| setColor(value) | 선의 색상을 가져오거나 설정합니다. 기본값은 흰색(1, 1, 1)입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNodes() | 모든 부모 노드를 가져옵니다. 엔터티는 기하학 인스턴싱을 위해 여러 부모 노드에 부착될 수 있습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExcluded() | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExcluded(value) | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNode() | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setParentNode(value) | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 이름 | 설명 |
+| --- | --- |
+| getScene() | 이 객체가 속한 씬을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEntityRendererKey() | 렌더러에 등록된 엔터티 렌더러의 키를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBoundingBox() | 현재 엔터티의 객체 공간 좌표계에서 경계 상자를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/customobject/_index.md
+++ b/korean/nodejs-java/aspose.threed/customobject/_index.md
@@ -1,0 +1,183 @@
+---
+title: "CustomObject"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/customobject/
+---
+## CustomObject class
+
+3D 파일에서 사용되는 메타 데이터 또는 사용자 정의 객체는 이 클래스에서 관리됩니다. 모든 사용자 정의 속성은 동적 속성으로 저장됩니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | CustomObject 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload(name) | CustomObject 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| name | String | 이름 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/cylinder/_index.md
+++ b/korean/nodejs-java/aspose.threed/cylinder/_index.md
@@ -1,0 +1,763 @@
+---
+title: "실린더"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/cylinder/
+---
+## Cylinder class
+
+매개변수화된 실린더. radiusTop 또는 radiusBottom 중 하나가 0일 때 원뿔을 나타내는 데에도 사용할 수 있습니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | Cylinder 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload(radius, height) | Cylinder 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 반경 | 숫자 | 상단 및 하단 캡의 반지름. |
+| height | 숫자 | 높이. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload2(radiusTop, radiusBottom, height) | Cylinder 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| radiusTop | 숫자 | 상단 반지름. |
+| radiusBottom | 숫자 | 하단 반지름. |
+| height | 숫자 | 높이. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload3{#constructor_overload3}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload3(radiusTop, radiusBottom, height, radialSegments, heightSegments, openEnded) | Cylinder 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| radiusTop | 숫자 | 실린더 상단 캡의 반지름. |
+| radiusBottom | 숫자 | 실린더 하단 캡의 반지름. |
+| height | 숫자 | 실린더의 높이. |
+| radialSegments | 숫자 | 상단 및 하단 원의 방사형 세그먼트.. |
+| heightSegments | 숫자 | 세로 세그먼트. |
+| openEnded | boolean | 설정된 경우 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload4{#constructor_overload4}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload4(name, radiusTop, radiusBottom, height, radialSegments, heightSegments, openEnded, thetaStart, thetaLength) | Cylinder 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| name | String | 이 객체의 이름 |
+| radiusTop | 숫자 | 실린더 상단 캡의 반지름. |
+| radiusBottom | 숫자 | 실린더 하단 캡의 반지름. |
+| height | 숫자 | 실린더의 높이. |
+| radialSegments | 숫자 | 상단 및 하단 원의 방사형 세그먼트.. |
+| heightSegments | 숫자 | 세로 세그먼트. |
+| openEnded | boolean | 설정된 경우 |
+| thetaStart | 숫자 | Theta 시작. |
+| thetaLength | 숫자 | Theta 길이. |
+
+ **Result:**
+
+
+
+---
+
+
+### getOffsetBottom{#getOffsetBottom}
+
+| 이름 | 설명 |
+| --- | --- |
+| getOffsetBottom() | 하단 측면의 정점 변환 오프셋을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setOffsetBottom{#setOffsetBottom}
+
+| 이름 | 설명 |
+| --- | --- |
+| setOffsetBottom(value) | 하단 측면의 정점 변환 오프셋을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getOffsetTop{#getOffsetTop}
+
+| 이름 | 설명 |
+| --- | --- |
+| getOffsetTop() | 상단 측면의 정점 변환 오프셋을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setOffsetTop{#setOffsetTop}
+
+| 이름 | 설명 |
+| --- | --- |
+| setOffsetTop(value) | 상단 측면의 정점 변환 오프셋을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getGenerateFanCylinder{#getGenerateFanCylinder}
+
+| 이름 | 설명 |
+| --- | --- |
+| getGenerateFanCylinder() | ThetaLength가 2PI보다 작을 때 팬 스타일 실린더를 생성할지 여부를 가져오거나 설정합니다. 그렇지 않으면 모델이 잘리지 않습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setGenerateFanCylinder{#setGenerateFanCylinder}
+
+| 이름 | 설명 |
+| --- | --- |
+| setGenerateFanCylinder(value) | ThetaLength가 2PI보다 작을 때 팬 스타일 실린더를 생성할지 여부를 가져오거나 설정합니다. 그렇지 않으면 모델이 잘리지 않습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getShearBottom{#getShearBottom}
+
+| 이름 | 설명 |
+| --- | --- |
+| getShearBottom() | 하단 측면의 전단 변환을 가져오거나 설정합니다. 벡터는 라디안으로 측정된 (x축, z축) 전단 값을 저장하며, 기본값은 (0, 0)입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setShearBottom{#setShearBottom}
+
+| 이름 | 설명 |
+| --- | --- |
+| setShearBottom(value) | 하단 측면의 전단 변환을 가져오거나 설정합니다. 벡터는 라디안으로 측정된 (x축, z축) 전단 값을 저장하며, 기본값은 (0, 0)입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getShearTop{#getShearTop}
+
+| 이름 | 설명 |
+| --- | --- |
+| getShearTop() | 상단 측면의 전단 변환을 가져오거나 설정합니다. 벡터는 라디안으로 측정된 (x축, z축) 전단 값을 저장하며, 기본값은 (0, 0)입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setShearTop{#setShearTop}
+
+| 이름 | 설명 |
+| --- | --- |
+| setShearTop(value) | 상단 측면의 전단 변환을 가져오거나 설정합니다. 벡터는 라디안으로 측정된 (x축, z축) 전단 값을 저장하며, 기본값은 (0, 0)입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getRadiusTop{#getRadiusTop}
+
+| 이름 | 설명 |
+| --- | --- |
+| getRadiusTop() | 실린더 상단 캡의 반경을 가져오거나 설정합니다. 상단 캡의 반경입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRadiusTop{#setRadiusTop}
+
+| 이름 | 설명 |
+| --- | --- |
+| setRadiusTop(value) | 실린더 상단 캡의 반경을 가져오거나 설정합니다. 상단 캡의 반경입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getRadiusBottom{#getRadiusBottom}
+
+| 이름 | 설명 |
+| --- | --- |
+| getRadiusBottom() | 실린더 하단 캡의 반경을 가져오거나 설정합니다. 하단 캡의 반경입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRadiusBottom{#setRadiusBottom}
+
+| 이름 | 설명 |
+| --- | --- |
+| setRadiusBottom(value) | 실린더 하단 캡의 반경을 가져오거나 설정합니다. 하단 캡의 반경입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getHeight{#getHeight}
+
+| 이름 | 설명 |
+| --- | --- |
+| getHeight() | 실린더의 높이를 가져오거나 설정합니다. 높이입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setHeight{#setHeight}
+
+| 이름 | 설명 |
+| --- | --- |
+| setHeight(value) | 실린더의 높이를 가져오거나 설정합니다. 높이입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getRadialSegments{#getRadialSegments}
+
+| 이름 | 설명 |
+| --- | --- |
+| getRadialSegments() | 방사형 세그먼트를 가져오거나 설정합니다. 방사형 세그먼트입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRadialSegments{#setRadialSegments}
+
+| 이름 | 설명 |
+| --- | --- |
+| setRadialSegments(value) | 방사형 세그먼트를 가져오거나 설정합니다. 방사형 세그먼트입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getHeightSegments{#getHeightSegments}
+
+| 이름 | 설명 |
+| --- | --- |
+| getHeightSegments() | 세로 세그먼트를 가져오거나 설정합니다. 세로 세그먼트. |
+
+ **Result:**
+
+
+
+---
+
+
+### setHeightSegments{#setHeightSegments}
+
+| 이름 | 설명 |
+| --- | --- |
+| setHeightSegments(value) | 세로 세그먼트를 가져오거나 설정합니다. 세로 세그먼트. |
+
+ **Result:**
+
+
+
+---
+
+
+### getOpenEnded{#getOpenEnded}
+
+| 이름 | 설명 |
+| --- | --- |
+| getOpenEnded() | 이 실린더가 개방형인지 여부를 나타내는 값을 가져오거나 설정합니다. 기본값은 false이며, 개방형이면 true; 그렇지 않으면 상단/하단 캡이 존재합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setOpenEnded{#setOpenEnded}
+
+| 이름 | 설명 |
+| --- | --- |
+| setOpenEnded(value) | 이 실린더가 개방형인지 여부를 나타내는 값을 가져오거나 설정합니다. 기본값은 false이며, 개방형이면 true; 그렇지 않으면 상단/하단 캡이 존재합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getThetaStart{#getThetaStart}
+
+| 이름 | 설명 |
+| --- | --- |
+| getThetaStart() | Theta 시작값을 가져오거나 설정합니다. 기본값은 0이며, Theta 시작값입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setThetaStart{#setThetaStart}
+
+| 이름 | 설명 |
+| --- | --- |
+| setThetaStart(value) | Theta 시작값을 가져오거나 설정합니다. 기본값은 0이며, Theta 시작값입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getThetaLength{#getThetaLength}
+
+| 이름 | 설명 |
+| --- | --- |
+| getThetaLength() | Theta 길이를 가져오거나 설정합니다. 기본값은 2π이며, Theta 길이입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setThetaLength{#setThetaLength}
+
+| 이름 | 설명 |
+| --- | --- |
+| setThetaLength(value) | Theta 길이를 가져오거나 설정합니다. 기본값은 2π이며, Theta 길이입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastShadows{#getCastShadows}
+
+| 이름 | 설명 |
+| --- | --- |
+| getCastShadows() | 이 지오메트리가 그림자를 드리울 수 있는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastShadows{#setCastShadows}
+
+| 이름 | 설명 |
+| --- | --- |
+| setCastShadows(value) | 이 지오메트리가 그림자를 드리울 수 있는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReceiveShadows{#getReceiveShadows}
+
+| 이름 | 설명 |
+| --- | --- |
+| getReceiveShadows() | 이 지오메트리가 그림자를 받을 수 있는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReceiveShadows{#setReceiveShadows}
+
+| 이름 | 설명 |
+| --- | --- |
+| setReceiveShadows(value) | 이 지오메트리가 그림자를 받을 수 있는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNodes() | 모든 부모 노드를 가져옵니다. 엔터티는 기하학 인스턴싱을 위해 여러 부모 노드에 부착될 수 있습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExcluded() | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExcluded(value) | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNode() | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setParentNode(value) | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 이름 | 설명 |
+| --- | --- |
+| getScene() | 이 객체가 속한 씬을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### toMesh{#toMesh}
+
+| 이름 | 설명 |
+| --- | --- |
+| toMesh() | 현재 객체를 메시로 변환합니다 |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBoundingBox() | 현재 엔터티의 객체 공간 좌표계에서 경계 상자를 가져옵니다. |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEntityRendererKey() | 렌더러에 등록된 엔터티 렌더러의 키를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/deformer/_index.md
+++ b/korean/nodejs-java/aspose.threed/deformer/_index.md
@@ -1,0 +1,183 @@
+---
+title: "Deformer"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/deformer/
+---
+## Deformer class
+
+SkinDeformer와 MorphTargetDeformer의 기본 클래스
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor(name) | Deformer 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| name | String | 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getOwner{#getOwner}
+
+| 이름 | 설명 |
+| --- | --- |
+| getOwner() | 이 디포머를 소유하는 지오메트리를 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/descriptorsetupdater/_index.md
+++ b/korean/nodejs-java/aspose.threed/descriptorsetupdater/_index.md
@@ -1,0 +1,137 @@
+---
+title: "DescriptorSetUpdater"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/descriptorsetupdater/
+---
+## DescriptorSetUpdater class
+
+이 클래스는 체인 작업에서 com.aspose.threed.IDescriptorSet을 업데이트할 수 있게 합니다.  @hideconstructor
+
+
+## 메서드
+
+### bind{#bind}
+
+| 이름 | 설명 |
+| --- | --- |
+| bind(buffer, offset, size) | 버퍼를 현재 디스크립터 세트에 바인드합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| buffer | IBuffer | 바인드할 buffer |
+| 오프셋 | 숫자 | 바인드할 buffer의 오프셋 |
+| 크기 | 숫자 | 바인드할 buffer의 크기 |
+
+ **Result:**
+DescriptorSetUpdater
+
+
+---
+
+
+### bind{#bind}
+
+| 이름 | 설명 |
+| --- | --- |
+| bind(buffer) | 전체 buffer를 현재 디스크립터에 바인드합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 버프 | IBuffer | null |
+
+ **Result:**
+DescriptorSetUpdater
+
+
+---
+
+
+### bind{#bind}
+
+| 이름 | 설명 |
+| --- | --- |
+| bind(binding, buffer) | 버퍼를 현재 디스크립터 세트에 지정된 바인딩 위치에 바인드합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 바인딩 | 숫자 | 바인딩 위치 |
+| buffer | IBuffer | 바인드할 전체 버퍼 |
+
+ **Result:**
+DescriptorSetUpdater
+
+
+---
+
+
+### bind{#bind}
+
+| 이름 | 설명 |
+| --- | --- |
+| bind(binding, buffer, offset, size) | 버퍼를 현재 디스크립터 세트에 지정된 바인딩 위치에 바인드합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 바인딩 | 숫자 | 바인딩 위치 |
+| buffer | IBuffer | 바인드할 버퍼 |
+| 오프셋 | 숫자 | 바인드할 buffer의 오프셋 |
+| 크기 | 숫자 | 바인드할 buffer의 크기 |
+
+ **Result:**
+DescriptorSetUpdater
+
+
+---
+
+
+### bind{#bind}
+
+| 이름 | 설명 |
+| --- | --- |
+| bind(texture) | 텍스처 유닛을 현재 디스크립터 세트에 바인드합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| texture | ITextureUnit | 바인드할 텍스처 유닛 |
+
+ **Result:**
+DescriptorSetUpdater
+
+
+---
+
+
+### bind{#bind}
+
+| 이름 | 설명 |
+| --- | --- |
+| bind(binding, texture) | 텍스처 유닛을 현재 디스크립터 세트에 바인드합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 바인딩 | 숫자 | 바인딩 위치 |
+| texture | ITextureUnit | 바인드할 텍스처 유닛 |
+
+ **Result:**
+DescriptorSetUpdater
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/discreet3dsloadoptions/_index.md
+++ b/korean/nodejs-java/aspose.threed/discreet3dsloadoptions/_index.md
@@ -1,0 +1,198 @@
+---
+title: "Discreet3dsLoadOptions"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/discreet3dsloadoptions/
+---
+## Discreet3dsLoadOptions class
+
+3DS 파일 로드 옵션.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | Discreet3dsLoadOptions의 생성자 |
+
+ **Result:**
+
+
+
+---
+
+
+### getGammaCorrectedColor{#getGammaCorrectedColor}
+
+| 이름 | 설명 |
+| --- | --- |
+| getGammaCorrectedColor() | 3ds 파일은 동일한 속성에 대해 원본 색상과 감마 보정 색상을 모두 포함할 수 있습니다. 이를 true로 설정하면 가능한 경우 감마 보정 색상을 사용하고, 그렇지 않으면 Aspose.3D가 원본 색상을 사용하려고 시도합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setGammaCorrectedColor{#setGammaCorrectedColor}
+
+| 이름 | 설명 |
+| --- | --- |
+| setGammaCorrectedColor(value) | 3ds 파일은 동일한 속성에 대해 원본 색상과 감마 보정 색상을 모두 포함할 수 있습니다. 이를 true로 설정하면 가능한 경우 감마 보정 색상을 사용하고, 그렇지 않으면 Aspose.3D가 원본 색상을 사용하려고 시도합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlipCoordinateSystem{#getFlipCoordinateSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFlipCoordinateSystem() | 가져오거나 설정합니다 제어점/법선의 플립 좌표계를 가져오기/내보내기 중에. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlipCoordinateSystem{#setFlipCoordinateSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFlipCoordinateSystem(value) | 가져오거나 설정합니다 제어점/법선의 플립 좌표계를 가져오기/내보내기 중에. |
+
+ **Result:**
+
+
+
+---
+
+
+### getApplyAnimationTransform{#getApplyAnimationTransform}
+
+| 이름 | 설명 |
+| --- | --- |
+| getApplyAnimationTransform() | 애니메이션 트랙의 첫 번째 프레임에 정의된 변환을 사용할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setApplyAnimationTransform{#setApplyAnimationTransform}
+
+| 이름 | 설명 |
+| --- | --- |
+| setApplyAnimationTransform(value) | 애니메이션 트랙의 첫 번째 프레임에 정의된 변환을 사용할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileFormat() | 현재 저장/로드 옵션에 지정된 파일 형식을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEncoding() | 텍스트 기반 파일에 대한 기본 인코딩을 가져오거나 설정합니다. 기본값은 null이며, 이는 가져오기/내보내기 프로그램이 사용할 인코딩을 결정함을 의미합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileSystem() | 로드/저장 중 외부 종속성을 관리하는 방법을 사용자가 처리하도록 허용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFileSystem(value) | 로드/저장 중 외부 종속성을 관리하는 방법을 사용자가 처리하도록 허용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| 이름 | 설명 |
+| --- | --- |
+| getLookupPaths() | OBJ와 같은 일부 파일은 외부 파일에 의존하며, 조회 경로를 통해 Aspose.3D가 외부 파일을 찾아 로드할 수 있도록 합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileName() | 내보내기/가져오기 씬의 파일 이름입니다. 선택 사항이지만 OBJ의 재질과 같은 외부 자산을 직렬화할 때 유용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFileName(value) | 내보내기/가져오기 씬의 파일 이름입니다. 선택 사항이지만 OBJ의 재질과 같은 외부 자산을 직렬화할 때 유용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/discreet3dssaveoptions/_index.md
+++ b/korean/nodejs-java/aspose.threed/discreet3dssaveoptions/_index.md
@@ -1,0 +1,380 @@
+---
+title: "Discreet3dsSaveOptions"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/discreet3dssaveoptions/
+---
+## Discreet3dsSaveOptions class
+
+3DS 파일 저장 옵션.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | Discreet3dsSaveOptions의 생성자 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportLight{#getExportLight}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExportLight() | 장면의 모든 조명을 내보낼지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportLight{#setExportLight}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExportLight(value) | 장면의 모든 조명을 내보낼지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportCamera{#getExportCamera}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExportCamera() | 장면의 모든 카메라를 내보낼지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportCamera{#setExportCamera}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExportCamera(value) | 장면의 모든 카메라를 내보낼지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDuplicatedNameSeparator{#getDuplicatedNameSeparator}
+
+| 이름 | 설명 |
+| --- | --- |
+| getDuplicatedNameSeparator() | 객체 이름과 중복 카운터 사이의 구분자이며, 기본값은 "_"입니다. 장면에 동일한 이름을 사용하는 객체가 포함된 경우, Aspose.3D 3DS 내보내기 도구는 해당 객체에 다른 이름을 생성합니다. 예를 들어 두 개의 노드가 "Box"라는 이름을 가지고 있다면, 첫 번째 노드는 이름이 "Box"이고, 두 번째 노드는 기본 구성으로 "Box_2"라는 새 이름을 갖게 됩니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDuplicatedNameSeparator{#setDuplicatedNameSeparator}
+
+| 이름 | 설명 |
+| --- | --- |
+| setDuplicatedNameSeparator(value) | 객체 이름과 중복 카운터 사이의 구분자이며, 기본값은 "_"입니다. 장면에 동일한 이름을 사용하는 객체가 포함된 경우, Aspose.3D 3DS 내보내기 도구는 해당 객체에 다른 이름을 생성합니다. 예를 들어 두 개의 노드가 "Box"라는 이름을 가지고 있다면, 첫 번째 노드는 이름이 "Box"이고, 두 번째 노드는 기본 구성으로 "Box_2"라는 새 이름을 갖게 됩니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDuplicatedNameCounterBase{#getDuplicatedNameCounterBase}
+
+| 이름 | 설명 |
+| --- | --- |
+| getDuplicatedNameCounterBase() | 중복된 이름에 대해 새 이름을 생성할 때 사용되는 카운터이며, 기본값은 2입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDuplicatedNameCounterBase{#setDuplicatedNameCounterBase}
+
+| 이름 | 설명 |
+| --- | --- |
+| setDuplicatedNameCounterBase(value) | 중복된 이름에 대해 새 이름을 생성할 때 사용되는 카운터이며, 기본값은 2입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDuplicatedNameCounterFormat{#getDuplicatedNameCounterFormat}
+
+| 이름 | 설명 |
+| --- | --- |
+| getDuplicatedNameCounterFormat() | 중복 카운터의 형식이며, 기본값은 빈 문자열입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDuplicatedNameCounterFormat{#setDuplicatedNameCounterFormat}
+
+| 이름 | 설명 |
+| --- | --- |
+| setDuplicatedNameCounterFormat(value) | 중복 카운터의 형식이며, 기본값은 빈 문자열입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMasterScale{#getMasterScale}
+
+| 이름 | 설명 |
+| --- | --- |
+| getMasterScale() | 내보내기에 사용되는 마스터 스케일을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMasterScale{#setMasterScale}
+
+| 이름 | 설명 |
+| --- | --- |
+| setMasterScale(value) | 내보내기에 사용되는 마스터 스케일을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getGammaCorrectedColor{#getGammaCorrectedColor}
+
+| 이름 | 설명 |
+| --- | --- |
+| getGammaCorrectedColor() | 3ds 파일은 동일한 속성에 대해 원본 색상과 감마 보정 색상을 모두 포함할 수 있습니다. 이를 true로 설정하면 가능한 경우 감마 보정 색상을 사용하고, 그렇지 않으면 Aspose.3D가 원본 색상을 사용하려고 시도합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setGammaCorrectedColor{#setGammaCorrectedColor}
+
+| 이름 | 설명 |
+| --- | --- |
+| setGammaCorrectedColor(value) | 3ds 파일은 동일한 속성에 대해 원본 색상과 감마 보정 색상을 모두 포함할 수 있습니다. 이를 true로 설정하면 가능한 경우 감마 보정 색상을 사용하고, 그렇지 않으면 Aspose.3D가 원본 색상을 사용하려고 시도합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlipCoordinateSystem{#getFlipCoordinateSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFlipCoordinateSystem() | 가져오거나 설정합니다 제어점/법선의 플립 좌표계를 가져오기/내보내기 중에. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlipCoordinateSystem{#setFlipCoordinateSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFlipCoordinateSystem(value) | 가져오거나 설정합니다 제어점/법선의 플립 좌표계를 가져오기/내보내기 중에. |
+
+ **Result:**
+
+
+
+---
+
+
+### getHighPreciseColor{#getHighPreciseColor}
+
+| 이름 | 설명 |
+| --- | --- |
+| getHighPreciseColor() | true로 설정하면 생성된 3ds 파일은 고정밀 색상을 사용합니다. 즉, 빨강/초록/파랑 각 채널이 32비트 부동소수점으로 표현됩니다. 그렇지 않으면 생성된 파일은 24비트 색상을 사용하며, 각 채널이 8비트 바이트로 표현됩니다. 기본값은 false이며, 모든 애플리케이션이 고정밀 색상을 지원하는 것은 아니기 때문입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setHighPreciseColor{#setHighPreciseColor}
+
+| 이름 | 설명 |
+| --- | --- |
+| setHighPreciseColor(value) | true로 설정하면 생성된 3ds 파일은 고정밀 색상을 사용합니다. 즉, 빨강/초록/파랑 각 채널이 32비트 부동소수점으로 표현됩니다. 그렇지 않으면 생성된 파일은 24비트 색상을 사용하며, 각 채널이 8비트 바이트로 표현됩니다. 기본값은 false이며, 모든 애플리케이션이 고정밀 색상을 지원하는 것은 아니기 때문입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportTextures{#getExportTextures}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExportTextures() | 씬에서 사용된 텍스처를 출력 디렉터리로 복사합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextures{#setExportTextures}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExportTextures(value) | 씬에서 사용된 텍스처를 출력 디렉터리로 복사합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileFormat() | 현재 저장/로드 옵션에 지정된 파일 형식을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEncoding() | 텍스트 기반 파일에 대한 기본 인코딩을 가져오거나 설정합니다. 기본값은 null이며, 이는 가져오기/내보내기 프로그램이 사용할 인코딩을 결정함을 의미합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileSystem() | 로드/저장 중 외부 종속성을 관리하는 방법을 사용자가 처리하도록 허용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFileSystem(value) | 로드/저장 중 외부 종속성을 관리하는 방법을 사용자가 처리하도록 허용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| 이름 | 설명 |
+| --- | --- |
+| getLookupPaths() | OBJ와 같은 일부 파일은 외부 파일에 의존하며, 조회 경로를 통해 Aspose.3D가 외부 파일을 찾아 로드할 수 있도록 합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileName() | 내보내기/가져오기 씬의 파일 이름입니다. 선택 사항이지만 OBJ의 재질과 같은 외부 자산을 직렬화할 때 유용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFileName(value) | 내보내기/가져오기 씬의 파일 이름입니다. 선택 사항이지만 OBJ의 재질과 같은 외부 자산을 직렬화할 때 유용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/dish/_index.md
+++ b/korean/nodejs-java/aspose.threed/dish/_index.md
@@ -1,0 +1,480 @@
+---
+title: "Dish"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/dish/
+---
+## Dish class
+
+매개변수화된 접시.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | 기본 반경(10)과 기본 높이(5)로 새로운 Dish 인스턴스를 생성합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload(radius, height) | 지정된 반경과 높이로 새로운 Dish 인스턴스를 생성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 반경 | 숫자 | Dish의 반경 |
+| height | 숫자 | Dish의 높이 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload2(name, radius, height, widthSegments, heightSegments) | 지정된 반경과 높이로 새로운 Dish 인스턴스를 생성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| name | String | Dish의 이름 |
+| 반경 | 숫자 | Dish의 반경 |
+| height | 숫자 | Dish의 높이 |
+| widthSegments | 숫자 | Dish의 가로 세그먼트 |
+| heightSegments | 숫자 | 접시의 높이 세그먼트 |
+
+ **Result:**
+
+
+
+---
+
+
+### getHeight{#getHeight}
+
+| 이름 | 설명 |
+| --- | --- |
+| getHeight() | 접시의 높이 |
+
+ **Result:**
+
+
+
+---
+
+
+### setHeight{#setHeight}
+
+| 이름 | 설명 |
+| --- | --- |
+| setHeight(value) | 접시의 높이 |
+
+ **Result:**
+
+
+
+---
+
+
+### getRadius{#getRadius}
+
+| 이름 | 설명 |
+| --- | --- |
+| getRadius() | 접시의 반지름 |
+
+ **Result:**
+
+
+
+---
+
+
+### setRadius{#setRadius}
+
+| 이름 | 설명 |
+| --- | --- |
+| setRadius(value) | 접시의 반지름 |
+
+ **Result:**
+
+
+
+---
+
+
+### getWidthSegments{#getWidthSegments}
+
+| 이름 | 설명 |
+| --- | --- |
+| getWidthSegments() | 너비 세그먼트를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setWidthSegments{#setWidthSegments}
+
+| 이름 | 설명 |
+| --- | --- |
+| setWidthSegments(value) | 너비 세그먼트를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getHeightSegments{#getHeightSegments}
+
+| 이름 | 설명 |
+| --- | --- |
+| getHeightSegments() | 높이 세그먼트를 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### setHeightSegments{#setHeightSegments}
+
+| 이름 | 설명 |
+| --- | --- |
+| setHeightSegments(value) | 높이 세그먼트를 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastShadows{#getCastShadows}
+
+| 이름 | 설명 |
+| --- | --- |
+| getCastShadows() | 이 지오메트리가 그림자를 드리울 수 있는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastShadows{#setCastShadows}
+
+| 이름 | 설명 |
+| --- | --- |
+| setCastShadows(value) | 이 지오메트리가 그림자를 드리울 수 있는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReceiveShadows{#getReceiveShadows}
+
+| 이름 | 설명 |
+| --- | --- |
+| getReceiveShadows() | 이 지오메트리가 그림자를 받을 수 있는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReceiveShadows{#setReceiveShadows}
+
+| 이름 | 설명 |
+| --- | --- |
+| setReceiveShadows(value) | 이 지오메트리가 그림자를 받을 수 있는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNodes() | 모든 부모 노드를 가져옵니다. 엔터티는 기하학 인스턴싱을 위해 여러 부모 노드에 부착될 수 있습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExcluded() | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExcluded(value) | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNode() | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setParentNode(value) | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 이름 | 설명 |
+| --- | --- |
+| getScene() | 이 객체가 속한 씬을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### toMesh{#toMesh}
+
+| 이름 | 설명 |
+| --- | --- |
+| toMesh() | 현재 객체를 메시로 변환합니다 |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBoundingBox() | 현재 엔터티의 객체 공간 좌표계에서 경계 상자를 가져옵니다. |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEntityRendererKey() | 렌더러에 등록된 엔터티 렌더러의 키를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/dracoformat/_index.md
+++ b/korean/nodejs-java/aspose.threed/dracoformat/_index.md
@@ -1,0 +1,199 @@
+---
+title: "DracoFormat"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/dracoformat/
+---
+## DracoFormat class
+
+Google Draco 형식  @hideconstructor
+
+
+## 메서드
+
+### getVersion{#getVersion}
+
+| 이름 | 설명 |
+| --- | --- |
+| getVersion() | 파일 형식 버전을 가져옵니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtension{#getExtension}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExtension() | 이 유형의 확장자 이름을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtensions{#getExtensions}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExtensions() | 이 유형의 확장자 이름들을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getContentType{#getContentType}
+
+| 이름 | 설명 |
+| --- | --- |
+| getContentType() | 파일 형식 콘텐츠 유형을 가져옵니다. 속성 값은 FileContentType 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormatType{#getFileFormatType}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileFormatType() | 파일 형식 유형을 가져옵니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### decode{#decode}
+
+| 이름 | 설명 |
+| --- | --- |
+| decode(fileName) | 지정된 파일 이름에서 포인트 클라우드 또는 메쉬를 디코딩합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| fileName | String | 파일 이름에는 drc 파일이 포함됩니다. |
+
+ **Result:**
+Geometry
+
+
+---
+
+
+### decode{#decode}
+
+| 이름 | 설명 |
+| --- | --- |
+| decode(data) | 메모리 데이터에서 포인트 클라우드 또는 메쉬를 디코딩합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| data | byte[] | 원시 drc 바이트 |
+
+ **Result:**
+Geometry
+
+
+---
+
+
+### encode{#encode}
+
+| 이름 | 설명 |
+| --- | --- |
+| encode(entity, fileName, options) | 엔티티를 지정된 파일에 인코딩합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| entity | Entity | 인코딩될 엔티티 |
+| fileName | String | 작성될 파일 이름 |
+| 옵션 | DracoSaveOptions | 포인트 클라우드 인코딩을 위한 추가 옵션 |
+
+ **Result:**
+Geometry
+
+
+---
+
+
+### encode{#encode}
+
+| 이름 | 설명 |
+| --- | --- |
+| encode(entity, options) | 엔티티를 Draco 원시 데이터로 인코딩합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| entity | Entity | 인코딩될 엔티티 |
+| 옵션 | DracoSaveOptions | 포인트 클라우드 인코딩을 위한 추가 옵션 |
+
+ **Result:**
+byte[]
+
+
+---
+
+
+### createLoadOptions{#createLoadOptions}
+
+| 이름 | 설명 |
+| --- | --- |
+| createLoadOptions() | 이 파일 형식에 대한 기본 로드 옵션을 생성합니다. |
+
+ **Result:**
+LoadOptions
+
+
+---
+
+
+### createSaveOptions{#createSaveOptions}
+
+| 이름 | 설명 |
+| --- | --- |
+| createSaveOptions() | 이 파일 형식에 대한 기본 저장 옵션을 생성합니다. |
+
+ **Result:**
+SaveOptions
+
+
+---
+
+
+### toString{#toString}
+
+| 이름 | 설명 |
+| --- | --- |
+| toString() | 형식을 문자열로 변환 |
+
+ **Result:**
+String
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/dracosaveoptions/_index.md
+++ b/korean/nodejs-java/aspose.threed/dracosaveoptions/_index.md
@@ -1,0 +1,328 @@
+---
+title: "DracoSaveOptions"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/dracosaveoptions/
+---
+## DracoSaveOptions class
+
+Google Draco 파일 저장 옵션
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | draco 파일을 저장하기 위한 기본 구성을 생성합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getPositionBits{#getPositionBits}
+
+| 이름 | 설명 |
+| --- | --- |
+| getPositionBits() | 위치에 대한 양자화 비트, 기본값은 14입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setPositionBits{#setPositionBits}
+
+| 이름 | 설명 |
+| --- | --- |
+| setPositionBits(value) | 위치에 대한 양자화 비트, 기본값은 14입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTextureCoordinateBits{#getTextureCoordinateBits}
+
+| 이름 | 설명 |
+| --- | --- |
+| getTextureCoordinateBits() | 텍스처 좌표에 대한 양자화 비트, 기본값은 12입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTextureCoordinateBits{#setTextureCoordinateBits}
+
+| 이름 | 설명 |
+| --- | --- |
+| setTextureCoordinateBits(value) | 텍스처 좌표에 대한 양자화 비트, 기본값은 12입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getColorBits{#getColorBits}
+
+| 이름 | 설명 |
+| --- | --- |
+| getColorBits() | 버텍스 색상에 대한 양자화 비트, 기본값은 10입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setColorBits{#setColorBits}
+
+| 이름 | 설명 |
+| --- | --- |
+| setColorBits(value) | 버텍스 색상에 대한 양자화 비트, 기본값은 10입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getNormalBits{#getNormalBits}
+
+| 이름 | 설명 |
+| --- | --- |
+| getNormalBits() | 노멀 벡터에 대한 양자화 비트, 기본값은 10입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setNormalBits{#setNormalBits}
+
+| 이름 | 설명 |
+| --- | --- |
+| setNormalBits(value) | 노멀 벡터에 대한 양자화 비트, 기본값은 10입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getCompressionLevel{#getCompressionLevel}
+
+| 이름 | 설명 |
+| --- | --- |
+| getCompressionLevel() | 압축 수준, 기본값은 DracoCompressionLevel.STANDARD입니다. 속성 값은 DracoCompressionLevel 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setCompressionLevel{#setCompressionLevel}
+
+| 이름 | 설명 |
+| --- | --- |
+| setCompressionLevel(value) | 압축 수준, 기본값은 DracoCompressionLevel.STANDARD입니다. 속성 값은 DracoCompressionLevel 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getApplyUnitScale{#getApplyUnitScale}
+
+| 이름 | 설명 |
+| --- | --- |
+| getApplyUnitScale() | AssetInfo.UnitScaleFactor를 메시에 적용합니다. 기본값은 false입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setApplyUnitScale{#setApplyUnitScale}
+
+| 이름 | 설명 |
+| --- | --- |
+| setApplyUnitScale(value) | AssetInfo.UnitScaleFactor를 메시에 적용합니다. 기본값은 false입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getPointCloud{#getPointCloud}
+
+| 이름 | 설명 |
+| --- | --- |
+| getPointCloud() | 장면을 포인트 클라우드로 내보내며, 기본값은 false입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setPointCloud{#setPointCloud}
+
+| 이름 | 설명 |
+| --- | --- |
+| setPointCloud(value) | 장면을 포인트 클라우드로 내보내며, 기본값은 false입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportTextures{#getExportTextures}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExportTextures() | 씬에서 사용된 텍스처를 출력 디렉터리로 복사합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextures{#setExportTextures}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExportTextures(value) | 씬에서 사용된 텍스처를 출력 디렉터리로 복사합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileFormat() | 현재 저장/로드 옵션에 지정된 파일 형식을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEncoding() | 텍스트 기반 파일에 대한 기본 인코딩을 가져오거나 설정합니다. 기본값은 null이며, 이는 가져오기/내보내기 프로그램이 사용할 인코딩을 결정함을 의미합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileSystem() | 로드/저장 중 외부 종속성을 관리하는 방법을 사용자가 처리하도록 허용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFileSystem(value) | 로드/저장 중 외부 종속성을 관리하는 방법을 사용자가 처리하도록 허용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| 이름 | 설명 |
+| --- | --- |
+| getLookupPaths() | OBJ와 같은 일부 파일은 외부 파일에 의존하며, 조회 경로를 통해 Aspose.3D가 외부 파일을 찾아 로드할 수 있도록 합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileName() | 내보내기/가져오기 씬의 파일 이름입니다. 선택 사항이지만 OBJ의 재질과 같은 외부 자산을 직렬화할 때 유용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFileName(value) | 내보내기/가져오기 씬의 파일 이름입니다. 선택 사항이지만 OBJ의 재질과 같은 외부 자산을 직렬화할 때 유용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/driverexception/_index.md
+++ b/korean/nodejs-java/aspose.threed/driverexception/_index.md
@@ -1,0 +1,29 @@
+---
+title: "DriverException"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/driverexception/
+---
+## DriverException class
+
+내부 렌더링 드라이버에서 발생한 예외.  @hideconstructor
+
+
+## 메서드
+
+### getErrorCode{#getErrorCode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getErrorCode() | 네이티브 오류 코드를 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/dummyfilesystem/_index.md
+++ b/korean/nodejs-java/aspose.threed/dummyfilesystem/_index.md
@@ -1,0 +1,69 @@
+---
+title: "DummyFileSystem"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/dummyfilesystem/
+---
+## DummyFileSystem class
+
+읽기/쓰기 작업은 더미 작업입니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### readFile{#readFile}
+
+| 이름 | 설명 |
+| --- | --- |
+| readFile(fileName, options) | 종속성을 읽기 위한 스트림을 생성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| fileNam | String | null |
+| 옵션 | IOConfig | null |
+
+ **Result:**
+Stream
+
+
+---
+
+
+### writeFile{#writeFile}
+
+| 이름 | 설명 |
+| --- | --- |
+| writeFile(fileName, options) | 종속성을 쓰기 위한 스트림을 생성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| fileNam | String | null |
+| 옵션 | IOConfig | null |
+
+ **Result:**
+Stream
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/ellipse/_index.md
+++ b/korean/nodejs-java/aspose.threed/ellipse/_index.md
@@ -1,0 +1,359 @@
+---
+title: "타원"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/ellipse/
+---
+## Ellipse class
+
+Ellipse는 타원의 형태를 이루는 점들의 집합을 정의합니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | 타원의 생성자 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload(semiAxis1, semiAxis2) | 타원의 생성자 |
+
+ **Result:**
+
+
+
+---
+
+
+### getSemiAxis1{#getSemiAxis1}
+
+| 이름 | 설명 |
+| --- | --- |
+| getSemiAxis1() | X축 반지름 |
+
+ **Result:**
+
+
+
+---
+
+
+### setSemiAxis1{#setSemiAxis1}
+
+| 이름 | 설명 |
+| --- | --- |
+| setSemiAxis1(value) | X축 반지름 |
+
+ **Result:**
+
+
+
+---
+
+
+### getSemiAxis2{#getSemiAxis2}
+
+| 이름 | 설명 |
+| --- | --- |
+| getSemiAxis2() | Y축 반지름 |
+
+ **Result:**
+
+
+
+---
+
+
+### setSemiAxis2{#setSemiAxis2}
+
+| 이름 | 설명 |
+| --- | --- |
+| setSemiAxis2(value) | Y축 반지름 |
+
+ **Result:**
+
+
+
+---
+
+
+### getColor{#getColor}
+
+| 이름 | 설명 |
+| --- | --- |
+| getColor() | 선의 색상을 가져오거나 설정합니다. 기본값은 흰색(1, 1, 1)입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setColor{#setColor}
+
+| 이름 | 설명 |
+| --- | --- |
+| setColor(value) | 선의 색상을 가져오거나 설정합니다. 기본값은 흰색(1, 1, 1)입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNodes() | 모든 부모 노드를 가져옵니다. 엔터티는 기하학 인스턴싱을 위해 여러 부모 노드에 부착될 수 있습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExcluded() | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExcluded(value) | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNode() | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setParentNode(value) | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 이름 | 설명 |
+| --- | --- |
+| getScene() | 이 객체가 속한 씬을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEntityRendererKey() | 렌더러에 등록된 엔터티 렌더러의 키를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBoundingBox() | 현재 엔터티의 객체 공간 좌표계에서 경계 상자를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/ellipseshape/_index.md
+++ b/korean/nodejs-java/aspose.threed/ellipseshape/_index.md
@@ -1,0 +1,333 @@
+---
+title: "EllipseShape"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/ellipseshape/
+---
+## EllipseShape class
+
+매개변수로 정의된 IFC 호환 타원 형태. 프로파일의 중심 위치는 경계 상자의 중앙에 있습니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getSemiAxis1{#getSemiAxis1}
+
+| 이름 | 설명 |
+| --- | --- |
+| getSemiAxis1() | x축 방향으로 측정되는 타원의 첫 번째 반지름을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setSemiAxis1{#setSemiAxis1}
+
+| 이름 | 설명 |
+| --- | --- |
+| setSemiAxis1(value) | x축 방향으로 측정되는 타원의 첫 번째 반지름을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getSemiAxis2{#getSemiAxis2}
+
+| 이름 | 설명 |
+| --- | --- |
+| getSemiAxis2() | 타원의 y축 방향으로 측정되는 두 번째 반지름을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setSemiAxis2{#setSemiAxis2}
+
+| 이름 | 설명 |
+| --- | --- |
+| setSemiAxis2(value) | 타원의 y축 방향으로 측정되는 두 번째 반지름을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNodes() | 모든 부모 노드를 가져옵니다. 엔터티는 기하학 인스턴싱을 위해 여러 부모 노드에 부착될 수 있습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExcluded() | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExcluded(value) | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNode() | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setParentNode(value) | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 이름 | 설명 |
+| --- | --- |
+| getScene() | 이 객체가 속한 씬을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtent{#getExtent}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExtent() | x 및 y 차원에서의 범위를 가져옵니다. |
+
+ **Result:**
+Vector2
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEntityRendererKey() | 렌더러에 등록된 엔터티 렌더러의 키를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBoundingBox() | 현재 엔터티의 객체 공간 좌표계에서 경계 상자를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/endpoint/_index.md
+++ b/korean/nodejs-java/aspose.threed/endpoint/_index.md
@@ -1,0 +1,157 @@
+---
+title: "EndPoint"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/endpoint/
+---
+## EndPoint class
+
+곡선을 자를 끝점으로, 매개변수 값이거나 직교 좌표점일 수 있습니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload(point) | 데카르트 좌표점을 사용하여 EndPoint를 생성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| poin | Vector3 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload2(v) | 실수 매개변수를 사용하여 EndPoint를 생성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+|  | 숫자 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### isCartesianPoint{#isCartesianPoint}
+
+| 이름 | 설명 |
+| --- | --- |
+| isCartesianPoint() | 끝점이 데카르트 좌표점인가요? |
+
+ **Result:**
+
+
+
+---
+
+
+### getAsPoint{#getAsPoint}
+
+| 이름 | 설명 |
+| --- | --- |
+| getAsPoint() | 끝점을 직교 좌표점으로 가져오고, 예외를 발생시킵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAsValue{#getAsValue}
+
+| 이름 | 설명 |
+| --- | --- |
+| getAsValue() | 끝점을 실수 매개변수로 가져오고, 예외를 발생시킵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### fromDegree{#fromDegree}
+
+| 이름 | 설명 |
+| --- | --- |
+| fromDegree(degree) | 각도로 측정된 끝점을 생성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| degre | 숫자 | null |
+
+ **Result:**
+EndPoint
+
+
+---
+
+
+### fromRadian{#fromRadian}
+
+| 이름 | 설명 |
+| --- | --- |
+| fromRadian(degree) | 라디안으로 측정된 끝점을 생성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| degre | 숫자 | null |
+
+ **Result:**
+EndPoint
+
+
+---
+
+
+### toString{#toString}
+
+| 이름 | 설명 |
+| --- | --- |
+| toString() | 현재 끝점의 문자열 표현을 반환합니다. |
+
+ **Result:**
+String
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/entity/_index.md
+++ b/korean/nodejs-java/aspose.threed/entity/_index.md
@@ -1,0 +1,274 @@
+---
+title: "Entity"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/entity/
+---
+## Entity class
+
+모든 엔터티의 기본 클래스. Entity는 Light/Geometry와 같은 노드 아래에 부착되는 구체적인 객체를 나타냅니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor(name) | Entity 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| name | String | 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNodes() | 모든 부모 노드를 가져옵니다. 엔터티는 기하학 인스턴싱을 위해 여러 부모 노드에 부착될 수 있습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExcluded() | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExcluded(value) | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNode() | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setParentNode(value) | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 이름 | 설명 |
+| --- | --- |
+| getScene() | 이 객체가 속한 씬을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBoundingBox() | 현재 엔터티의 객체 공간 좌표계에서 경계 상자를 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEntityRendererKey() | 렌더러에 등록된 엔터티 렌더러의 키를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/entityrenderer/_index.md
+++ b/korean/nodejs-java/aspose.threed/entityrenderer/_index.md
@@ -1,0 +1,185 @@
+---
+title: "EntityRenderer"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/entityrenderer/
+---
+## EntityRenderer class
+
+다양한 종류의 엔터티에 대한 렌더링을 구현하려면 이 클래스를 서브클래스화하십시오.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor(key, features) | EntityRenderer의 생성자 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| key | String | EntityRenderer의 키 |
+| features | byte | EntityRendererFeatures |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload(key) | EntityRenderer의 생성자 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| key | String | EntityRenderer의 키 |
+
+ **Result:**
+
+
+
+---
+
+
+### initialize{#initialize}
+
+| 이름 | 설명 |
+| --- | --- |
+| initialize(renderer) | EntityRenderer를 초기화합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| rendere | Renderer | null |
+
+ **Result:**
+
+
+
+---
+
+
+### resetSceneCache{#resetSceneCache}
+
+| 이름 | 설명 |
+| --- | --- |
+| resetSceneCache() | 씬이 변경되었거나 제거되었습니다. 이 경우 씬 수준의 렌더 리소스를 해제해야 합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### frameBegin{#frameBegin}
+
+| 이름 | 설명 |
+| --- | --- |
+| frameBegin(renderer, renderQueue) | 프레임 렌더링을 시작합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| renderer | Renderer | 현재 렌더러 |
+| renderQueue | IRenderQueue | 렌더 큐 |
+
+ **Result:**
+
+
+
+---
+
+
+### frameEnd{#frameEnd}
+
+| 이름 | 설명 |
+| --- | --- |
+| frameEnd(renderer, renderQueue) | 프레임 렌더링을 종료합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| renderer | Renderer | 현재 렌더러 |
+| renderQueue | IRenderQueue | 렌더 큐 |
+
+ **Result:**
+
+
+
+---
+
+
+### prepareRenderQueue{#prepareRenderQueue}
+
+| 이름 | 설명 |
+| --- | --- |
+| prepareRenderQueue(renderer, queue, node, entity) | 지정된 노드/엔터티 쌍에 대한 렌더링 명령을 준비합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| renderer | Renderer | 현재 렌더러 인스턴스 |
+| queue | IRenderQueue | 렌더 작업을 관리하는 데 사용되는 렌더 큐 |
+| node | Node | 현재 노드 |
+| entity | Entity | 렌더링이 필요한 엔터티 |
+
+ **Result:**
+
+
+
+---
+
+
+### renderEntity{#renderEntity}
+
+| 이름 | 설명 |
+| --- | --- |
+| renderEntity(renderer, commandList, node, renderableResource, subEntity) | com.aspose.threed.IRenderQueue에 푸시된 각 렌더 작업은 구체적인 렌더링 작업을 수행하기 위해 해당하는 RenderEntity 호출을 가집니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| renderer | Renderer | 그 렌더러 |
+| commandList | ICommandList | 그 commandList는 렌더링 명령을 기록하는 데 사용됩니다 |
+| node | Node | 그 동일한 노드가 렌더링될 엔터티의 PrepareRenderQueue에 전달되었습니다 |
+| renderableResource | Object | 그 사용자 정의 객체가 PrepareRenderQueue 동안 IRenderQueue에 전달되었습니다 |
+| subEntity | 숫자 | 그 서브 엔터티가 IRenderQueue에 전달된 인덱스 |
+
+ **Result:**
+
+
+
+---
+
+
+### dispose{#dispose}
+
+| 이름 | 설명 |
+| --- | --- |
+| dispose() | 그 엔터티 렌더러가 해제되고 있으며, 공유 리소스를 해제합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/entityrendererkey/_index.md
+++ b/korean/nodejs-java/aspose.threed/entityrendererkey/_index.md
@@ -1,0 +1,48 @@
+---
+title: "EntityRendererKey"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/entityrendererkey/
+---
+## EntityRendererKey class
+
+등록된 엔터티 렌더러의 키
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor(name) | EntityRendererKey의 생성자 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| nam | String | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| 이름 | 설명 |
+| --- | --- |
+| toString() |  |
+
+ **Result:**
+String
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/exportexception/_index.md
+++ b/korean/nodejs-java/aspose.threed/exportexception/_index.md
@@ -1,0 +1,35 @@
+---
+title: "ExportException"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/exportexception/
+---
+## ExportException class
+
+Aspose.3D가 씬을 파일로 내보내지 못했을 때 발생하는 예외
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor(msg) | 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 메시지 | String | 오류 메시지 |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/extrapolation/_index.md
+++ b/korean/nodejs-java/aspose.threed/extrapolation/_index.md
@@ -1,0 +1,68 @@
+---
+title: "Extrapolation"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/extrapolation/
+---
+## Extrapolation class
+
+Extrapolation은 샘플링된 값이 첫 번째와 마지막 키프레임으로 정의된 범위를 벗어났을 때 어떻게 처리할지를 정의합니다.  @hideconstructor
+
+
+## 메서드
+
+### getType{#getType}
+
+| 이름 | 설명 |
+| --- | --- |
+| getType() | 외삽의 샘플링 패턴을 가져오거나 설정합니다. 이 속성의 값은 ExtrapolationType 정수 상수이며, 유형을 나타냅니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setType{#setType}
+
+| 이름 | 설명 |
+| --- | --- |
+| setType(value) | 외삽의 샘플링 패턴을 가져오거나 설정합니다. 이 속성의 값은 ExtrapolationType 정수 상수이며, 유형을 나타냅니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getRepeatCount{#getRepeatCount}
+
+| 이름 | 설명 |
+| --- | --- |
+| getRepeatCount() | 외삽 패턴의 반복 횟수를 가져오거나 설정합니다. 횟수. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRepeatCount{#setRepeatCount}
+
+| 이름 | 설명 |
+| --- | --- |
+| setRepeatCount(value) | 외삽 패턴의 반복 횟수를 가져오거나 설정합니다. 횟수. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/fbxloadoptions/_index.md
+++ b/korean/nodejs-java/aspose.threed/fbxloadoptions/_index.md
@@ -1,0 +1,165 @@
+---
+title: "FbxLoadOptions"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/fbxloadoptions/
+---
+## FbxLoadOptions class
+
+Fbx 형식 로드 옵션.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor(format) | FbxLoadOptions의 생성자 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 형식 | 파일 형식 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload() | FbxLoadOptions의 생성자 |
+
+ **Result:**
+
+
+
+---
+
+
+### getKeepBuiltinGlobalSettings{#getKeepBuiltinGlobalSettings}
+
+| 이름 | 설명 |
+| --- | --- |
+| getKeepBuiltinGlobalSettings() | AssetInfo에서 네이티브 속성 교체가 있는 GlobalSettings의 내장 속성을 유지할지 여부를 가져오거나 설정합니다. 전체 속성을 GlobalSettings에 유지하려면 true로 설정하십시오. 기본값은 false입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setKeepBuiltinGlobalSettings{#setKeepBuiltinGlobalSettings}
+
+| 이름 | 설명 |
+| --- | --- |
+| setKeepBuiltinGlobalSettings(value) | AssetInfo에서 네이티브 속성 교체가 있는 GlobalSettings의 내장 속성을 유지할지 여부를 가져오거나 설정합니다. 전체 속성을 GlobalSettings에 유지하려면 true로 설정하십시오. 기본값은 false입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileFormat() | 현재 저장/로드 옵션에 지정된 파일 형식을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEncoding() | 텍스트 기반 파일에 대한 기본 인코딩을 가져오거나 설정합니다. 기본값은 null이며, 이는 가져오기/내보내기 프로그램이 사용할 인코딩을 결정함을 의미합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileSystem() | 로드/저장 중 외부 종속성을 관리하는 방법을 사용자가 처리하도록 허용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFileSystem(value) | 로드/저장 중 외부 종속성을 관리하는 방법을 사용자가 처리하도록 허용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| 이름 | 설명 |
+| --- | --- |
+| getLookupPaths() | OBJ와 같은 일부 파일은 외부 파일에 의존하며, 조회 경로를 통해 Aspose.3D가 외부 파일을 찾아 로드할 수 있도록 합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileName() | 내보내기/가져오기 씬의 파일 이름입니다. 선택 사항이지만 OBJ의 재질과 같은 외부 자산을 직렬화할 때 유용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFileName(value) | 내보내기/가져오기 씬의 파일 이름입니다. 선택 사항이지만 OBJ의 재질과 같은 외부 자산을 직렬화할 때 유용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/fbxsaveoptions/_index.md
+++ b/korean/nodejs-java/aspose.threed/fbxsaveoptions/_index.md
@@ -1,0 +1,340 @@
+---
+title: "FbxSaveOptions"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/fbxsaveoptions/
+---
+## FbxSaveOptions class
+
+Fbx 파일 저장 옵션.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor(format) | FbxSaveOptions를 초기화합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 형식 | 파일 형식 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload(contentType) | 최신 지원 버전을 사용하여 FbxSaveOptions를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| contentType | FileContentType | FileContentType |
+
+ **Result:**
+
+
+
+---
+
+
+### getReusePrimitiveMesh{#getReusePrimitiveMesh}
+
+| 이름 | 설명 |
+| --- | --- |
+| getReusePrimitiveMesh() | 같은 매개변수를 가진 프리미티브에 대해 메시를 재사용하면, 대량의 프리미티브 형태(예: CAD 파일에서 가져온)로 구성된 장면의 FBX 출력 크기를 크게 줄일 수 있습니다. 기본값은 false입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReusePrimitiveMesh{#setReusePrimitiveMesh}
+
+| 이름 | 설명 |
+| --- | --- |
+| setReusePrimitiveMesh(value) | 같은 매개변수를 가진 프리미티브에 대해 메시를 재사용하면, 대량의 프리미티브 형태(예: CAD 파일에서 가져온)로 구성된 장면의 FBX 출력 크기를 크게 줄일 수 있습니다. 기본값은 false입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEnableCompression{#getEnableCompression}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEnableCompression() | FBX 파일에서 대용량 바이너리 데이터(예: 애니메이션 데이터, 제어점, 정점 요소 데이터, 인덱스)를 압축합니다. 기본값은 true입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setEnableCompression{#setEnableCompression}
+
+| 이름 | 설명 |
+| --- | --- |
+| setEnableCompression(value) | FBX 파일에서 대용량 바이너리 데이터(예: 애니메이션 데이터, 제어점, 정점 요소 데이터, 인덱스)를 압축합니다. 기본값은 true입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFoldRepeatedCurveData{#getFoldRepeatedCurveData}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFoldRepeatedCurveData() | 반복된 곡선 데이터를 재사용할지 여부를 가져오거나 설정합니다. 마지막 데이터의 참조 카운트를 증가시켜 재사용하면 true, 그렇지 않으면 false입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportLegacyMaterialProperties{#getExportLegacyMaterialProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExportLegacyMaterialProperties() | 레거시 재질 속성을 내보낼지 여부를 가져오거나 설정합니다. 이는 이전 호환성을 위해 사용됩니다. 이 옵션은 기본적으로 켜져 있습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportLegacyMaterialProperties{#setExportLegacyMaterialProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExportLegacyMaterialProperties(value) | 레거시 재질 속성을 내보낼지 여부를 가져오거나 설정합니다. 이는 이전 호환성을 위해 사용됩니다. 이 옵션은 기본적으로 켜져 있습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getVideoForTexture{#getVideoForTexture}
+
+| 이름 | 설명 |
+| --- | --- |
+| getVideoForTexture() | FBX로 내보낼 때 텍스처에 대한 Video 인스턴스를 생성할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setVideoForTexture{#setVideoForTexture}
+
+| 이름 | 설명 |
+| --- | --- |
+| setVideoForTexture(value) | FBX로 내보낼 때 텍스처에 대한 Video 인스턴스를 생성할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEmbedTextures{#getEmbedTextures}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEmbedTextures() | 텍스처를 최종 출력 파일에 포함시킬지 여부를 가져오거나 설정합니다. FBX Exporter는 파일 시스템에서 텍스처의 원시 데이터를 찾아 최종 FBX 파일에 포함시키려고 시도합니다. 기본값은 false입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setEmbedTextures{#setEmbedTextures}
+
+| 이름 | 설명 |
+| --- | --- |
+| setEmbedTextures(value) | 텍스처를 최종 출력 파일에 포함시킬지 여부를 가져오거나 설정합니다. FBX Exporter는 파일 시스템에서 텍스처의 원시 데이터를 찾아 최종 FBX 파일에 포함시키려고 시도합니다. 기본값은 false입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getGenerateVertexElementMaterial{#getGenerateVertexElementMaterial}
+
+| 이름 | 설명 |
+| --- | --- |
+| getGenerateVertexElementMaterial() | 첨부된 노드에 재질이 포함된 경우, 기하학에 항상 VertexElementMaterial을 생성할지 여부를 가져오거나 설정합니다. 기본적으로 이 옵션은 꺼져 있습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setGenerateVertexElementMaterial{#setGenerateVertexElementMaterial}
+
+| 이름 | 설명 |
+| --- | --- |
+| setGenerateVertexElementMaterial(value) | 첨부된 노드에 재질이 포함된 경우, 기하학에 항상 VertexElementMaterial을 생성할지 여부를 가져오거나 설정합니다. 기본적으로 이 옵션은 꺼져 있습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportTextures{#getExportTextures}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExportTextures() | 씬에서 사용된 텍스처를 출력 디렉터리로 복사합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextures{#setExportTextures}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExportTextures(value) | 씬에서 사용된 텍스처를 출력 디렉터리로 복사합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileFormat() | 현재 저장/로드 옵션에 지정된 파일 형식을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEncoding() | 텍스트 기반 파일에 대한 기본 인코딩을 가져오거나 설정합니다. 기본값은 null이며, 이는 가져오기/내보내기 프로그램이 사용할 인코딩을 결정함을 의미합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileSystem() | 로드/저장 중 외부 종속성을 관리하는 방법을 사용자가 처리하도록 허용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFileSystem(value) | 로드/저장 중 외부 종속성을 관리하는 방법을 사용자가 처리하도록 허용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| 이름 | 설명 |
+| --- | --- |
+| getLookupPaths() | OBJ와 같은 일부 파일은 외부 파일에 의존하며, 조회 경로를 통해 Aspose.3D가 외부 파일을 찾아 로드할 수 있도록 합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileName() | 내보내기/가져오기 씬의 파일 이름입니다. 선택 사항이지만 OBJ의 재질과 같은 외부 자산을 직렬화할 때 유용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFileName(value) | 내보내기/가져오기 씬의 파일 이름입니다. 선택 사항이지만 OBJ의 재질과 같은 외부 자산을 직렬화할 때 유용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/fileformat/_index.md
+++ b/korean/nodejs-java/aspose.threed/fileformat/_index.md
@@ -1,0 +1,187 @@
+---
+title: "파일 형식"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/fileformat/
+---
+## FileFormat class
+
+파일 형식 정의  @hideconstructor
+
+
+## Properties
+
+| 이름 | 설명 |
+| --- | --- |
+| MAYA_BINARY | 바이너리 형식의 Autodesk Maya |
+| STL_BINARY | 바이너리 STL 파일 형식 |
+| STLASCII | ASCII STL 파일 형식 |
+| COLLADA | Collada 파일 형식 |
+| GLTF | Khronos Group의 glTF |
+| GLTF_BINARY | Khronos Group의 바이너리 형식 glTF |
+| PDF | Adobe의 휴대용 문서 형식 |
+| DXF | AutoCAD DXF |
+| PLY | Polygon 파일 형식 또는 Stanford Triangle 형식 |
+| X_BINARY | 바이너리 형식의 DirectX X 파일 |
+| X_TEXT | 바이너리 형식의 DirectX X 파일 |
+| DRACO | Google Draco 메시 |
+| RVM_TEXT | AVEVA Plant Design Management System 모델을 텍스트 형식으로 |
+| RVM_BINARY | AVEVA Plant Design Management System 모델을 바이너리 형식으로 |
+| ASE | 3D Studio Max의 ASCII Scene Exporter 형식. |
+| IFC | ISO 16739-1 Industry Foundation Classes 데이터 모델. |
+| AMF | 적층 제조 파일 형식 |
+| VRML | 가상 현실 모델링 언어 |
+| ZIP | 다른 3D 파일 형식을 포함하는 Zip 아카이브. |
+| USD | 범용 장면 설명 |
+| USDZ | 압축된 범용 장면 설명 |
+| XYZ | Xyz 포인트 클라우드 파일 |
+| PCD | PCL 포인트 클라우드 데이터 파일을 ASCII 모드로 |
+| PCD_BINARY | PCL 포인트 클라우드 데이터 파일을 바이너리 모드로 |
+
+## 메서드
+
+### getVersion{#getVersion}
+
+| 이름 | 설명 |
+| --- | --- |
+| getVersion() | 파일 형식 버전을 가져옵니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtension{#getExtension}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExtension() | 이 유형의 확장자 이름을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtensions{#getExtensions}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExtensions() | 이 유형의 확장자 이름들을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getContentType{#getContentType}
+
+| 이름 | 설명 |
+| --- | --- |
+| getContentType() | 파일 형식 콘텐츠 유형을 가져옵니다. 속성 값은 FileContentType 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormatType{#getFileFormatType}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileFormatType() | 파일 형식 유형을 가져옵니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFormatByExtension{#getFormatByExtension}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFormatByExtension(extensionName) | 파일 확장자 이름에서 선호하는 파일 형식을 가져옵니다. 확장자 이름은 점('.')으로 시작해야 합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| extensionNam | String | null |
+
+ **Result:**
+파일 형식
+
+
+---
+
+
+### detect{#detect}
+
+| 이름 | 설명 |
+| --- | --- |
+| detect(fileName) | 파일 이름으로 파일 형식을 감지합니다. 파일이 읽을 수 있어야 Aspose.3D가 파일 헤더를 통해 파일 형식을 감지할 수 있습니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| fileNam | String | null |
+
+ **Result:**
+파일 형식
+
+
+---
+
+
+### createLoadOptions{#createLoadOptions}
+
+| 이름 | 설명 |
+| --- | --- |
+| createLoadOptions() | 이 파일 형식에 대한 기본 로드 옵션을 생성합니다. |
+
+ **Result:**
+LoadOptions
+
+
+---
+
+
+### createSaveOptions{#createSaveOptions}
+
+| 이름 | 설명 |
+| --- | --- |
+| createSaveOptions() | 이 파일 형식에 대한 기본 저장 옵션을 생성합니다. |
+
+ **Result:**
+SaveOptions
+
+
+---
+
+
+### toString{#toString}
+
+| 이름 | 설명 |
+| --- | --- |
+| toString() | 형식을 문자열로 변환 |
+
+ **Result:**
+String
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/fileformattype/_index.md
+++ b/korean/nodejs-java/aspose.threed/fileformattype/_index.md
@@ -1,0 +1,66 @@
+---
+title: "FileFormatType"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/fileformattype/
+---
+## FileFormatType class
+
+파일 형식 유형  @hideconstructor
+
+
+## Properties
+
+| 이름 | 설명 |
+| --- | --- |
+| MAYA | Autodesk Maya 형식 유형 |
+| FBX | FBX 파일 형식 유형 |
+| STL | STL 파일 형식 유형 |
+| COLLADA | Khronos Group의 Collada 파일 형식입니다. |
+| PDF | 포터블 문서 형식 |
+| GLTF | Khronos Group의 glTF |
+| DXF | AutoCAD DXF |
+| PLY | Polygon 파일 형식 또는 Stanford Triangle 형식 |
+| X | DirectX의 X 파일 |
+| DRACO | Google Draco 메시 |
+| RVM | AVEVA Plant Design Management System 모델입니다. |
+| ASE | 3D Studio Max의 ASCII Scene Exporter 형식. |
+| ZIP | 다른 3D 파일 형식을 포함하는 Zip 아카이브. |
+| USD | 범용 장면 설명 |
+| PCD | Point Cloud Library에서 사용되는 포인트 클라우드 데이터 |
+| XYZ | Xyz 포인트 클라우드 파일 |
+| IFC | ISO 16739-1 Industry Foundation Classes 데이터 모델. |
+| AMF | 적층 제조 파일 형식 |
+| VRML | 가상 현실 모델링 언어 |
+
+## 메서드
+
+### getExtension{#getExtension}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExtension() | 이 파일 형식의 확장자 이름은 . 로 시작합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| 이름 | 설명 |
+| --- | --- |
+| toString() | 이 파일 형식 유형의 이름을 가져옵니다. |
+
+ **Result:**
+String
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/filesystem/_index.md
+++ b/korean/nodejs-java/aspose.threed/filesystem/_index.md
@@ -1,0 +1,56 @@
+---
+title: "FileSystem"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/filesystem/
+---
+## FileSystem class
+
+파일 시스템 캡슐화.  Aspose.3D는 이를 사용하여 종속성을 읽고/쓸 수 있습니다.  @hideconstructor
+
+
+## 메서드
+
+### readFile{#readFile}
+
+| 이름 | 설명 |
+| --- | --- |
+| readFile(fileName, options) | 종속성을 읽기 위한 스트림을 생성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| fileNam | String | null |
+| 옵션 | IOConfig | null |
+
+ **Result:**
+Stream
+
+
+---
+
+
+### writeFile{#writeFile}
+
+| 이름 | 설명 |
+| --- | --- |
+| writeFile(fileName, options) | 종속성을 쓰기 위한 스트림을 생성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| fileNam | String | null |
+| 옵션 | IOConfig | null |
+
+ **Result:**
+Stream
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/fmatrix4/_index.md
+++ b/korean/nodejs-java/aspose.threed/fmatrix4/_index.md
@@ -1,0 +1,190 @@
+---
+title: "FMatrix4"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/fmatrix4/
+---
+## FMatrix4 class
+
+모든 구성 요소가 float 타입인 4x4 행렬
+
+
+## Properties
+
+| 이름 | 설명 |
+| --- | --- |
+| m00 | m00 값. |
+| m01 | m01 값. |
+| m02 | m02 값. |
+| m03 | m03 값. |
+| m10 | m10 값. |
+| m11 | m11 값. |
+| m12 | 그 m12. |
+| m13 | 그 m13. |
+| m20 | 그 m20. |
+| m21 | 그 m21. |
+| m22 | 그 m22. |
+| m23 | 그 m23. |
+| m30 | 그 m30. |
+| m31 | 그 m31. |
+| m32 | 그 m32. |
+| m33 | 그 m33. |
+| IDENTITY | 그 단위 행렬 |
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload(m00, m01, m02, m03, m10, m11, m12, m13, m20, m21, m22, m23, m30, m31, m32, m33) | FMatrix4의 인스턴스를 초기화합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| m0 | 숫자 | null |
+| m0 | 숫자 | null |
+| m0 | 숫자 | null |
+| m0 | 숫자 | null |
+| m1 | 숫자 | null |
+| m1 | 숫자 | null |
+| m1 | 숫자 | null |
+| m1 | 숫자 | null |
+| m2 | 숫자 | null |
+| m2 | 숫자 | null |
+| m2 | 숫자 | null |
+| m2 | 숫자 | null |
+| m3 | 숫자 | null |
+| m3 | 숫자 | null |
+| m3 | 숫자 | null |
+| m3 | 숫자 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload2(mat) | Matrix4 인스턴스로부터 FMatrix4 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| ma | Matrix4 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload3{#constructor_overload3}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload3(r0, r1, r2, r3) | 4개의 행으로부터 행렬을 구성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| r0 | FVector4 | R0. |
+| r1 | FVector4 | R1. |
+| r2 | FVector4 | R2. |
+| r3 | FVector4 | R3. |
+
+ **Result:**
+
+
+
+---
+
+
+### concatenate{#concatenate}
+
+| 이름 | 설명 |
+| --- | --- |
+| concatenate(m2) | 두 행렬을 연결합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| m2 | FMatrix4 | M2. |
+
+ **Result:**
+FMatrix4
+
+
+---
+
+
+### concatenate{#concatenate}
+
+| 이름 | 설명 |
+| --- | --- |
+| concatenate(m2) | 두 행렬을 연결합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| m2 | Matrix4 | M2. |
+
+ **Result:**
+FMatrix4
+
+
+---
+
+
+### transpose{#transpose}
+
+| 이름 | 설명 |
+| --- | --- |
+| transpose() | 이 인스턴스를 전치합니다. |
+
+ **Result:**
+FMatrix4
+
+
+---
+
+
+### inverse{#inverse}
+
+| 이름 | 설명 |
+| --- | --- |
+| inverse() | 현재 인스턴스의 역행렬을 계산합니다. |
+
+ **Result:**
+FMatrix4
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/fontfile/_index.md
+++ b/korean/nodejs-java/aspose.threed/fontfile/_index.md
@@ -1,0 +1,189 @@
+---
+title: "FontFile"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/fontfile/
+---
+## FontFile class
+
+폰트 파일에는 글리프 정의가 포함되어 있으며, 이는 텍스트 프로파일을 만드는 데 사용됩니다.  @hideconstructor
+
+
+## 메서드
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### fromFile{#fromFile}
+
+| 이름 | 설명 |
+| --- | --- |
+| fromFile(fileName) | 파일 이름에서 FontFile을 로드합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| fileName | String | 폰트 파일 경로 |
+
+ **Result:**
+FontFile
+
+
+---
+
+
+### parse{#parse}
+
+| 이름 | 설명 |
+| --- | --- |
+| parse(bytes) | 바이트에서 FontFile을 파싱합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| bytes | byte[] | OTF 폰트 파일 원시 내용 |
+
+ **Result:**
+FontFile
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/frustum/_index.md
+++ b/korean/nodejs-java/aspose.threed/frustum/_index.md
@@ -1,0 +1,489 @@
+---
+title: "프러스텀"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/frustum/
+---
+## Frustum class
+
+Camera와 Light의 기본 클래스  @hideconstructor
+
+
+## 메서드
+
+### getRotationMode{#getRotationMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getRotationMode() | 프러스텀의 방향 모드를 가져오거나 설정합니다. 이 속성은 Target이 null인 경우에만 작동합니다. 값이 RotationMode.FIXED_TARGET이면 방향은 항상 LookAt 속성에 의해 계산됩니다. 그렇지 않으면 LookAt은 항상 Direction에 의해 계산됩니다. 이 속성의 값은 RotationMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRotationMode{#setRotationMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setRotationMode(value) | 프러스텀의 방향 모드를 가져오거나 설정합니다. 이 속성은 Target이 null인 경우에만 작동합니다. 값이 RotationMode.FIXED_TARGET이면 방향은 항상 LookAt 속성에 의해 계산됩니다. 그렇지 않으면 LookAt은 항상 Direction에 의해 계산됩니다. 이 속성의 값은 RotationMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getNearPlane{#getNearPlane}
+
+| 이름 | 설명 |
+| --- | --- |
+| getNearPlane() | 프러스텀의 근접 평면 거리를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setNearPlane{#setNearPlane}
+
+| 이름 | 설명 |
+| --- | --- |
+| setNearPlane(value) | 프러스텀의 근접 평면 거리를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFarPlane{#getFarPlane}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFarPlane() | 프러스텀의 원거리 평면 거리를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFarPlane{#setFarPlane}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFarPlane(value) | 프러스텀의 원거리 평면 거리를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAspect{#getAspect}
+
+| 이름 | 설명 |
+| --- | --- |
+| getAspect() | 프러스텀의 종횡비를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setAspect{#setAspect}
+
+| 이름 | 설명 |
+| --- | --- |
+| setAspect(value) | 프러스텀의 종횡비를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getOrthoHeight{#getOrthoHeight}
+
+| 이름 | 설명 |
+| --- | --- |
+| getOrthoHeight() | 프러스텀을 직교 투영으로 사용할 때 높이를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setOrthoHeight{#setOrthoHeight}
+
+| 이름 | 설명 |
+| --- | --- |
+| setOrthoHeight(value) | 프러스텀을 직교 투영으로 사용할 때 높이를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getUp{#getUp}
+
+| 이름 | 설명 |
+| --- | --- |
+| getUp() | 카메라의 위쪽 방향을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setUp{#setUp}
+
+| 이름 | 설명 |
+| --- | --- |
+| setUp(value) | 카메라의 위쪽 방향을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookAt{#getLookAt}
+
+| 이름 | 설명 |
+| --- | --- |
+| getLookAt() | 카메라가 바라보는 관심 위치를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setLookAt{#setLookAt}
+
+| 이름 | 설명 |
+| --- | --- |
+| setLookAt(value) | 카메라가 바라보는 관심 위치를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDirection{#getDirection}
+
+| 이름 | 설명 |
+| --- | --- |
+| getDirection() | 카메라가 바라보는 방향을 가져오거나 설정합니다. 이 속성의 변경은 LookAt 및 Target에도 영향을 줍니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDirection{#setDirection}
+
+| 이름 | 설명 |
+| --- | --- |
+| setDirection(value) | 카메라가 바라보는 방향을 가져오거나 설정합니다. 이 속성의 변경은 LookAt 및 Target에도 영향을 줍니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTarget{#getTarget}
+
+| 이름 | 설명 |
+| --- | --- |
+| getTarget() | 카메라가 바라보는 대상을 가져오거나 설정합니다. 사용자가 이 속성을 지원하는 경우 LookAt 속성보다 먼저 설정해야 합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTarget{#setTarget}
+
+| 이름 | 설명 |
+| --- | --- |
+| setTarget(value) | 카메라가 바라보는 대상을 가져오거나 설정합니다. 사용자가 이 속성을 지원하는 경우 LookAt 속성보다 먼저 설정해야 합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNodes() | 모든 부모 노드를 가져옵니다. 엔터티는 기하학 인스턴싱을 위해 여러 부모 노드에 부착될 수 있습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExcluded() | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExcluded(value) | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNode() | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setParentNode(value) | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 이름 | 설명 |
+| --- | --- |
+| getScene() | 이 객체가 속한 씬을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBoundingBox() | 현재 엔터티의 객체 공간 좌표계에서 경계 상자를 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEntityRendererKey() | 렌더러에 등록된 엔터티 렌더러의 키를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/fvector2/_index.md
+++ b/korean/nodejs-java/aspose.threed/fvector2/_index.md
@@ -1,0 +1,126 @@
+---
+title: "FVector2"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/fvector2/
+---
+## FVector2 class
+
+두 개 구성 요소를 가진 float 벡터.
+
+
+## Properties
+
+| 이름 | 설명 |
+| --- | --- |
+| x | x 구성 요소. |
+| y | y 구성 요소. |
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload(x, y) | FVector2의 새 인스턴스를 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload2(vec) | FVector2의 새 인스턴스를 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| 이름 | 설명 |
+| --- | --- |
+| toString() |  |
+
+ **Result:**
+String
+
+
+---
+
+
+### equals{#equals}
+
+| 이름 | 설명 |
+| --- | --- |
+| equals(rhs) | 두 벡터가 같은지 확인합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| rh | FVector2 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### equals{#equals}
+
+| 이름 | 설명 |
+| --- | --- |
+| equals(obj) | 두 벡터가 같은지 확인합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| ob | Object | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### hashCode{#hashCode}
+
+| 이름 | 설명 |
+| --- | --- |
+| hashCode() | 이 인스턴스의 해시 코드를 가져옵니다. |
+
+ **Result:**
+숫자
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/fvector3/_index.md
+++ b/korean/nodejs-java/aspose.threed/fvector3/_index.md
@@ -1,0 +1,123 @@
+---
+title: "FVector3"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/fvector3/
+---
+## FVector3 class
+
+세 개 구성 요소를 가진 float 벡터.
+
+
+## Properties
+
+| 이름 | 설명 |
+| --- | --- |
+| x | x 구성 요소. |
+| y | y 구성 요소. |
+| z | y 구성 요소. |
+| 제로 | 제로 벡터입니다. |
+| UNIT_SCALE | 모든 구성 요소가 1인 단위 스케일 벡터 |
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload(x, y, z) | FVector3의 새 인스턴스를 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload2(vec) | FVector3의 새 인스턴스를 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload3{#constructor_overload3}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload3(vec) | FVector4의 새 인스턴스를 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| 이름 | 설명 |
+| --- | --- |
+| toString() |  |
+
+ **Result:**
+String
+
+
+---
+
+
+### normalize{#normalize}
+
+| 이름 | 설명 |
+| --- | --- |
+| normalize() | 이 인스턴스를 정규화합니다. |
+
+ **Result:**
+FVector3
+
+
+---
+
+
+### cross{#cross}
+
+| 이름 | 설명 |
+| --- | --- |
+| cross(rhs) | 두 벡터의 외적 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| rhs | FVector3 | 우변 값입니다. |
+
+ **Result:**
+FVector3
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/fvector4/_index.md
+++ b/korean/nodejs-java/aspose.threed/fvector4/_index.md
@@ -1,0 +1,116 @@
+---
+title: "FVector4"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/fvector4/
+---
+## FVector4 class
+
+네 개 구성 요소를 가진 float 벡터.
+
+
+## Properties
+
+| 이름 | 설명 |
+| --- | --- |
+| x | x 구성 요소. |
+| y | y 구성 요소. |
+| z | z 구성 요소. |
+| w | w 구성 요소입니다. |
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload(x, y, z, w) | FVector4의 새 인스턴스를 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload2(x, y, z) | FVector4의 새 인스턴스를 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload3{#constructor_overload3}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload3(vec) | FVector4의 새 인스턴스를 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload4{#constructor_overload4}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload4(vec) | FVector4의 새 인스턴스를 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload5{#constructor_overload5}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload5(vec, w) | FVector4의 새 인스턴스를 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| 이름 | 설명 |
+| --- | --- |
+| toString() |  |
+
+ **Result:**
+String
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/geometry/_index.md
+++ b/korean/nodejs-java/aspose.threed/geometry/_index.md
@@ -1,0 +1,528 @@
+---
+title: "Geometry"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/geometry/
+---
+## Geometry class
+
+렌더링 가능한 모든 기하학 객체(예: Mesh, NurbsSurface, Patch 등)의 기본 클래스입니다. Geometry 기본 클래스는 다음을 지원합니다: 제어점 관리, 제어점은 기하학의 기본 3D 공간 구조를 정의하며, 다양한 기하학 유형마다 구체적인 3D 모델을 정의하는 방식이 다릅니다. 정점 요소 정의, 정점 요소는 노멀/uv 좌표/정점 색상과 같은 추가 정보를 기하학에 적용합니다. 자세한 내용은 VertexElement를 참조하십시오. 객체 변형, Deformer는 기하학 형태를 애니메이션화하기 위해 결합될 수 있습니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor(name) | Geometry 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| name | String | 이름 |
+
+ **Result:**
+
+
+
+---
+
+
+### getVisible{#getVisible}
+
+| 이름 | 설명 |
+| --- | --- |
+| getVisible() | 지오메트리가 보이는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setVisible{#setVisible}
+
+| 이름 | 설명 |
+| --- | --- |
+| setVisible(value) | 지오메트리가 보이는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDeformers{#getDeformers}
+
+| 이름 | 설명 |
+| --- | --- |
+| getDeformers() | 이 지오메트리와 연결된 모든 디포머를 가져옵니다. 디포머. |
+
+ **Result:**
+
+
+
+---
+
+
+### getControlPoints{#getControlPoints}
+
+| 이름 | 설명 |
+| --- | --- |
+| getControlPoints() | 모든 제어점을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastShadows{#getCastShadows}
+
+| 이름 | 설명 |
+| --- | --- |
+| getCastShadows() | 이 지오메트리가 그림자를 드리울 수 있는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastShadows{#setCastShadows}
+
+| 이름 | 설명 |
+| --- | --- |
+| setCastShadows(value) | 이 지오메트리가 그림자를 드리울 수 있는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReceiveShadows{#getReceiveShadows}
+
+| 이름 | 설명 |
+| --- | --- |
+| getReceiveShadows() | 이 지오메트리가 그림자를 받을 수 있는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReceiveShadows{#setReceiveShadows}
+
+| 이름 | 설명 |
+| --- | --- |
+| setReceiveShadows(value) | 이 지오메트리가 그림자를 받을 수 있는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElements{#getVertexElements}
+
+| 이름 | 설명 |
+| --- | --- |
+| getVertexElements() | 모든 정점 요소를 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNodes() | 모든 부모 노드를 가져옵니다. 엔터티는 기하학 인스턴싱을 위해 여러 부모 노드에 부착될 수 있습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExcluded() | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExcluded(value) | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNode() | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setParentNode(value) | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 이름 | 설명 |
+| --- | --- |
+| getScene() | 이 객체가 속한 씬을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getElement{#getElement}
+
+| 이름 | 설명 |
+| --- | --- |
+| getElement(type) | 지정된 타입의 정점 요소를 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| type | VertexElementType | VertexElementType |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### getVertexElementOfUV{#getVertexElementOfUV}
+
+| 이름 | 설명 |
+| --- | --- |
+| getVertexElementOfUV(textureMapping) | 주어진 텍스처 매핑 타입으로 VertexElementUV 인스턴스를 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| textureMapping | TextureMapping | TextureMapping |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### createElement{#createElement}
+
+| 이름 | 설명 |
+| --- | --- |
+| createElement(type) | 지정된 타입의 정점 요소를 생성하고 이를 지오메트리에 추가합니다. 타입이 VertexElementType.UV인 경우, TextureMapping.DIFFUSE 타입의 텍스처 매핑을 가진 VertexElementUV가 생성됩니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| type | VertexElementType | VertexElementType |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### addElement{#addElement}
+
+| 이름 | 설명 |
+| --- | --- |
+| addElement(element) | 기존 정점 요소를 현재 지오메트리에 추가합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| element | VertexElement | 추가할 정점 요소 |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### createElement{#createElement}
+
+| 이름 | 설명 |
+| --- | --- |
+| createElement(type, mappingMode, referenceMode) | 지정된 타입의 정점 요소를 생성하고 이를 지오메트리에 추가합니다. 타입이 VertexElementType.UV인 경우, TextureMapping.DIFFUSE 타입의 텍스처 매핑을 가진 VertexElementUV가 생성됩니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| type | VertexElementType | VertexElementType |
+| mappingMode | MappingMode | MappingMode |
+| referenceMode | ReferenceMode | ReferenceMode |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### createElementUV{#createElementUV}
+
+| 이름 | 설명 |
+| --- | --- |
+| createElementUV(uvMapping) | 주어진 텍스처 매핑 유형으로 VertexElementUV를 생성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| uvMapping | TextureMapping | TextureMapping |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### createElementUV{#createElementUV}
+
+| 이름 | 설명 |
+| --- | --- |
+| createElementUV(uvMapping, mappingMode, referenceMode) | 주어진 텍스처 매핑 유형으로 VertexElementUV를 생성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| uvMapping | TextureMapping | TextureMapping |
+| mappingMode | MappingMode | MappingMode |
+| referenceMode | ReferenceMode | ReferenceMode |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBoundingBox() | 현재 엔터티의 객체 공간 좌표계에서 경계 상자를 가져옵니다. |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEntityRendererKey() | 렌더러에 등록된 엔터티 렌더러의 키를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/globaltransform/_index.md
+++ b/korean/nodejs-java/aspose.threed/globaltransform/_index.md
@@ -1,0 +1,81 @@
+---
+title: "GlobalTransform"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/globaltransform/
+---
+## GlobalTransform class
+
+Global transform은 Transform과 유사하지만 최종 평가된 변환을 나타내는 동안 불변입니다. 전역 변환을 평가할 때 오른손 좌표계가 사용됩니다.  @hideconstructor
+
+
+## 메서드
+
+### getTranslation{#getTranslation}
+
+| 이름 | 설명 |
+| --- | --- |
+| getTranslation() | 변환을 가져옵니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getScale{#getScale}
+
+| 이름 | 설명 |
+| --- | --- |
+| getScale() | 스케일을 가져옵니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEulerAngles{#getEulerAngles}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEulerAngles() | Euler 각도로 표현된 회전을 가져옵니다(단위:도) |
+
+ **Result:**
+
+
+
+---
+
+
+### getRotation{#getRotation}
+
+| 이름 | 설명 |
+| --- | --- |
+| getRotation() | 쿼터니언으로 표현된 회전을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTransformMatrix{#getTransformMatrix}
+
+| 이름 | 설명 |
+| --- | --- |
+| getTransformMatrix() | 변환 행렬을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/glslsource/_index.md
+++ b/korean/nodejs-java/aspose.threed/glslsource/_index.md
@@ -1,0 +1,153 @@
+---
+title: "GLSLSource"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/glslsource/
+---
+## GLSLSource class
+
+GLSL에서 쉐이더의 소스 코드
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getComputeShader{#getComputeShader}
+
+| 이름 | 설명 |
+| --- | --- |
+| getComputeShader() | 컴퓨트 셰이더의 소스 코드를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setComputeShader{#setComputeShader}
+
+| 이름 | 설명 |
+| --- | --- |
+| setComputeShader(value) | 컴퓨트 셰이더의 소스 코드를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getGeometryShader{#getGeometryShader}
+
+| 이름 | 설명 |
+| --- | --- |
+| getGeometryShader() | 지오메트리 셰이더의 소스 코드를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setGeometryShader{#setGeometryShader}
+
+| 이름 | 설명 |
+| --- | --- |
+| setGeometryShader(value) | 지오메트리 셰이더의 소스 코드를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexShader{#getVertexShader}
+
+| 이름 | 설명 |
+| --- | --- |
+| getVertexShader() | 버텍스 셰이더의 소스 코드를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setVertexShader{#setVertexShader}
+
+| 이름 | 설명 |
+| --- | --- |
+| setVertexShader(value) | 버텍스 셰이더의 소스 코드를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFragmentShader{#getFragmentShader}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFragmentShader() | 프래그먼트 셰이더의 소스 코드를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFragmentShader{#setFragmentShader}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFragmentShader(value) | 프래그먼트 셰이더의 소스 코드를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### defineInclude{#defineInclude}
+
+| 이름 | 설명 |
+| --- | --- |
+| defineInclude(fileName, content) | GLSL 소스 코드에서 #include를 위한 가상 파일을 정의합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| fileName | String | 가상 파일의 파일 이름 |
+| 콘텐츠 | String | null |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/gltfloadoptions/_index.md
+++ b/korean/nodejs-java/aspose.threed/gltfloadoptions/_index.md
@@ -1,0 +1,146 @@
+---
+title: "GltfLoadOptions"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/gltfloadoptions/
+---
+## GltfLoadOptions class
+
+glTF 형식에 대한 로드 옵션
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | GltfLoadOptions의 생성자 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlipTexCoordV{#getFlipTexCoordV}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFlipTexCoordV() | 메시의 텍스처 좌표에서 v(t) 좌표를 뒤집습니다. 기본값은 true입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlipTexCoordV{#setFlipTexCoordV}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFlipTexCoordV(value) | 메시의 텍스처 좌표에서 v(t) 좌표를 뒤집습니다. 기본값은 true입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileFormat() | 현재 저장/로드 옵션에 지정된 파일 형식을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEncoding() | 텍스트 기반 파일에 대한 기본 인코딩을 가져오거나 설정합니다. 기본값은 null이며, 이는 가져오기/내보내기 프로그램이 사용할 인코딩을 결정함을 의미합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileSystem() | 로드/저장 중 외부 종속성을 관리하는 방법을 사용자가 처리하도록 허용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFileSystem(value) | 로드/저장 중 외부 종속성을 관리하는 방법을 사용자가 처리하도록 허용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| 이름 | 설명 |
+| --- | --- |
+| getLookupPaths() | OBJ와 같은 일부 파일은 외부 파일에 의존하며, 조회 경로를 통해 Aspose.3D가 외부 파일을 찾아 로드할 수 있도록 합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileName() | 내보내기/가져오기 씬의 파일 이름입니다. 선택 사항이지만 OBJ의 재질과 같은 외부 자산을 직렬화할 때 유용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFileName(value) | 내보내기/가져오기 씬의 파일 이름입니다. 선택 사항이지만 OBJ의 재질과 같은 외부 자산을 직렬화할 때 유용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/gltfsaveoptions/_index.md
+++ b/korean/nodejs-java/aspose.threed/gltfsaveoptions/_index.md
@@ -1,0 +1,470 @@
+---
+title: "GltfSaveOptions"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/gltfsaveoptions/
+---
+## GltfSaveOptions class
+
+glTF 형식에 대한 저장 옵션.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor(contentType) | GltfSaveOptions의 생성자 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| contentType | FileContentType | FileContentType |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload(format) | GltfSaveOptions의 생성자 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 형식 | 파일 형식 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### getPrettyPrint{#getPrettyPrint}
+
+| 이름 | 설명 |
+| --- | --- |
+| getPrettyPrint() | GLTF 파일의 JSON 내용은 사람이 읽기 쉽도록 들여쓰기 되며, 기본값은 false입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setPrettyPrint{#setPrettyPrint}
+
+| 이름 | 설명 |
+| --- | --- |
+| setPrettyPrint(value) | GLTF 파일의 JSON 내용은 사람이 읽기 쉽도록 들여쓰기 되며, 기본값은 false입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFallbackNormal{#getFallbackNormal}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFallbackNormal() | GLTF2 내보내기에서 잘못된 노멀을 감지하면, 검증을 우회하기 위해 원래 값 대신 이 값이 사용됩니다. 기본값은 (0, 1, 0)입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEmbedAssets{#getEmbedAssets}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEmbedAssets() | 외부 자산을 모두 base64로 인코딩하여 ASCII 모드의 단일 파일에 포함합니다. 기본값은 false입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setEmbedAssets{#setEmbedAssets}
+
+| 이름 | 설명 |
+| --- | --- |
+| setEmbedAssets(value) | 외부 자산을 모두 base64로 인코딩하여 ASCII 모드의 단일 파일에 포함합니다. 기본값은 false입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getImageFormat{#getImageFormat}
+
+| 이름 | 설명 |
+| --- | --- |
+| getImageFormat() | 표준 glTF는 텍스처 형식으로 PNG/JPG만 지원하며, 이 옵션은 내보내기 중 Aspose.3D가 비표준 이미지를 지원되는 형식으로 변환하는 방법을 안내합니다. 기본값은 GltfEmbeddedImageFormat.PNG이며, 해당 속성의 값은 GltfEmbeddedImageFormat 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setImageFormat{#setImageFormat}
+
+| 이름 | 설명 |
+| --- | --- |
+| setImageFormat(value) | 표준 glTF는 텍스처 형식으로 PNG/JPG만 지원하며, 이 옵션은 내보내기 중 Aspose.3D가 비표준 이미지를 지원되는 형식으로 변환하는 방법을 안내합니다. 기본값은 GltfEmbeddedImageFormat.PNG이며, 해당 속성의 값은 GltfEmbeddedImageFormat 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMaterialConverter{#getMaterialConverter}
+
+| 이름 | 설명 |
+| --- | --- |
+| getMaterialConverter() | 지오메트리의 재질을 PBR 재질로 변환하는 사용자 지정 컨버터입니다. 이 값이 지정되지 않은 경우 glTF 2.0 내보내기는 표준 재질을 자동으로 PBR 재질로 변환합니다. 기본값은 null이며, 이 속성은 씬을 glTF 2.0 파일로 내보낼 때 사용됩니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMaterialConverter{#setMaterialConverter}
+
+| 이름 | 설명 |
+| --- | --- |
+| setMaterialConverter(value) | 지오메트리의 재질을 PBR 재질로 변환하는 사용자 지정 컨버터입니다. 이 값이 지정되지 않은 경우 glTF 2.0 내보내기는 표준 재질을 자동으로 PBR 재질로 변환합니다. 기본값은 null이며, 이 속성은 씬을 glTF 2.0 파일로 내보낼 때 사용됩니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getUseCommonMaterials{#getUseCommonMaterials}
+
+| 이름 | 설명 |
+| --- | --- |
+| getUseCommonMaterials() | KHR 공통 재질 확장을 사용하여 재질을 직렬화합니다. 기본값은 false입니다. 이를 false로 설정하면 Aspose.3D가 vertex/fragment 셰이더 집합을 내보내게 됩니다 #Error Cref: P:Aspose.ThreeD.Formats.GltfSaveOptions.ExportShaders |
+
+ **Result:**
+
+
+
+---
+
+
+### setUseCommonMaterials{#setUseCommonMaterials}
+
+| 이름 | 설명 |
+| --- | --- |
+| setUseCommonMaterials(value) | KHR 공통 재질 확장을 사용하여 재질을 직렬화합니다. 기본값은 false입니다. 이를 false로 설정하면 Aspose.3D가 vertex/fragment 셰이더 집합을 내보내게 됩니다 #Error Cref: P:Aspose.ThreeD.Formats.GltfSaveOptions.ExportShaders |
+
+ **Result:**
+
+
+
+---
+
+
+### getExternalDracoEncoder{#getExternalDracoEncoder}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExternalDracoEncoder() | 외부 draco 인코더를 사용하여 draco 압축 속도를 가속화합니다. Aspose.3D는 메시를 draco 형식으로 인코딩하기 위해 새로운 하위 프로세스를 생성하며, 사용은 사용자 책임 하에 진행됩니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExternalDracoEncoder{#setExternalDracoEncoder}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExternalDracoEncoder(value) | 외부 draco 인코더를 사용하여 draco 압축 속도를 가속화합니다. Aspose.3D는 메시를 draco 형식으로 인코딩하기 위해 새로운 하위 프로세스를 생성하며, 사용은 사용자 책임 하에 진행됩니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlipTexCoordV{#getFlipTexCoordV}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFlipTexCoordV() | 텍스처 좌표 v(t) 구성 요소를 뒤집습니다. 기본값은 true입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlipTexCoordV{#setFlipTexCoordV}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFlipTexCoordV(value) | 텍스처 좌표 v(t) 구성 요소를 뒤집습니다. 기본값은 true입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getBufferFile{#getBufferFile}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBufferFile() | 바이너리 데이터를 저장하는 외부 버퍼 파일의 파일 이름입니다. 이 파일이 지정되지 않으면 Aspose.3D가 이름을 자동으로 생성합니다. 이 설정은 바이너리 모드로 glTF를 내보낼 때 무시됩니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setBufferFile{#setBufferFile}
+
+| 이름 | 설명 |
+| --- | --- |
+| setBufferFile(value) | 바이너리 데이터를 저장하는 외부 버퍼 파일의 파일 이름입니다. 이 파일이 지정되지 않으면 Aspose.3D가 이름을 자동으로 생성합니다. 이 설정은 바이너리 모드로 glTF를 내보낼 때 무시됩니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getSaveExtras{#getSaveExtras}
+
+| 이름 | 설명 |
+| --- | --- |
+| getSaveExtras() | 생성된 glTF 파일의 'extra' 필드에 씬 객체의 동적 속성을 저장합니다. 이는 애플리케이션별 데이터를 제공하는 데 유용합니다. 기본값은 false입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setSaveExtras{#setSaveExtras}
+
+| 이름 | 설명 |
+| --- | --- |
+| setSaveExtras(value) | 생성된 glTF 파일의 'extra' 필드에 씬 객체의 동적 속성을 저장합니다. 이는 애플리케이션별 데이터를 제공하는 데 유용합니다. 기본값은 false입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getApplyUnitScale{#getApplyUnitScale}
+
+| 이름 | 설명 |
+| --- | --- |
+| getApplyUnitScale() | AssetInfo.UnitScaleFactor를 메시에 적용합니다. 기본값은 false입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setApplyUnitScale{#setApplyUnitScale}
+
+| 이름 | 설명 |
+| --- | --- |
+| setApplyUnitScale(value) | AssetInfo.UnitScaleFactor를 메시에 적용합니다. 기본값은 false입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDracoCompression{#getDracoCompression}
+
+| 이름 | 설명 |
+| --- | --- |
+| getDracoCompression() | draco 압축을 활성화할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDracoCompression{#setDracoCompression}
+
+| 이름 | 설명 |
+| --- | --- |
+| setDracoCompression(value) | draco 압축을 활성화할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportTextures{#getExportTextures}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExportTextures() | 씬에서 사용된 텍스처를 출력 디렉터리로 복사합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextures{#setExportTextures}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExportTextures(value) | 씬에서 사용된 텍스처를 출력 디렉터리로 복사합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileFormat() | 현재 저장/로드 옵션에 지정된 파일 형식을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEncoding() | 텍스트 기반 파일에 대한 기본 인코딩을 가져오거나 설정합니다. 기본값은 null이며, 이는 가져오기/내보내기 프로그램이 사용할 인코딩을 결정함을 의미합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileSystem() | 로드/저장 중 외부 종속성을 관리하는 방법을 사용자가 처리하도록 허용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFileSystem(value) | 로드/저장 중 외부 종속성을 관리하는 방법을 사용자가 처리하도록 허용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| 이름 | 설명 |
+| --- | --- |
+| getLookupPaths() | OBJ와 같은 일부 파일은 외부 파일에 의존하며, 조회 경로를 통해 Aspose.3D가 외부 파일을 찾아 로드할 수 있도록 합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileName() | 내보내기/가져오기 씬의 파일 이름입니다. 선택 사항이지만 OBJ의 재질과 같은 외부 자산을 직렬화할 때 유용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFileName(value) | 내보내기/가져오기 씬의 파일 이름입니다. 선택 사항이지만 OBJ의 재질과 같은 외부 자산을 직렬화할 때 유용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/hollowcircleshape/_index.md
+++ b/korean/nodejs-java/aspose.threed/hollowcircleshape/_index.md
@@ -1,0 +1,333 @@
+---
+title: "HollowCircleShape"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/hollowcircleshape/
+---
+## HollowCircleShape class
+
+IFC 호환 중공 원형 프로파일.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getWallThickness{#getWallThickness}
+
+| 이름 | 설명 |
+| --- | --- |
+| getWallThickness() | 외부 반경과 내부 반경 사이의 차이를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setWallThickness{#setWallThickness}
+
+| 이름 | 설명 |
+| --- | --- |
+| setWallThickness(value) | 외부 반경과 내부 반경 사이의 차이를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getRadius{#getRadius}
+
+| 이름 | 설명 |
+| --- | --- |
+| getRadius() | 원의 반경을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRadius{#setRadius}
+
+| 이름 | 설명 |
+| --- | --- |
+| setRadius(value) | 원의 반경을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNodes() | 모든 부모 노드를 가져옵니다. 엔터티는 기하학 인스턴싱을 위해 여러 부모 노드에 부착될 수 있습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExcluded() | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExcluded(value) | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNode() | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setParentNode(value) | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 이름 | 설명 |
+| --- | --- |
+| getScene() | 이 객체가 속한 씬을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtent{#getExtent}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExtent() | x 및 y 차원에서의 범위를 가져옵니다. |
+
+ **Result:**
+Vector2
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEntityRendererKey() | 렌더러에 등록된 엔터티 렌더러의 키를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBoundingBox() | 현재 엔터티의 객체 공간 좌표계에서 경계 상자를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/hollowrectangleshape/_index.md
+++ b/korean/nodejs-java/aspose.threed/hollowrectangleshape/_index.md
@@ -1,0 +1,411 @@
+---
+title: "HollowRectangleShape"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/hollowrectangleshape/
+---
+## HollowRectangleShape class
+
+내부/외부 모서리 라운딩이 모두 적용된 IFC 호환 중공 직사각형 형태.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getWallThickness{#getWallThickness}
+
+| 이름 | 설명 |
+| --- | --- |
+| getWallThickness() | 사각형 경계와 내부 구멍 사이의 두께 |
+
+ **Result:**
+
+
+
+---
+
+
+### setWallThickness{#setWallThickness}
+
+| 이름 | 설명 |
+| --- | --- |
+| setWallThickness(value) | 사각형 경계와 내부 구멍 사이의 두께 |
+
+ **Result:**
+
+
+
+---
+
+
+### getInnerFilletRadius{#getInnerFilletRadius}
+
+| 이름 | 설명 |
+| --- | --- |
+| getInnerFilletRadius() | 내부 사각형의 내부 필릿 반경입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setInnerFilletRadius{#setInnerFilletRadius}
+
+| 이름 | 설명 |
+| --- | --- |
+| setInnerFilletRadius(value) | 내부 사각형의 내부 필릿 반경입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getRoundingRadius{#getRoundingRadius}
+
+| 이름 | 설명 |
+| --- | --- |
+| getRoundingRadius() | 네 모서리 모두의 원형 호 반경을 가져오거나 설정합니다(단위:도). 기본값은 0.0입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRoundingRadius{#setRoundingRadius}
+
+| 이름 | 설명 |
+| --- | --- |
+| setRoundingRadius(value) | 네 모서리 모두의 원형 호 반경을 가져오거나 설정합니다(단위:도). 기본값은 0.0입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getXDim{#getXDim}
+
+| 이름 | 설명 |
+| --- | --- |
+| getXDim() | x축 방향으로 사각형의 크기를 가져오거나 설정합니다. 기본값은 2.0입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setXDim{#setXDim}
+
+| 이름 | 설명 |
+| --- | --- |
+| setXDim(value) | x축 방향으로 사각형의 크기를 가져오거나 설정합니다. 기본값은 2.0입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getYDim{#getYDim}
+
+| 이름 | 설명 |
+| --- | --- |
+| getYDim() | y축 방향으로 사각형의 크기를 가져오거나 설정합니다. 기본값은 2.0입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setYDim{#setYDim}
+
+| 이름 | 설명 |
+| --- | --- |
+| setYDim(value) | y축 방향으로 사각형의 크기를 가져오거나 설정합니다. 기본값은 2.0입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNodes() | 모든 부모 노드를 가져옵니다. 엔터티는 기하학 인스턴싱을 위해 여러 부모 노드에 부착될 수 있습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExcluded() | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExcluded(value) | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNode() | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setParentNode(value) | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 이름 | 설명 |
+| --- | --- |
+| getScene() | 이 객체가 속한 씬을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtent{#getExtent}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExtent() | x 및 y 차원에서의 범위를 가져옵니다. |
+
+ **Result:**
+Vector2
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEntityRendererKey() | 렌더러에 등록된 엔터티 렌더러의 키를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBoundingBox() | 현재 엔터티의 객체 공간 좌표계에서 경계 상자를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/hshape/_index.md
+++ b/korean/nodejs-java/aspose.threed/hshape/_index.md
@@ -1,0 +1,541 @@
+---
+title: "HShape"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/hshape/
+---
+## HShape class
+
+HShape는 'H' 또는 'I' 형태의 정의 매개변수를 제공합니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | HShape의 생성자 |
+
+ **Result:**
+
+
+
+---
+
+
+### getOverallDepth{#getOverallDepth}
+
+| 이름 | 설명 |
+| --- | --- |
+| getOverallDepth() | 깊이의 범위를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setOverallDepth{#setOverallDepth}
+
+| 이름 | 설명 |
+| --- | --- |
+| setOverallDepth(value) | 깊이의 범위를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getBottomFlangeWidth{#getBottomFlangeWidth}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBottomFlangeWidth() | 너비의 범위를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setBottomFlangeWidth{#setBottomFlangeWidth}
+
+| 이름 | 설명 |
+| --- | --- |
+| setBottomFlangeWidth(value) | 너비의 범위를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTopFlangeWidth{#getTopFlangeWidth}
+
+| 이름 | 설명 |
+| --- | --- |
+| getTopFlangeWidth() | 상단 플랜지의 너비를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTopFlangeWidth{#setTopFlangeWidth}
+
+| 이름 | 설명 |
+| --- | --- |
+| setTopFlangeWidth(value) | 상단 플랜지의 너비를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTopFlangeThickness{#getTopFlangeThickness}
+
+| 이름 | 설명 |
+| --- | --- |
+| getTopFlangeThickness() | 상단 플랜지의 두께를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTopFlangeThickness{#setTopFlangeThickness}
+
+| 이름 | 설명 |
+| --- | --- |
+| setTopFlangeThickness(value) | 상단 플랜지의 두께를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTopFlangeEdgeRadius{#getTopFlangeEdgeRadius}
+
+| 이름 | 설명 |
+| --- | --- |
+| getTopFlangeEdgeRadius() | 상단 플랜지의 하단 가장자리 반경을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTopFlangeEdgeRadius{#setTopFlangeEdgeRadius}
+
+| 이름 | 설명 |
+| --- | --- |
+| setTopFlangeEdgeRadius(value) | 상단 플랜지의 하단 가장자리 반경을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTopFlangeFilletRadius{#getTopFlangeFilletRadius}
+
+| 이름 | 설명 |
+| --- | --- |
+| getTopFlangeFilletRadius() | 웹과 상단 플랜지 사이의 필렛 반경을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTopFlangeFilletRadius{#setTopFlangeFilletRadius}
+
+| 이름 | 설명 |
+| --- | --- |
+| setTopFlangeFilletRadius(value) | 웹과 상단 플랜지 사이의 필렛 반경을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getBottomFlangeThickness{#getBottomFlangeThickness}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBottomFlangeThickness() | H-형상의 플랜지 두께를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setBottomFlangeThickness{#setBottomFlangeThickness}
+
+| 이름 | 설명 |
+| --- | --- |
+| setBottomFlangeThickness(value) | H-형상의 플랜지 두께를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getWebThickness{#getWebThickness}
+
+| 이름 | 설명 |
+| --- | --- |
+| getWebThickness() | H-형상의 웹 두께를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setWebThickness{#setWebThickness}
+
+| 이름 | 설명 |
+| --- | --- |
+| setWebThickness(value) | H-형상의 웹 두께를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getBottomFlangeFilletRadius{#getBottomFlangeFilletRadius}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBottomFlangeFilletRadius() | 웹과 하단 플랜지 사이의 필렛 반경을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setBottomFlangeFilletRadius{#setBottomFlangeFilletRadius}
+
+| 이름 | 설명 |
+| --- | --- |
+| setBottomFlangeFilletRadius(value) | 웹과 하단 플랜지 사이의 필렛 반경을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getBottomFlangeEdgeRadius{#getBottomFlangeEdgeRadius}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBottomFlangeEdgeRadius() | 하단 플랜지의 상단 가장자리 반경을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setBottomFlangeEdgeRadius{#setBottomFlangeEdgeRadius}
+
+| 이름 | 설명 |
+| --- | --- |
+| setBottomFlangeEdgeRadius(value) | 하단 플랜지의 상단 가장자리 반경을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNodes() | 모든 부모 노드를 가져옵니다. 엔터티는 기하학 인스턴싱을 위해 여러 부모 노드에 부착될 수 있습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExcluded() | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExcluded(value) | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNode() | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setParentNode(value) | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 이름 | 설명 |
+| --- | --- |
+| getScene() | 이 객체가 속한 씬을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtent{#getExtent}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExtent() | x 및 y 차원에서의 범위를 가져옵니다. |
+
+ **Result:**
+Vector2
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEntityRendererKey() | 렌더러에 등록된 엔터티 렌더러의 키를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBoundingBox() | 현재 엔터티의 객체 공간 좌표계에서 경계 상자를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/html5saveoptions/_index.md
+++ b/korean/nodejs-java/aspose.threed/html5saveoptions/_index.md
@@ -1,0 +1,406 @@
+---
+title: "Html5SaveOptions"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/html5saveoptions/
+---
+## Html5SaveOptions class
+
+HTML5에 대한 저장 옵션
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | Html5SaveOptions의 모든 기본 설정을 가진 생성자입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getShowGrid{#getShowGrid}
+
+| 이름 | 설명 |
+| --- | --- |
+| getShowGrid() | 씬에 그리드를 표시합니다. 기본값은 true입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setShowGrid{#setShowGrid}
+
+| 이름 | 설명 |
+| --- | --- |
+| setShowGrid(value) | 씬에 그리드를 표시합니다. 기본값은 true입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getShowRulers{#getShowRulers}
+
+| 이름 | 설명 |
+| --- | --- |
+| getShowRulers() | 모델을 측정하기 위해 씬에 x/y/z 축 눈금을 표시합니다. 기본값은 false입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setShowRulers{#setShowRulers}
+
+| 이름 | 설명 |
+| --- | --- |
+| setShowRulers(value) | 모델을 측정하기 위해 씬에 x/y/z 축 눈금을 표시합니다. 기본값은 false입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getShowUI{#getShowUI}
+
+| 이름 | 설명 |
+| --- | --- |
+| getShowUI() | 씬에 간단한 UI를 표시합니다. 기본값은 true입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setShowUI{#setShowUI}
+
+| 이름 | 설명 |
+| --- | --- |
+| setShowUI(value) | 씬에 간단한 UI를 표시합니다. 기본값은 true입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getOrientationBox{#getOrientationBox}
+
+| 이름 | 설명 |
+| --- | --- |
+| getOrientationBox() | 오리엔테이션 박스를 표시합니다. 기본값은 true입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setOrientationBox{#setOrientationBox}
+
+| 이름 | 설명 |
+| --- | --- |
+| setOrientationBox(value) | 오리엔테이션 박스를 표시합니다. 기본값은 true입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getUpVector{#getUpVector}
+
+| 이름 | 설명 |
+| --- | --- |
+| getUpVector() | 업 벡터를 가져오거나 설정합니다. 값은 "x"/"y"/"z" 중 하나이며, 기본값은 "y"입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setUpVector{#setUpVector}
+
+| 이름 | 설명 |
+| --- | --- |
+| setUpVector(value) | 업 벡터를 가져오거나 설정합니다. 값은 "x"/"y"/"z" 중 하나이며, 기본값은 "y"입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFarPlane{#getFarPlane}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFarPlane() | 카메라의 원거리 평면을 가져오거나 설정합니다. 기본값은 1000입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFarPlane{#setFarPlane}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFarPlane(value) | 카메라의 원거리 평면을 가져오거나 설정합니다. 기본값은 1000입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getNearPlane{#getNearPlane}
+
+| 이름 | 설명 |
+| --- | --- |
+| getNearPlane() | 카메라의 근거리 평면을 가져오거나 설정합니다. 기본값은 1입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setNearPlane{#setNearPlane}
+
+| 이름 | 설명 |
+| --- | --- |
+| setNearPlane(value) | 카메라의 근거리 평면을 가져오거나 설정합니다. 기본값은 1입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookAt{#getLookAt}
+
+| 이름 | 설명 |
+| --- | --- |
+| getLookAt() | 기본 바라보는 위치를 가져오거나 설정합니다. 기본값은 (0, 0, 0)입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setLookAt{#setLookAt}
+
+| 이름 | 설명 |
+| --- | --- |
+| setLookAt(value) | 기본 바라보는 위치를 가져오거나 설정합니다. 기본값은 (0, 0, 0)입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getCameraPosition{#getCameraPosition}
+
+| 이름 | 설명 |
+| --- | --- |
+| getCameraPosition() | 카메라의 초기 위치를 가져오거나 설정합니다. 기본값은 (10, 10, 10)입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setCameraPosition{#setCameraPosition}
+
+| 이름 | 설명 |
+| --- | --- |
+| setCameraPosition(value) | 카메라의 초기 위치를 가져오거나 설정합니다. 기본값은 (10, 10, 10)입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFieldOfView{#getFieldOfView}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFieldOfView() | 시야 영역을 가져오거나 설정합니다. 기본값은 45이며, 단위는 도입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFieldOfView{#setFieldOfView}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFieldOfView(value) | 시야 영역을 가져오거나 설정합니다. 기본값은 45이며, 단위는 도입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportTextures{#getExportTextures}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExportTextures() | 씬에서 사용된 텍스처를 출력 디렉터리로 복사합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextures{#setExportTextures}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExportTextures(value) | 씬에서 사용된 텍스처를 출력 디렉터리로 복사합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileFormat() | 현재 저장/로드 옵션에 지정된 파일 형식을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEncoding() | 텍스트 기반 파일에 대한 기본 인코딩을 가져오거나 설정합니다. 기본값은 null이며, 이는 가져오기/내보내기 프로그램이 사용할 인코딩을 결정함을 의미합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileSystem() | 로드/저장 중 외부 종속성을 관리하는 방법을 사용자가 처리하도록 허용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFileSystem(value) | 로드/저장 중 외부 종속성을 관리하는 방법을 사용자가 처리하도록 허용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| 이름 | 설명 |
+| --- | --- |
+| getLookupPaths() | OBJ와 같은 일부 파일은 외부 파일에 의존하며, 조회 경로를 통해 Aspose.3D가 외부 파일을 찾아 로드할 수 있도록 합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileName() | 내보내기/가져오기 씬의 파일 이름입니다. 선택 사항이지만 OBJ의 재질과 같은 외부 자산을 직렬화할 때 유용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFileName(value) | 내보내기/가져오기 씬의 파일 이름입니다. 선택 사항이지만 OBJ의 재질과 같은 외부 자산을 직렬화할 때 유용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/imagerenderoptions/_index.md
+++ b/korean/nodejs-java/aspose.threed/imagerenderoptions/_index.md
@@ -1,0 +1,229 @@
+---
+title: "ImageRenderOptions"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/imagerenderoptions/
+---
+## ImageRenderOptions class
+
+Scene.render(com.aspose.threed.Camera, java.lang.String, com.aspose.threed.Vector2, java.lang.String, com.aspose.threed.ImageRenderOptions) 및 Scene.render(com.aspose.threed.Camera, com.aspose.threed.TextureData, com.aspose.threed.ImageRenderOptions)의 옵션
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | ImageRenderOptions 인스턴스를 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getBackgroundColor{#getBackgroundColor}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBackgroundColor() | 렌더 결과의 배경 색상입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setBackgroundColor{#setBackgroundColor}
+
+| 이름 | 설명 |
+| --- | --- |
+| setBackgroundColor(value) | 렌더 결과의 배경 색상입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAssetDirectories{#getAssetDirectories}
+
+| 이름 | 설명 |
+| --- | --- |
+| getAssetDirectories() | 외부 자산(예: 텍스처)을 저장하는 디렉터리 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEnableShadows{#getEnableShadows}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEnableShadows() | 그림자를 렌더링할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setEnableShadows{#setEnableShadows}
+
+| 이름 | 설명 |
+| --- | --- |
+| setEnableShadows(value) | 그림자를 렌더링할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/importexception/_index.md
+++ b/korean/nodejs-java/aspose.threed/importexception/_index.md
@@ -1,0 +1,35 @@
+---
+title: "ImportException"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/importexception/
+---
+## ImportException class
+
+Aspose.3D가 지정된 소스를 열지 못했을 때 발생하는 예외
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor(msg) | 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 메시지 | String | 오류 메시지 |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/indexdatatype/_index.md
+++ b/korean/nodejs-java/aspose.threed/indexdatatype/_index.md
@@ -1,0 +1,13 @@
+---
+title: "IndexDataType"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/indexdatatype/
+---
+## IndexDataType class
+
+상수들을 포함하는 유틸리티 클래스. com.aspose.threed.IIndexBuffer의 요소 데이터 타입  @hideconstructor
+
+

--- a/korean/nodejs-java/aspose.threed/initializationexception/_index.md
+++ b/korean/nodejs-java/aspose.threed/initializationexception/_index.md
@@ -1,0 +1,42 @@
+---
+title: "InitializationException"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/initializationexception/
+---
+## InitializationException class
+
+렌더 파이프라인 초기화 중 예외
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | InitializationException 인스턴스를 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload(msg) | 지정된 예외 메시지를 사용하여 InitializationException 인스턴스를 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/ioconfig/_index.md
+++ b/korean/nodejs-java/aspose.threed/ioconfig/_index.md
@@ -1,0 +1,133 @@
+---
+title: "IOConfig"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/ioconfig/
+---
+## IOConfig class
+
+직렬화/역직렬화를 위한 IO 구성. 사용자는 종속성 조회 경로와 같은 상세 구성을 지정하거나 여기에서 형식 관련 구성을 지정할 수 있습니다.  @hideconstructor
+
+
+## 메서드
+
+### getFileSystemFactory{#getFileSystemFactory}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileSystemFactory() | FileSystem에 대한 팩터리 클래스를 가져오거나 설정합니다. 기본 팩터리는 LocalFileSystem을 생성하지만 서버 환경에는 적합하지 않습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystemFactory{#setFileSystemFactory}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFileSystemFactory(value) | FileSystem에 대한 팩터리 클래스를 가져오거나 설정합니다. 기본 팩터리는 LocalFileSystem을 생성하지만 서버 환경에는 적합하지 않습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileFormat() | 현재 저장/로드 옵션에 지정된 파일 형식을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEncoding() | 텍스트 기반 파일에 대한 기본 인코딩을 가져오거나 설정합니다. 기본값은 null이며, 이는 가져오기/내보내기 프로그램이 사용할 인코딩을 결정함을 의미합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileSystem() | 로드/저장 중 외부 종속성을 관리하는 방법을 사용자가 처리하도록 허용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFileSystem(value) | 로드/저장 중 외부 종속성을 관리하는 방법을 사용자가 처리하도록 허용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| 이름 | 설명 |
+| --- | --- |
+| getLookupPaths() | OBJ와 같은 일부 파일은 외부 파일에 의존하며, 조회 경로를 통해 Aspose.3D가 외부 파일을 찾아 로드할 수 있도록 합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileName() | 내보내기/가져오기 씬의 파일 이름입니다. 선택 사항이지만 OBJ의 재질과 같은 외부 자산을 직렬화할 때 유용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFileName(value) | 내보내기/가져오기 씬의 파일 이름입니다. 선택 사항이지만 OBJ의 재질과 같은 외부 자산을 직렬화할 때 유용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/ioutils/_index.md
+++ b/korean/nodejs-java/aspose.threed/ioutils/_index.md
@@ -1,0 +1,13 @@
+---
+title: "IOUtils"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/ioutils/
+---
+## IOUtils class
+
+행렬/벡터를 바이너리 라이터에 쓰기 위한 유틸리티  @hideconstructor
+
+

--- a/korean/nodejs-java/aspose.threed/keyframe/_index.md
+++ b/korean/nodejs-java/aspose.threed/keyframe/_index.md
@@ -1,0 +1,439 @@
+---
+title: "KeyFrame"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/keyframe/
+---
+## KeyFrame class
+
+키 프레임은 주로 시간과 값으로 정의되며, 일부 보간 유형에서는 최종 샘플 값을 계산할 때 접선/텐션/바이어스/연속성도 사용됩니다. 키 프레임이 아닌 시간 위치의 샘플 값은 이전 및 다음 키 프레임 사이의 키 프레임에 의해 보간됩니다. 첫 번째/마지막 키 프레임 이전/이후의 값은 Extrapolation 클래스에 의해 계산됩니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor(curve, time) | 지정된 곡선에 새로운 키 프레임을 생성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| curve | KeyframeSequence | 키 프레임이 생성될 곡선 |
+| time | 숫자 | 키 프레임의 시간 위치 |
+
+ **Result:**
+
+
+
+---
+
+
+### getTime{#getTime}
+
+| 이름 | 설명 |
+| --- | --- |
+| getTime() | list.data[index] 키 프레임의 시간 위치를 초 단위로 가져오거나 설정합니다. 시간. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTime{#setTime}
+
+| 이름 | 설명 |
+| --- | --- |
+| setTime(value) | list.data[index] 키 프레임의 시간 위치를 초 단위로 가져오거나 설정합니다. 시간. |
+
+ **Result:**
+
+
+
+---
+
+
+### getValue{#getValue}
+
+| 이름 | 설명 |
+| --- | --- |
+| getValue() | 키 프레임의 값을 가져오거나 설정합니다. 값. |
+
+ **Result:**
+
+
+
+---
+
+
+### setValue{#setValue}
+
+| 이름 | 설명 |
+| --- | --- |
+| setValue(value) | 키 프레임의 값을 가져오거나 설정합니다. 값. |
+
+ **Result:**
+
+
+
+---
+
+
+### getInterpolation{#getInterpolation}
+
+| 이름 | 설명 |
+| --- | --- |
+| getInterpolation() | 키의 보간 유형을 가져오거나 설정합니다. list.data[index]는 샘플링된 값이 계산되는 알고리즘을 정의합니다. 속성의 값은 Interpolation 정수 상수입니다. 보간. |
+
+ **Result:**
+
+
+
+---
+
+
+### setInterpolation{#setInterpolation}
+
+| 이름 | 설명 |
+| --- | --- |
+| setInterpolation(value) | 키의 보간 유형을 가져오거나 설정합니다. list.data[index]는 샘플링된 값이 계산되는 알고리즘을 정의합니다. 속성의 값은 Interpolation 정수 상수입니다. 보간. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTangentWeightMode{#getTangentWeightMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getTangentWeightMode() | 키의 탄젠트 가중치 모드를 가져오거나 설정합니다. 외부 탄젠트 또는 다음 내부 탄젠트를 올바른 WeightedMode를 선택하여 사용자 지정할 수 있습니다. 속성의 값은 WeightedMode 정수 상수입니다. 탄젠트 가중치 모드. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTangentWeightMode{#setTangentWeightMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setTangentWeightMode(value) | 키의 탄젠트 가중치 모드를 가져오거나 설정합니다. 외부 탄젠트 또는 다음 내부 탄젠트를 올바른 WeightedMode를 선택하여 사용자 지정할 수 있습니다. 속성의 값은 WeightedMode 정수 상수입니다. 탄젠트 가중치 모드. |
+
+ **Result:**
+
+
+
+---
+
+
+### getStepMode{#getStepMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getStepMode() | 키의 단계 모드를 가져오거나 설정합니다. 보간 유형이 Interpolation.CONSTANT인 경우, list.data[index]는 보간 중에 사용할 키 프레임의 값을 결정합니다. StepMode.PREVIOUS_VALUE는 왼쪽 키 프레임의 값을 사용함을 의미하고, StepMode.NEXT_VALUE는 오른쪽 다음 키 프레임의 값을 사용함을 의미합니다. 속성의 값은 StepMode 정수 상수입니다. 단계 모드. |
+
+ **Result:**
+
+
+
+---
+
+
+### setStepMode{#setStepMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setStepMode(value) | 키의 단계 모드를 가져오거나 설정합니다. 보간 유형이 Interpolation.CONSTANT인 경우, list.data[index]는 보간 중에 사용할 키 프레임의 값을 결정합니다. StepMode.PREVIOUS_VALUE는 왼쪽 키 프레임의 값을 사용함을 의미하고, StepMode.NEXT_VALUE는 오른쪽 다음 키 프레임의 값을 사용함을 의미합니다. 속성의 값은 StepMode 정수 상수입니다. 단계 모드. |
+
+ **Result:**
+
+
+
+---
+
+
+### getNextInTangent{#getNextInTangent}
+
+| 이름 | 설명 |
+| --- | --- |
+| getNextInTangent() | 이 키 프레임의 다음 내부(왼쪽) 탄젠트를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setNextInTangent{#setNextInTangent}
+
+| 이름 | 설명 |
+| --- | --- |
+| setNextInTangent(value) | 이 키 프레임의 다음 내부(왼쪽) 탄젠트를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getOutTangent{#getOutTangent}
+
+| 이름 | 설명 |
+| --- | --- |
+| getOutTangent() | 이 키 프레임의 외부(오른쪽) 탄젠트를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setOutTangent{#setOutTangent}
+
+| 이름 | 설명 |
+| --- | --- |
+| setOutTangent(value) | 이 키 프레임의 외부(오른쪽) 탄젠트를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getOutWeight{#getOutWeight}
+
+| 이름 | 설명 |
+| --- | --- |
+| getOutWeight() | 이 키 프레임의 외부(오른쪽) 가중치를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setOutWeight{#setOutWeight}
+
+| 이름 | 설명 |
+| --- | --- |
+| setOutWeight(value) | 이 키 프레임의 외부(오른쪽) 가중치를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getNextInWeight{#getNextInWeight}
+
+| 이름 | 설명 |
+| --- | --- |
+| getNextInWeight() | 이 키 프레임에서 다음 인(왼쪽) 가중치를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setNextInWeight{#setNextInWeight}
+
+| 이름 | 설명 |
+| --- | --- |
+| setNextInWeight(value) | 이 키 프레임에서 다음 인(왼쪽) 가중치를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTension{#getTension}
+
+| 이름 | 설명 |
+| --- | --- |
+| getTension() | TCB 스플라인에서 사용되는 장력을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTension{#setTension}
+
+| 이름 | 설명 |
+| --- | --- |
+| setTension(value) | TCB 스플라인에서 사용되는 장력을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getContinuity{#getContinuity}
+
+| 이름 | 설명 |
+| --- | --- |
+| getContinuity() | TCB 스플라인에서 사용되는 연속성을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setContinuity{#setContinuity}
+
+| 이름 | 설명 |
+| --- | --- |
+| setContinuity(value) | TCB 스플라인에서 사용되는 연속성을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getBias{#getBias}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBias() | TCB 스플라인에서 사용되는 바이어스를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setBias{#setBias}
+
+| 이름 | 설명 |
+| --- | --- |
+| setBias(value) | TCB 스플라인에서 사용되는 바이어스를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndependentTangent{#getIndependentTangent}
+
+| 이름 | 설명 |
+| --- | --- |
+| getIndependentTangent() | 출력 및 다음 입력 탄젠트가 독립적인지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndependentTangent{#setIndependentTangent}
+
+| 이름 | 설명 |
+| --- | --- |
+| setIndependentTangent(value) | 출력 및 다음 입력 탄젠트가 독립적인지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlat{#getFlat}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFlat() | 키 프레임이 평평한지 여부를 가져오거나 설정합니다. 다음 또는 이전 키 프레임이 동일한 값을 가지면 키 프레임은 평평해야 합니다. 평평한 키 프레임은 평평한 탄젠트와 고정된 보간을 가집니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlat{#setFlat}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFlat(value) | 키 프레임이 평평한지 여부를 가져오거나 설정합니다. 다음 또는 이전 키 프레임이 동일한 값을 가지면 키 프레임은 평평해야 합니다. 평평한 키 프레임은 평평한 탄젠트와 고정된 보간을 가집니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTimeIndependentTangent{#getTimeIndependentTangent}
+
+| 이름 | 설명 |
+| --- | --- |
+| getTimeIndependentTangent() | 탄젠트가 시간에 독립적인지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTimeIndependentTangent{#setTimeIndependentTangent}
+
+| 이름 | 설명 |
+| --- | --- |
+| setTimeIndependentTangent(value) | 탄젠트가 시간에 독립적인지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| 이름 | 설명 |
+| --- | --- |
+| toString() | 키 프레임의 문자열 표현을 가져옵니다. |
+
+ **Result:**
+String
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/keyframesequence/_index.md
+++ b/korean/nodejs-java/aspose.threed/keyframesequence/_index.md
@@ -1,0 +1,302 @@
+---
+title: "KeyframeSequence"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/keyframesequence/
+---
+## KeyframeSequence class
+
+키 프레임의 시퀀스로, 시간에 따라 샘플 값의 변환을 설명합니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor(name) | KeyframeSequence 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| name | String | 이름 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload() | KeyframeSequence 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getBindPoint{#getBindPoint}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBindPoint() | 이 곡선을 소유하는 속성 바인드 포인트를 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getKeyFrames{#getKeyFrames}
+
+| 이름 | 설명 |
+| --- | --- |
+| getKeyFrames() | 이 곡선의 키 프레임을 가져옵니다. 키들. |
+
+ **Result:**
+
+
+
+---
+
+
+### getPostBehavior{#getPostBehavior}
+
+| 이름 | 설명 |
+| --- | --- |
+| getPostBehavior() | 마지막 키 프레임 이후에 샘플링된 값이 어떻게 될지 나타내는 포스트 동작을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getPreBehavior{#getPreBehavior}
+
+| 이름 | 설명 |
+| --- | --- |
+| getPreBehavior() | 첫 번째 키 이전에 샘플링된 값이 어떻게 될지 나타내는 프리 동작을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### add{#add}
+
+| 이름 | 설명 |
+| --- | --- |
+| add(time, value) | 지정된 값으로 새 키 프레임을 생성합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| time | 숫자 | 시간 위치(초 단위 측정) |
+| value | 숫자 | 이 시간 위치의 값 |
+
+ **Result:**
+
+
+
+---
+
+
+### add{#add}
+
+| 이름 | 설명 |
+| --- | --- |
+| add(time, value, interpolation) | 지정된 값으로 새 키 프레임을 생성합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| time | 숫자 | 시간 위치(초 단위 측정) |
+| value | 숫자 | 이 시간 위치의 값 |
+| 보간 | 보간 | 보간 |
+
+ **Result:**
+
+
+
+---
+
+
+### reset{#reset}
+
+| 이름 | 설명 |
+| --- | --- |
+| reset() | 모든 키 프레임을 제거하고 포스트/프리 행동을 재설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+### iterator{#iterator}
+
+| 이름 | 설명 |
+| --- | --- |
+| iterator() | 내부 사용을 위해 예약되었습니다. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/lambertmaterial/_index.md
+++ b/korean/nodejs-java/aspose.threed/lambertmaterial/_index.md
@@ -1,0 +1,378 @@
+---
+title: "LambertMaterial"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/lambertmaterial/
+---
+## LambertMaterial class
+
+Lambert 셰이딩 모델을 위한 재질
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | LambertMaterial 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload(name) | LambertMaterial 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| name | String | 이름 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEmissiveColor{#getEmissiveColor}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEmissiveColor() | 방출 색상을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setEmissiveColor{#setEmissiveColor}
+
+| 이름 | 설명 |
+| --- | --- |
+| setEmissiveColor(value) | 방출 색상을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAmbientColor{#getAmbientColor}
+
+| 이름 | 설명 |
+| --- | --- |
+| getAmbientColor() | 주변 색상을 가져오거나 설정합니다. 예시: var mat = new LambertMaterial(); mat.AmbientColor = new Vector3(1, 1, 1); ambient. |
+
+ **Result:**
+
+
+
+---
+
+
+### setAmbientColor{#setAmbientColor}
+
+| 이름 | 설명 |
+| --- | --- |
+| setAmbientColor(value) | 주변 색상을 가져오거나 설정합니다. 예시: var mat = new LambertMaterial(); mat.AmbientColor = new Vector3(1, 1, 1); ambient. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDiffuseColor{#getDiffuseColor}
+
+| 이름 | 설명 |
+| --- | --- |
+| getDiffuseColor() | 확산 색상을 가져오거나 설정합니다. 예시: var mat = new LambertMaterial(); mat.DiffuseColor = new Vector3(1, 0, 0); 확산. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDiffuseColor{#setDiffuseColor}
+
+| 이름 | 설명 |
+| --- | --- |
+| setDiffuseColor(value) | 확산 색상을 가져오거나 설정합니다. 예시: var mat = new LambertMaterial(); mat.DiffuseColor = new Vector3(1, 0, 0); 확산. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTransparentColor{#getTransparentColor}
+
+| 이름 | 설명 |
+| --- | --- |
+| getTransparentColor() | 투명 색상을 가져오거나 설정합니다. 예시: var mat = new LambertMaterial(); mat.TransparentColor = new Vector3(0.3, 0.5, 0.2); 투명 색상. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTransparentColor{#setTransparentColor}
+
+| 이름 | 설명 |
+| --- | --- |
+| setTransparentColor(value) | 투명 색상을 가져오거나 설정합니다. 예시: var mat = new LambertMaterial(); mat.TransparentColor = new Vector3(0.3, 0.5, 0.2); 투명 색상. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTransparency{#getTransparency}
+
+| 이름 | 설명 |
+| --- | --- |
+| getTransparency() | 투명도 계수를 가져오거나 설정합니다. 이 계수는 0(0%, 완전 불투명)과 1(100%, 완전 투명) 사이여야 합니다. 잘못된 계수 값은 클램프됩니다. 예시: var mat = new LambertMaterial(); mat.Transparency = 0.3; 투명도 계수. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTransparency{#setTransparency}
+
+| 이름 | 설명 |
+| --- | --- |
+| setTransparency(value) | 투명도 계수를 가져오거나 설정합니다. 이 계수는 0(0%, 완전 불투명)과 1(100%, 완전 투명) 사이여야 합니다. 잘못된 계수 값은 클램프됩니다. 예시: var mat = new LambertMaterial(); mat.Transparency = 0.3; 투명도 계수. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTexture{#getTexture}
+
+| 이름 | 설명 |
+| --- | --- |
+| getTexture(slotName) | 지정된 슬롯에서 텍스처를 가져옵니다. 이는 재질의 속성 이름이거나 셰이더의 매개변수 이름일 수 있습니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| slotName | String | 슬롯 이름. |
+
+ **Result:**
+TextureBase
+
+
+---
+
+
+### setTexture{#setTexture}
+
+| 이름 | 설명 |
+| --- | --- |
+| setTexture(slotName, texture) | 지정된 슬롯에 텍스처를 설정합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| slotName | String | 슬롯 이름. |
+| texture | TextureBase | 텍스처. |
+
+ **Result:**
+TextureBase
+
+
+---
+
+
+### toString{#toString}
+
+| 이름 | 설명 |
+| --- | --- |
+| toString() | 객체를 문자열로 포맷합니다. |
+
+ **Result:**
+String
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+### iterator{#iterator}
+
+| 이름 | 설명 |
+| --- | --- |
+| iterator() | 내부 사용을 위해 예약되었습니다. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/license/_index.md
+++ b/korean/nodejs-java/aspose.threed/license/_index.md
@@ -1,0 +1,61 @@
+---
+title: "라이선스"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/license/
+---
+## License class
+
+구성 요소에 대한 라이선스 부여 메서드를 제공합니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | 이 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setLicense{#setLicense}
+
+| 이름 | 설명 |
+| --- | --- |
+| setLicense(licenseName) | 구성 요소에 라이선스를 적용합니다. 다음 위치에서 라이선스를 찾으려고 시도합니다:1. 명시적인 경로.2. Aspose 구성 요소 JAR 파일이 포함된 폴더.3. 클라이언트가 호출하는 JAR 파일이 포함된 폴더. |
+
+ **Result:**
+
+
+
+---
+
+
+### setLicense{#setLicense}
+
+| 이름 | 설명 |
+| --- | --- |
+| setLicense(stream) | 구성 요소에 라이선스를 적용합니다. 이 메서드를 사용하여 스트림에서 라이선스를 로드합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| stream | InputStream | 라이선스를 포함하는 스트림입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/light/_index.md
+++ b/korean/nodejs-java/aspose.threed/light/_index.md
@@ -1,0 +1,827 @@
+---
+title: "Light"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/light/
+---
+## Light class
+
+빛이 장면을 비춥니다.  빛의 전체 감쇠를 계산하는 공식은 다음과 같습니다:  A = ConstantAttenuation + (Dist  LinearAttenuation) + ((Dist^2)  QuadraticAttenuation)
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | Light 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload(name) | Light 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| name | String | 이름 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload2(name, type) | Light 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| name | String | 이름 |
+| type | LightType | LightType |
+
+ **Result:**
+
+
+
+---
+
+
+### getColor{#getColor}
+
+| 이름 | 설명 |
+| --- | --- |
+| getColor() | 광원의 색상을 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### setColor{#setColor}
+
+| 이름 | 설명 |
+| --- | --- |
+| setColor(value) | 광원의 색상을 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getLightType{#getLightType}
+
+| 이름 | 설명 |
+| --- | --- |
+| getLightType() | 광원의 유형을 가져오거나 설정합니다. 해당 속성의 값은 LightType 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setLightType{#setLightType}
+
+| 이름 | 설명 |
+| --- | --- |
+| setLightType(value) | 광원의 유형을 가져오거나 설정합니다. 해당 속성의 값은 LightType 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastLight{#getCastLight}
+
+| 이름 | 설명 |
+| --- | --- |
+| getCastLight() | 현재 광원 인스턴스가 다른 객체를 비출 수 있는지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastLight{#setCastLight}
+
+| 이름 | 설명 |
+| --- | --- |
+| setCastLight(value) | 현재 광원 인스턴스가 다른 객체를 비출 수 있는지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getIntensity{#getIntensity}
+
+| 이름 | 설명 |
+| --- | --- |
+| getIntensity() | 광원의 강도를 가져오거나 설정합니다. 기본값은 100입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setIntensity{#setIntensity}
+
+| 이름 | 설명 |
+| --- | --- |
+| setIntensity(value) | 광원의 강도를 가져오거나 설정합니다. 기본값은 100입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getHotSpot{#getHotSpot}
+
+| 이름 | 설명 |
+| --- | --- |
+| getHotSpot() | 핫 스팟 콘 각도(도)를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setHotSpot{#setHotSpot}
+
+| 이름 | 설명 |
+| --- | --- |
+| setHotSpot(value) | 핫 스팟 콘 각도(도)를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFalloff{#getFalloff}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFalloff() | 감쇠 콘 각도(도)를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFalloff{#setFalloff}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFalloff(value) | 감쇠 콘 각도(도)를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getConstantAttenuation{#getConstantAttenuation}
+
+| 이름 | 설명 |
+| --- | --- |
+| getConstantAttenuation() | 빛의 전체 감쇠를 계산하기 위한 상수 감쇠를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setConstantAttenuation{#setConstantAttenuation}
+
+| 이름 | 설명 |
+| --- | --- |
+| setConstantAttenuation(value) | 빛의 전체 감쇠를 계산하기 위한 상수 감쇠를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLinearAttenuation{#getLinearAttenuation}
+
+| 이름 | 설명 |
+| --- | --- |
+| getLinearAttenuation() | 빛의 전체 감쇠를 계산하기 위한 선형 감쇠를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setLinearAttenuation{#setLinearAttenuation}
+
+| 이름 | 설명 |
+| --- | --- |
+| setLinearAttenuation(value) | 빛의 전체 감쇠를 계산하기 위한 선형 감쇠를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getQuadraticAttenuation{#getQuadraticAttenuation}
+
+| 이름 | 설명 |
+| --- | --- |
+| getQuadraticAttenuation() | 빛의 전체 감쇠를 계산하기 위한 2차 감쇠를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setQuadraticAttenuation{#setQuadraticAttenuation}
+
+| 이름 | 설명 |
+| --- | --- |
+| setQuadraticAttenuation(value) | 빛의 전체 감쇠를 계산하기 위한 2차 감쇠를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastShadows{#getCastShadows}
+
+| 이름 | 설명 |
+| --- | --- |
+| getCastShadows() | 빛이 다른 객체에 그림자를 드리울 수 있는지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastShadows{#setCastShadows}
+
+| 이름 | 설명 |
+| --- | --- |
+| setCastShadows(value) | 빛이 다른 객체에 그림자를 드리울 수 있는지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getShadowColor{#getShadowColor}
+
+| 이름 | 설명 |
+| --- | --- |
+| getShadowColor() | 그림자의 색상을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setShadowColor{#setShadowColor}
+
+| 이름 | 설명 |
+| --- | --- |
+| setShadowColor(value) | 그림자의 색상을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getRotationMode{#getRotationMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getRotationMode() | 프러스텀의 방향 모드를 가져오거나 설정합니다. 이 속성은 Target이 null인 경우에만 작동합니다. 값이 RotationMode.FIXED_TARGET이면 방향은 항상 LookAt 속성에 의해 계산됩니다. 그렇지 않으면 LookAt은 항상 Direction에 의해 계산됩니다. 이 속성의 값은 RotationMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRotationMode{#setRotationMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setRotationMode(value) | 프러스텀의 방향 모드를 가져오거나 설정합니다. 이 속성은 Target이 null인 경우에만 작동합니다. 값이 RotationMode.FIXED_TARGET이면 방향은 항상 LookAt 속성에 의해 계산됩니다. 그렇지 않으면 LookAt은 항상 Direction에 의해 계산됩니다. 이 속성의 값은 RotationMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getNearPlane{#getNearPlane}
+
+| 이름 | 설명 |
+| --- | --- |
+| getNearPlane() | 프러스텀의 근접 평면 거리를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setNearPlane{#setNearPlane}
+
+| 이름 | 설명 |
+| --- | --- |
+| setNearPlane(value) | 프러스텀의 근접 평면 거리를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFarPlane{#getFarPlane}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFarPlane() | 프러스텀의 원거리 평면 거리를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFarPlane{#setFarPlane}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFarPlane(value) | 프러스텀의 원거리 평면 거리를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAspect{#getAspect}
+
+| 이름 | 설명 |
+| --- | --- |
+| getAspect() | 프러스텀의 종횡비를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setAspect{#setAspect}
+
+| 이름 | 설명 |
+| --- | --- |
+| setAspect(value) | 프러스텀의 종횡비를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getOrthoHeight{#getOrthoHeight}
+
+| 이름 | 설명 |
+| --- | --- |
+| getOrthoHeight() | 프러스텀을 직교 투영으로 사용할 때 높이를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setOrthoHeight{#setOrthoHeight}
+
+| 이름 | 설명 |
+| --- | --- |
+| setOrthoHeight(value) | 프러스텀을 직교 투영으로 사용할 때 높이를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getUp{#getUp}
+
+| 이름 | 설명 |
+| --- | --- |
+| getUp() | 카메라의 위쪽 방향을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setUp{#setUp}
+
+| 이름 | 설명 |
+| --- | --- |
+| setUp(value) | 카메라의 위쪽 방향을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookAt{#getLookAt}
+
+| 이름 | 설명 |
+| --- | --- |
+| getLookAt() | 카메라가 바라보는 관심 위치를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setLookAt{#setLookAt}
+
+| 이름 | 설명 |
+| --- | --- |
+| setLookAt(value) | 카메라가 바라보는 관심 위치를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDirection{#getDirection}
+
+| 이름 | 설명 |
+| --- | --- |
+| getDirection() | 카메라가 바라보는 방향을 가져오거나 설정합니다. 이 속성의 변경은 LookAt 및 Target에도 영향을 줍니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDirection{#setDirection}
+
+| 이름 | 설명 |
+| --- | --- |
+| setDirection(value) | 카메라가 바라보는 방향을 가져오거나 설정합니다. 이 속성의 변경은 LookAt 및 Target에도 영향을 줍니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTarget{#getTarget}
+
+| 이름 | 설명 |
+| --- | --- |
+| getTarget() | 카메라가 바라보는 대상을 가져오거나 설정합니다. 사용자가 이 속성을 지원하는 경우 LookAt 속성보다 먼저 설정해야 합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTarget{#setTarget}
+
+| 이름 | 설명 |
+| --- | --- |
+| setTarget(value) | 카메라가 바라보는 대상을 가져오거나 설정합니다. 사용자가 이 속성을 지원하는 경우 LookAt 속성보다 먼저 설정해야 합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNodes() | 모든 부모 노드를 가져옵니다. 엔터티는 기하학 인스턴싱을 위해 여러 부모 노드에 부착될 수 있습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExcluded() | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExcluded(value) | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNode() | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setParentNode(value) | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 이름 | 설명 |
+| --- | --- |
+| getScene() | 이 객체가 속한 씬을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBoundingBox() | 현재 엔터티의 객체 공간 좌표계에서 경계 상자를 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEntityRendererKey() | 렌더러에 등록된 엔터티 렌더러의 키를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/line/_index.md
+++ b/korean/nodejs-java/aspose.threed/line/_index.md
@@ -1,0 +1,397 @@
+---
+title: "Line"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/line/
+---
+## Line class
+
+폴리라인은 Geometry.ControlPoints 로 정의된 점 집합으로 구성된 경로이며, Segments 로 연결됩니다. 이는 연결된 선분 집합이 될 수도 있음을 의미합니다. 라인은 일반적으로 선형 객체이므로 곡선을 표현할 수 없으며, 곡선을 표현하려면 NurbsCurve 를 사용합니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | Line 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload(name) | Line 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| name | String | 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getControlPoints{#getControlPoints}
+
+| 이름 | 설명 |
+| --- | --- |
+| getControlPoints() | 모든 제어점을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getVisible{#getVisible}
+
+| 이름 | 설명 |
+| --- | --- |
+| getVisible() | 지오메트리가 보이는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setVisible{#setVisible}
+
+| 이름 | 설명 |
+| --- | --- |
+| setVisible(value) | 지오메트리가 보이는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getSegments{#getSegments}
+
+| 이름 | 설명 |
+| --- | --- |
+| getSegments() | 라인의 세그먼트를 가져옵니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getColor{#getColor}
+
+| 이름 | 설명 |
+| --- | --- |
+| getColor() | 선의 색상을 가져오거나 설정합니다. 기본값은 흰색(1, 1, 1)입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setColor{#setColor}
+
+| 이름 | 설명 |
+| --- | --- |
+| setColor(value) | 선의 색상을 가져오거나 설정합니다. 기본값은 흰색(1, 1, 1)입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNodes() | 모든 부모 노드를 가져옵니다. 엔터티는 기하학 인스턴싱을 위해 여러 부모 노드에 부착될 수 있습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExcluded() | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExcluded(value) | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNode() | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setParentNode(value) | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 이름 | 설명 |
+| --- | --- |
+| getScene() | 이 객체가 속한 씬을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### fromPoints{#fromPoints}
+
+| 이름 | 설명 |
+| --- | --- |
+| fromPoints(points) | 점 집합으로부터 Line 인스턴스를 생성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| point | Vector3[] | null |
+
+ **Result:**
+Line
+
+
+---
+
+
+### makeDefaultIndices{#makeDefaultIndices}
+
+| 이름 | 설명 |
+| --- | --- |
+| makeDefaultIndices() | 0,1,2,3....Geometry.ControlPoints.Length-1 시퀀스를 Segments에 생성하여 ControlPoints를 단일 라인으로 사용할 수 있도록 합니다 |
+
+ **Result:**
+Line
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEntityRendererKey() | 렌더러에 등록된 엔터티 렌더러의 키를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBoundingBox() | 현재 엔터티의 객체 공간 좌표계에서 경계 상자를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/linearextrusion/_index.md
+++ b/korean/nodejs-java/aspose.threed/linearextrusion/_index.md
@@ -1,0 +1,476 @@
+---
+title: "LinearExtrusion"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/linearextrusion/
+---
+## LinearExtrusion class
+
+선형 압출은 2D 형태를 입력으로 받아 3차원으로 형태를 확장합니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | LinearExtrusion 인스턴스의 생성자입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload(shape, height) | LinearExtrusion 인스턴스의 생성자입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getShape{#getShape}
+
+| 이름 | 설명 |
+| --- | --- |
+| getShape() | 추출될 기본 형태입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setShape{#setShape}
+
+| 이름 | 설명 |
+| --- | --- |
+| setShape(value) | 추출될 기본 형태입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDirection{#getDirection}
+
+| 이름 | 설명 |
+| --- | --- |
+| getDirection() | 추출 방향, 기본값은 (0, 0, 1)입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDirection{#setDirection}
+
+| 이름 | 설명 |
+| --- | --- |
+| setDirection(value) | 추출 방향, 기본값은 (0, 0, 1)입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getHeight{#getHeight}
+
+| 이름 | 설명 |
+| --- | --- |
+| getHeight() | 추출된 기하학의 높이, 기본값은 1.0입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setHeight{#setHeight}
+
+| 이름 | 설명 |
+| --- | --- |
+| setHeight(value) | 추출된 기하학의 높이, 기본값은 1.0입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getSlices{#getSlices}
+
+| 이름 | 설명 |
+| --- | --- |
+| getSlices() | 비틀린 추출 기하학의 슬라이스 수, 기본값은 1입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setSlices{#setSlices}
+
+| 이름 | 설명 |
+| --- | --- |
+| setSlices(value) | 비틀린 추출 기하학의 슬라이스 수, 기본값은 1입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getCenter{#getCenter}
+
+| 이름 | 설명 |
+| --- | --- |
+| getCenter() | 이 값이 false이면 선형 추출 Z 범위는 0부터 높이까지이며, 그렇지 않으면 범위는 -height/2부터 height/2까지입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setCenter{#setCenter}
+
+| 이름 | 설명 |
+| --- | --- |
+| setCenter(value) | 이 값이 false이면 선형 추출 Z 범위는 0부터 높이까지이며, 그렇지 않으면 범위는 -height/2부터 height/2까지입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTwistOffset{#getTwistOffset}
+
+| 이름 | 설명 |
+| --- | --- |
+| getTwistOffset() | 비틀기에 사용되는 오프셋, 기본값은 (0, 0, 0)입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTwistOffset{#setTwistOffset}
+
+| 이름 | 설명 |
+| --- | --- |
+| setTwistOffset(value) | 비틀기에 사용되는 오프셋, 기본값은 (0, 0, 0)입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTwist{#getTwist}
+
+| 이름 | 설명 |
+| --- | --- |
+| getTwist() | 형태가 추출되는 각도(도) 수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTwist{#setTwist}
+
+| 이름 | 설명 |
+| --- | --- |
+| setTwist(value) | 형태가 추출되는 각도(도) 수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNodes() | 모든 부모 노드를 가져옵니다. 엔터티는 기하학 인스턴싱을 위해 여러 부모 노드에 부착될 수 있습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExcluded() | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExcluded(value) | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNode() | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setParentNode(value) | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 이름 | 설명 |
+| --- | --- |
+| getScene() | 이 객체가 속한 씬을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### toMesh{#toMesh}
+
+| 이름 | 설명 |
+| --- | --- |
+| toMesh() | 추출을 메시로 변환합니다. |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBoundingBox() | 현재 엔터티의 객체 공간 좌표계에서 경계 상자를 가져옵니다. |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEntityRendererKey() | 렌더러에 등록된 엔터티 렌더러의 키를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/loadoptions/_index.md
+++ b/korean/nodejs-java/aspose.threed/loadoptions/_index.md
@@ -1,0 +1,107 @@
+---
+title: "LoadOptions"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/loadoptions/
+---
+## LoadOptions class
+
+다양한 유형에 대한 파일 로드 옵션을 구성하기 위한 기본 클래스  @hideconstructor
+
+
+## 메서드
+
+### getFileFormat{#getFileFormat}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileFormat() | 현재 저장/로드 옵션에 지정된 파일 형식을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEncoding() | 텍스트 기반 파일에 대한 기본 인코딩을 가져오거나 설정합니다. 기본값은 null이며, 이는 가져오기/내보내기 프로그램이 사용할 인코딩을 결정함을 의미합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileSystem() | 로드/저장 중 외부 종속성을 관리하는 방법을 사용자가 처리하도록 허용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFileSystem(value) | 로드/저장 중 외부 종속성을 관리하는 방법을 사용자가 처리하도록 허용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| 이름 | 설명 |
+| --- | --- |
+| getLookupPaths() | OBJ와 같은 일부 파일은 외부 파일에 의존하며, 조회 경로를 통해 Aspose.3D가 외부 파일을 찾아 로드할 수 있도록 합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileName() | 내보내기/가져오기 씬의 파일 이름입니다. 선택 사항이지만 OBJ의 재질과 같은 외부 자산을 직렬화할 때 유용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFileName(value) | 내보내기/가져오기 씬의 파일 이름입니다. 선택 사항이지만 OBJ의 재질과 같은 외부 자산을 직렬화할 때 유용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/localfilesystem/_index.md
+++ b/korean/nodejs-java/aspose.threed/localfilesystem/_index.md
@@ -1,0 +1,75 @@
+---
+title: "LocalFileSystem"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/localfilesystem/
+---
+## LocalFileSystem class
+
+LocalFileSystem 은 읽기/쓰기 작업을 로컬 디렉터리에 매핑합니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor(directory) | 지정된 기본 디렉터리를 사용하여 새 LocalFileSystem을 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 디렉터 | String | null |
+
+ **Result:**
+
+
+
+---
+
+
+### readFile{#readFile}
+
+| 이름 | 설명 |
+| --- | --- |
+| readFile(fileName, options) | 종속성을 읽기 위한 스트림을 생성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| fileNam | String | null |
+| 옵션 | IOConfig | null |
+
+ **Result:**
+Stream
+
+
+---
+
+
+### writeFile{#writeFile}
+
+| 이름 | 설명 |
+| --- | --- |
+| writeFile(fileName, options) | 종속성을 쓰기 위한 스트림을 생성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| fileNam | String | null |
+| 옵션 | IOConfig | null |
+
+ **Result:**
+Stream
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/lshape/_index.md
+++ b/korean/nodejs-java/aspose.threed/lshape/_index.md
@@ -1,0 +1,411 @@
+---
+title: "LShape"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/lshape/
+---
+## LShape class
+
+파라미터로 정의된 IFC 호환 L자형 프로파일.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | LShape의 생성자 |
+
+ **Result:**
+
+
+
+---
+
+
+### getDepth{#getDepth}
+
+| 이름 | 설명 |
+| --- | --- |
+| getDepth() | 프로필의 깊이를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDepth{#setDepth}
+
+| 이름 | 설명 |
+| --- | --- |
+| setDepth(value) | 프로필의 깊이를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getWidth{#getWidth}
+
+| 이름 | 설명 |
+| --- | --- |
+| getWidth() | 프로필의 너비를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setWidth{#setWidth}
+
+| 이름 | 설명 |
+| --- | --- |
+| setWidth(value) | 프로필의 너비를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getThickness{#getThickness}
+
+| 이름 | 설명 |
+| --- | --- |
+| getThickness() | 상수벽의 두께를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setThickness{#setThickness}
+
+| 이름 | 설명 |
+| --- | --- |
+| setThickness(value) | 상수벽의 두께를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFilletRadius{#getFilletRadius}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFilletRadius() | 필렛의 반경을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFilletRadius{#setFilletRadius}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFilletRadius(value) | 필렛의 반경을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEdgeRadius{#getEdgeRadius}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEdgeRadius() | 엣지의 반경을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setEdgeRadius{#setEdgeRadius}
+
+| 이름 | 설명 |
+| --- | --- |
+| setEdgeRadius(value) | 엣지의 반경을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNodes() | 모든 부모 노드를 가져옵니다. 엔터티는 기하학 인스턴싱을 위해 여러 부모 노드에 부착될 수 있습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExcluded() | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExcluded(value) | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNode() | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setParentNode(value) | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 이름 | 설명 |
+| --- | --- |
+| getScene() | 이 객체가 속한 씬을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtent{#getExtent}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExtent() | x 및 y 차원에서의 범위를 가져옵니다. |
+
+ **Result:**
+Vector2
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEntityRendererKey() | 렌더러에 등록된 엔터티 렌더러의 키를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBoundingBox() | 현재 엔터티의 객체 공간 좌표계에서 경계 상자를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/material/_index.md
+++ b/korean/nodejs-java/aspose.threed/material/_index.md
@@ -1,0 +1,226 @@
+---
+title: "재료"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/material/
+---
+## Material class
+
+Material 은 기하학의 시각적 외관에 필요한 매개변수를 정의합니다.  Aspose.3D 는 LambertMaterial, PhongMaterial 및 ShaderMaterial 에 대한 셰이딩 모델을 제공합니다  @hideconstructor
+
+
+## Properties
+
+| 이름 | 설명 |
+| --- | --- |
+| MAP_SPECULAR | setTexture(java.lang.String, com.aspose.threed.TextureBase)에서 반사 텍스처 매핑을 할당하는 데 사용됩니다. |
+| MAP_DIFFUSE | setTexture(java.lang.String, com.aspose.threed.TextureBase)에서 확산 텍스처 매핑을 할당하는 데 사용됩니다. |
+| MAP_EMISSIVE | setTexture(java.lang.String, com.aspose.threed.TextureBase)에서 방출 텍스처 매핑을 할당하는 데 사용됩니다. |
+| MAP_AMBIENT | setTexture(java.lang.String, com.aspose.threed.TextureBase)에서 주변 텍스처 매핑을 할당하는 데 사용됩니다. |
+| MAP_NORMAL | setTexture(java.lang.String, com.aspose.threed.TextureBase)에서 노멀 텍스처 매핑을 할당하는 데 사용됩니다. |
+
+## 메서드
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTexture{#getTexture}
+
+| 이름 | 설명 |
+| --- | --- |
+| getTexture(slotName) | 지정된 슬롯에서 텍스처를 가져옵니다. 이는 재질의 속성 이름이거나 셰이더의 매개변수 이름일 수 있습니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| slotName | String | 슬롯 이름. |
+
+ **Result:**
+TextureBase
+
+
+---
+
+
+### setTexture{#setTexture}
+
+| 이름 | 설명 |
+| --- | --- |
+| setTexture(slotName, texture) | 지정된 슬롯에 텍스처를 설정합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| slotName | String | 슬롯 이름. |
+| texture | TextureBase | 텍스처. |
+
+ **Result:**
+TextureBase
+
+
+---
+
+
+### toString{#toString}
+
+| 이름 | 설명 |
+| --- | --- |
+| toString() | 객체를 문자열로 포맷합니다. |
+
+ **Result:**
+String
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+### iterator{#iterator}
+
+| 이름 | 설명 |
+| --- | --- |
+| iterator() | 내부 사용을 위해 예약되었습니다. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/mathutils/_index.md
+++ b/korean/nodejs-java/aspose.threed/mathutils/_index.md
@@ -1,0 +1,193 @@
+---
+title: "MathUtils"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/mathutils/
+---
+## MathUtils class
+
+유용한 수학 유틸리티 집합입니다.  @hideconstructor
+
+
+## 메서드
+
+### clamp{#clamp}
+
+| 이름 | 설명 |
+| --- | --- |
+| clamp(val, min, max) | 값을 [min, max] 범위로 제한합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| val | 숫자 | 제한할 값. |
+| min | 숫자 | 최소값. |
+| max | 숫자 | 최대값. |
+
+ **Result:**
+숫자
+
+
+---
+
+
+### toDegree{#toDegree}
+
+| 이름 | 설명 |
+| --- | --- |
+| toDegree(radian) | Vector3를 라디안에서 도(degree)로 변환합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| radian | Vector3 | 라디안 값. |
+
+ **Result:**
+Vector3
+
+
+---
+
+
+### toRadian{#toRadian}
+
+| 이름 | 설명 |
+| --- | --- |
+| toRadian(degree) | Vector3를 도(degree)에서 라디안으로 변환합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| degree | Vector3 | 도 값. |
+
+ **Result:**
+Vector3
+
+
+---
+
+
+### toDegree{#toDegree}
+
+| 이름 | 설명 |
+| --- | --- |
+| toDegree(radian) | 숫자를 라디안에서 도로 변환합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| radian | 숫자 | 라디안 값. |
+
+ **Result:**
+숫자
+
+
+---
+
+
+### toDegree{#toDegree}
+
+| 이름 | 설명 |
+| --- | --- |
+| toDegree(radian) | 숫자를 라디안에서 도로 변환합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| radian | 숫자 | 라디안 값. |
+
+ **Result:**
+숫자
+
+
+---
+
+
+### toDegree{#toDegree}
+
+| 이름 | 설명 |
+| --- | --- |
+| toDegree(x, y, z) | 숫자를 라디안에서 도로 변환합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| x | 숫자 | 라디안 값의 x 구성 요소. |
+| y | 숫자 | 라디안 값의 y 구성 요소. |
+| z | 숫자 | 라디안 값의 z 구성 요소. |
+
+ **Result:**
+Vector3
+
+
+---
+
+
+### toRadian{#toRadian}
+
+| 이름 | 설명 |
+| --- | --- |
+| toRadian(degree) | 숫자를 도에서 라디안으로 변환합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| degree | 숫자 | 도 값. |
+
+ **Result:**
+숫자
+
+
+---
+
+
+### toRadian{#toRadian}
+
+| 이름 | 설명 |
+| --- | --- |
+| toRadian(degree) | 숫자를 도에서 라디안으로 변환합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| degree | 숫자 | 도 값. |
+
+ **Result:**
+숫자
+
+
+---
+
+
+### toRadian{#toRadian}
+
+| 이름 | 설명 |
+| --- | --- |
+| toRadian(x, y, z) | 벡터를 degree에서 radian으로 변환합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| x | 숫자 | degree 값의 x 구성 요소. |
+| y | 숫자 | degree 값의 y 구성 요소. |
+| z | 숫자 | degree 값의 z 구성 요소. |
+
+ **Result:**
+Vector3
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/matrix4/_index.md
+++ b/korean/nodejs-java/aspose.threed/matrix4/_index.md
@@ -1,0 +1,453 @@
+---
+title: "Matrix4"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/matrix4/
+---
+## Matrix4 class
+
+4x4 행렬 구현.
+
+
+## Properties
+
+| 이름 | 설명 |
+| --- | --- |
+| m00 | m00 값. |
+| m01 | m01 값. |
+| m02 | m02 값. |
+| m03 | m03 값. |
+| m10 | m10 값. |
+| m11 | m11 값. |
+| m12 | 그 m12. |
+| m13 | 그 m13. |
+| m20 | 그 m20. |
+| m21 | 그 m21. |
+| m22 | 그 m22. |
+| m23 | 그 m23. |
+| m30 | 그 m30. |
+| m31 | 그 m31. |
+| m32 | 그 m32. |
+| m33 | 그 m33. |
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload(r0, r1, r2, r3) | 4개의 행으로부터 행렬을 구성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| r0 | Vector4 | R0. |
+| r1 | Vector4 | R1. |
+| r2 | Vector4 | R2. |
+| r3 | Vector4 | R3. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload2(m00, m01, m02, m03, m10, m11, m12, m13, m20, m21, m22, m23, m30, m31, m32, m33) | Matrix4 구조체의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| m00 | 숫자 | M00. |
+| m01 | 숫자 | M01. |
+| m02 | 숫자 | M02. |
+| m03 | 숫자 | M03. |
+| m10 | 숫자 | M10. |
+| m11 | 숫자 | M11. |
+| m12 | 숫자 | M12. |
+| m13 | 숫자 | M13. |
+| m20 | 숫자 | M20. |
+| m21 | 숫자 | M21. |
+| m22 | 숫자 | M22. |
+| m23 | 숫자 | M23. |
+| m30 | 숫자 | M30. |
+| m31 | 숫자 | M31. |
+| m32 | 숫자 | M32. |
+| m33 | 숫자 | M33. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload3{#constructor_overload3}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload3(m) | FMatrix4 인스턴스로부터 Matrix4를 구성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+|  | FMatrix4 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload4{#constructor_overload4}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload4(m) | Matrix4 구조체의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| m | Number[] | M. |
+
+ **Result:**
+
+
+
+---
+
+
+### getIdentity{#getIdentity}
+
+| 이름 | 설명 |
+| --- | --- |
+| getIdentity() | 단위 행렬을 가져옵니다. 단위 행렬. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDeterminant{#getDeterminant}
+
+| 이름 | 설명 |
+| --- | --- |
+| getDeterminant() | 행렬의 행렬식을 가져옵니다. 행렬식. |
+
+ **Result:**
+
+
+
+---
+
+
+### concatenate{#concatenate}
+
+| 이름 | 설명 |
+| --- | --- |
+| concatenate(m2) | 두 행렬을 연결합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| m2 | Matrix4 | M2. |
+
+ **Result:**
+Matrix4
+
+
+---
+
+
+### transpose{#transpose}
+
+| 이름 | 설명 |
+| --- | --- |
+| transpose() | 이 인스턴스를 전치합니다. |
+
+ **Result:**
+Matrix4
+
+
+---
+
+
+### normalize{#normalize}
+
+| 이름 | 설명 |
+| --- | --- |
+| normalize() | 이 인스턴스를 정규화합니다. |
+
+ **Result:**
+Matrix4
+
+
+---
+
+
+### inverse{#inverse}
+
+| 이름 | 설명 |
+| --- | --- |
+| inverse() | 이 인스턴스를 역행렬로 변환합니다. |
+
+ **Result:**
+Matrix4
+
+
+---
+
+
+### setTRS{#setTRS}
+
+| 이름 | 설명 |
+| --- | --- |
+| setTRS(translation, rotation, scale) | 행렬을 변환/회전/스케일로 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 변환 | Vector3 | 변환. |
+| 회전 | Vector3 | 회전을 위한 오일러 각도, 필드는 도 단위입니다. |
+| 스케일 | Vector3 | 스케일. |
+
+ **Result:**
+Matrix4
+
+
+---
+
+
+### toArray{#toArray}
+
+| 이름 | 설명 |
+| --- | --- |
+| toArray() | 행렬을 배열로 변환합니다. |
+
+ **Result:**
+Number[]
+
+
+---
+
+
+### toString{#toString}
+
+| 이름 | 설명 |
+| --- | --- |
+| toString() | 현재 Matrix4를 나타내는 java.lang.String을 반환합니다. |
+
+ **Result:**
+String
+
+
+---
+
+
+### translate{#translate}
+
+| 이름 | 설명 |
+| --- | --- |
+| translate(t) | x축, y축 및 z축을 따라 변환하는 행렬을 생성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| t | Vector3 | 변환 오프셋 |
+
+ **Result:**
+Matrix4
+
+
+---
+
+
+### translate{#translate}
+
+| 이름 | 설명 |
+| --- | --- |
+| translate(tx, ty, tz) | x축, y축 및 z축을 따라 변환하는 행렬을 생성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| tx | 숫자 | X 좌표 오프셋 |
+| ty | 숫자 | Y 좌표 오프셋 |
+| tz | 숫자 | Z 좌표 오프셋 |
+
+ **Result:**
+Matrix4
+
+
+---
+
+
+### scale{#scale}
+
+| 이름 | 설명 |
+| --- | --- |
+| scale(s) | x축, y축 및 z축을 따라 스케일링하는 행렬을 생성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| s | Vector3 | 스케일링 팩터리는 x축, y축 및 z축에 적용됩니다. |
+
+ **Result:**
+Matrix4
+
+
+---
+
+
+### scale{#scale}
+
+| 이름 | 설명 |
+| --- | --- |
+| scale(s) | x축, y축 및 z축을 따라 스케일링하는 행렬을 생성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| s | 숫자 | 스케일링 팩터리는 모든 축에 적용됩니다. |
+
+ **Result:**
+Matrix4
+
+
+---
+
+
+### scale{#scale}
+
+| 이름 | 설명 |
+| --- | --- |
+| scale(sx, sy, sz) | x축, y축 및 z축을 따라 스케일링하는 행렬을 생성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| sx | 숫자 | 스케일링 팩터리는 x축에 적용됩니다. |
+| sy | 숫자 | 스케일링 팩터리는 y축에 적용됩니다. |
+| sz | 숫자 | 스케일링 팩터리는 z축에 적용됩니다. |
+
+ **Result:**
+Matrix4
+
+
+---
+
+
+### rotateFromEuler{#rotateFromEuler}
+
+| 이름 | 설명 |
+| --- | --- |
+| rotateFromEuler(eul) | Euler 각도에서 회전 행렬을 생성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| eul | Vector3 | 라디안 단위 회전 |
+
+ **Result:**
+Matrix4
+
+
+---
+
+
+### rotateFromEuler{#rotateFromEuler}
+
+| 이름 | 설명 |
+| --- | --- |
+| rotateFromEuler(rx, ry, rz) | Euler 각도에서 회전 행렬을 생성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| rx | 숫자 | x축에 대한 라디안 단위 회전 |
+| ry | 숫자 | y축에 대한 라디안 단위 회전 |
+| rz | 숫자 | z 축의 회전 (라디안) |
+
+ **Result:**
+Matrix4
+
+
+---
+
+
+### rotate{#rotate}
+
+| 이름 | 설명 |
+| --- | --- |
+| rotate(angle, axis) | 회전 각도와 축을 사용하여 회전 행렬을 생성합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| angle | 숫자 | 라디안 단위 회전 각도 |
+| axis | Vector3 | 회전 축 |
+
+ **Result:**
+Matrix4
+
+
+---
+
+
+### rotate{#rotate}
+
+| 이름 | 설명 |
+| --- | --- |
+| rotate(q) | 쿼터니언으로부터 회전 행렬을 생성합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| q | Quaternion | 회전 쿼터니언 |
+
+ **Result:**
+Matrix4
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/memoryfilesystem/_index.md
+++ b/korean/nodejs-java/aspose.threed/memoryfilesystem/_index.md
@@ -1,0 +1,101 @@
+---
+title: "MemoryFileSystem"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/memoryfilesystem/
+---
+## MemoryFileSystem class
+
+MemoryFileSystem 은 읽기/쓰기 작업을 메모리로 매핑합니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileNames{#getFileNames}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileNames() | 이 메모리 파일 시스템에 있는 파일 이름들. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileContent{#getFileContent}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileContent(fileName) | 지정된 파일의 원시 콘텐츠를 반환합니다. 지정된 파일이 존재하지 않을 경우 System.IO.FileNotFoundException을 발생시킵니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| fileNam | String | null |
+
+ **Result:**
+byte[]
+
+
+---
+
+
+### readFile{#readFile}
+
+| 이름 | 설명 |
+| --- | --- |
+| readFile(fileName, options) | 종속성을 읽기 위한 스트림을 생성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| fileNam | String | null |
+| 옵션 | IOConfig | null |
+
+ **Result:**
+Stream
+
+
+---
+
+
+### writeFile{#writeFile}
+
+| 이름 | 설명 |
+| --- | --- |
+| writeFile(fileName, options) | 종속성을 쓰기 위한 스트림을 생성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| fileNam | String | null |
+| 옵션 | IOConfig | null |
+
+ **Result:**
+Stream
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/mesh/_index.md
+++ b/korean/nodejs-java/aspose.threed/mesh/_index.md
@@ -1,0 +1,708 @@
+---
+title: "Mesh"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/mesh/
+---
+## Mesh class
+
+메시는 다수의 n각형으로 구성됩니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | Mesh 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload(name) | Mesh 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| name | String | 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEdges{#getEdges}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEdges() | Mesh의 엣지를 가져옵니다. 엣지는 Mesh에서 선택 사항이므로 비어 있을 수 있습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getPolygonCount{#getPolygonCount}
+
+| 이름 | 설명 |
+| --- | --- |
+| getPolygonCount() | 다각형 개수를 가져옵니다. 다각형 개수. |
+
+ **Result:**
+
+
+
+---
+
+
+### getPolygons{#getPolygons}
+
+| 이름 | 설명 |
+| --- | --- |
+| getPolygons() | Mesh의 다각형 정의를 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getVisible{#getVisible}
+
+| 이름 | 설명 |
+| --- | --- |
+| getVisible() | 지오메트리가 보이는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setVisible{#setVisible}
+
+| 이름 | 설명 |
+| --- | --- |
+| setVisible(value) | 지오메트리가 보이는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDeformers{#getDeformers}
+
+| 이름 | 설명 |
+| --- | --- |
+| getDeformers() | 이 지오메트리와 연결된 모든 디포머를 가져옵니다. 디포머. |
+
+ **Result:**
+
+
+
+---
+
+
+### getControlPoints{#getControlPoints}
+
+| 이름 | 설명 |
+| --- | --- |
+| getControlPoints() | 모든 제어점을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastShadows{#getCastShadows}
+
+| 이름 | 설명 |
+| --- | --- |
+| getCastShadows() | 이 지오메트리가 그림자를 드리울 수 있는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastShadows{#setCastShadows}
+
+| 이름 | 설명 |
+| --- | --- |
+| setCastShadows(value) | 이 지오메트리가 그림자를 드리울 수 있는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReceiveShadows{#getReceiveShadows}
+
+| 이름 | 설명 |
+| --- | --- |
+| getReceiveShadows() | 이 지오메트리가 그림자를 받을 수 있는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReceiveShadows{#setReceiveShadows}
+
+| 이름 | 설명 |
+| --- | --- |
+| setReceiveShadows(value) | 이 지오메트리가 그림자를 받을 수 있는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElements{#getVertexElements}
+
+| 이름 | 설명 |
+| --- | --- |
+| getVertexElements() | 모든 정점 요소를 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNodes() | 모든 부모 노드를 가져옵니다. 엔터티는 기하학 인스턴싱을 위해 여러 부모 노드에 부착될 수 있습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExcluded() | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExcluded(value) | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNode() | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setParentNode(value) | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 이름 | 설명 |
+| --- | --- |
+| getScene() | 이 객체가 속한 씬을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getPolygonSize{#getPolygonSize}
+
+| 이름 | 설명 |
+| --- | --- |
+| getPolygonSize(index) | 지정된 다각형의 정점 개수를 가져옵니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 인덱스 | 숫자 | 인덱스. |
+
+ **Result:**
+숫자
+
+
+---
+
+
+### createPolygon{#createPolygon}
+
+| 이름 | 설명 |
+| --- | --- |
+| createPolygon(indices, offset, length) | indices에 정의된 모든 정점으로 새로운 다각형을 생성합니다. 정점을 하나씩 생성하려면 PolygonBuilder를 사용하십시오. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 인덱스 | Number[] | 다각형 인덱스 배열이며, 각 인덱스는 다각형을 구성하는 제어점을 가리킵니다. |
+| 오프셋 | 숫자 | 첫 번째 다각형 인덱스의 오프셋 |
+| 길이 | 숫자 | 인덱스의 길이 |
+
+ **Result:**
+숫자
+
+
+---
+
+
+### createPolygon{#createPolygon}
+
+| 이름 | 설명 |
+| --- | --- |
+| createPolygon(indices) | indices에 정의된 모든 정점으로 새로운 다각형을 생성합니다. 정점을 하나씩 생성하려면 PolygonBuilder를 사용하십시오. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 인덱스 | Number[] | 다각형 인덱스 배열이며, 각 인덱스는 다각형을 구성하는 제어점을 가리킵니다. |
+
+ **Result:**
+숫자
+
+
+---
+
+
+### createPolygon{#createPolygon}
+
+| 이름 | 설명 |
+| --- | --- |
+| createPolygon(v1, v2, v3, v4) | 4개의 정점(쿼드)으로 다각형을 생성합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| v1 | 숫자 | 첫 번째 정점의 인덱스 |
+| v2 | 숫자 | 두 번째 정점의 인덱스 |
+| v3 | 숫자 | 세 번째 정점의 인덱스 |
+| v4 | 숫자 | 네 번째 정점의 인덱스 |
+
+ **Result:**
+숫자
+
+
+---
+
+
+### createPolygon{#createPolygon}
+
+| 이름 | 설명 |
+| --- | --- |
+| createPolygon(v1, v2, v3) | 3개의 정점(삼각형)으로 폴리곤을 생성합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| v1 | 숫자 | 첫 번째 정점의 인덱스 |
+| v2 | 숫자 | 두 번째 정점의 인덱스 |
+| v3 | 숫자 | 세 번째 정점의 인덱스 |
+
+ **Result:**
+숫자
+
+
+---
+
+
+### toMesh{#toMesh}
+
+| 이름 | 설명 |
+| --- | --- |
+| toMesh() | 현재 엔터티에서 Mesh 인스턴스를 가져옵니다. |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getElement{#getElement}
+
+| 이름 | 설명 |
+| --- | --- |
+| getElement(type) | 지정된 타입의 정점 요소를 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| type | VertexElementType | VertexElementType |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### getVertexElementOfUV{#getVertexElementOfUV}
+
+| 이름 | 설명 |
+| --- | --- |
+| getVertexElementOfUV(textureMapping) | 주어진 텍스처 매핑 타입으로 VertexElementUV 인스턴스를 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| textureMapping | TextureMapping | TextureMapping |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### createElement{#createElement}
+
+| 이름 | 설명 |
+| --- | --- |
+| createElement(type) | 지정된 타입의 정점 요소를 생성하고 이를 지오메트리에 추가합니다. 타입이 VertexElementType.UV인 경우, TextureMapping.DIFFUSE 타입의 텍스처 매핑을 가진 VertexElementUV가 생성됩니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| type | VertexElementType | VertexElementType |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### addElement{#addElement}
+
+| 이름 | 설명 |
+| --- | --- |
+| addElement(element) | 기존 정점 요소를 현재 지오메트리에 추가합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| element | VertexElement | 추가할 정점 요소 |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### createElement{#createElement}
+
+| 이름 | 설명 |
+| --- | --- |
+| createElement(type, mappingMode, referenceMode) | 지정된 타입의 정점 요소를 생성하고 이를 지오메트리에 추가합니다. 타입이 VertexElementType.UV인 경우, TextureMapping.DIFFUSE 타입의 텍스처 매핑을 가진 VertexElementUV가 생성됩니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| type | VertexElementType | VertexElementType |
+| mappingMode | MappingMode | MappingMode |
+| referenceMode | ReferenceMode | ReferenceMode |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### createElementUV{#createElementUV}
+
+| 이름 | 설명 |
+| --- | --- |
+| createElementUV(uvMapping) | 주어진 텍스처 매핑 유형으로 VertexElementUV를 생성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| uvMapping | TextureMapping | TextureMapping |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### createElementUV{#createElementUV}
+
+| 이름 | 설명 |
+| --- | --- |
+| createElementUV(uvMapping, mappingMode, referenceMode) | 주어진 텍스처 매핑 유형으로 VertexElementUV를 생성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| uvMapping | TextureMapping | TextureMapping |
+| mappingMode | MappingMode | MappingMode |
+| referenceMode | ReferenceMode | ReferenceMode |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBoundingBox() | 현재 엔터티의 객체 공간 좌표계에서 경계 상자를 가져옵니다. |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEntityRendererKey() | 렌더러에 등록된 엔터티 렌더러의 키를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+### iterator{#iterator}
+
+| 이름 | 설명 |
+| --- | --- |
+| iterator() | 내부 사용을 위해 예약되었습니다. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/metered/_index.md
+++ b/korean/nodejs-java/aspose.threed/metered/_index.md
@@ -1,0 +1,75 @@
+---
+title: "Metered"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/metered/
+---
+## Metered class
+
+metered key 를 설정하는 메서드를 제공합니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | 이 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMeteredKey{#setMeteredKey}
+
+| 이름 | 설명 |
+| --- | --- |
+| setMeteredKey(publicKey, privateKey) | 계량형(public) 및 개인 키를 설정합니다. 계량형 라이선스를 구매한 경우 애플리케이션을 시작할 때 이 API를 호출해야 하며, 일반적으로 이것만으로 충분합니다. 그러나 사용량 데이터를 업로드하는 데 지속적으로 실패하고 24시간을 초과하면 라이선스가 평가 상태로 전환됩니다. 이러한 상황을 방지하려면 라이선스 상태를 정기적으로 확인하고, 평가 상태인 경우 이 API를 다시 호출해야 합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| publicKey | String | 공개 키 |
+| privateKey | String | 개인 키 |
+
+ **Result:**
+
+
+
+---
+
+
+### getConsumptionQuantity{#getConsumptionQuantity}
+
+| 이름 | 설명 |
+| --- | --- |
+| getConsumptionQuantity() | 소비 파일 크기를 가져옵니다 |
+
+ **Result:**
+BigDecimal
+
+
+---
+
+
+### getConsumptionCredit{#getConsumptionCredit}
+
+| 이름 | 설명 |
+| --- | --- |
+| getConsumptionCredit() | 소비 크레딧을 가져옵니다 |
+
+ **Result:**
+BigDecimal
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/mirroredprofile/_index.md
+++ b/korean/nodejs-java/aspose.threed/mirroredprofile/_index.md
@@ -1,0 +1,287 @@
+---
+title: "MirroredProfile"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/mirroredprofile/
+---
+## MirroredProfile class
+
+IFC 호환 미러 프로파일.  이 프로파일은 y축을 기준으로 기본 프로파일을 반사하여 새로운 프로파일을 정의합니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor(baseProfile) | 기존 프로파일에서 새로운 MirroredProfile을 생성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| baseProfile | Profile | 반사될 기본 프로파일입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getBaseProfile{#getBaseProfile}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBaseProfile() | 반사될 기본 프로파일입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNodes() | 모든 부모 노드를 가져옵니다. 엔터티는 기하학 인스턴싱을 위해 여러 부모 노드에 부착될 수 있습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExcluded() | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExcluded(value) | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNode() | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setParentNode(value) | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 이름 | 설명 |
+| --- | --- |
+| getScene() | 이 객체가 속한 씬을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEntityRendererKey() | 렌더러에 등록된 엔터티 렌더러의 키를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBoundingBox() | 현재 엔터티의 객체 공간 좌표계에서 경계 상자를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/morphtargetchannel/_index.md
+++ b/korean/nodejs-java/aspose.threed/morphtargetchannel/_index.md
@@ -1,0 +1,306 @@
+---
+title: "MorphTargetChannel"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/morphtargetchannel/
+---
+## MorphTargetChannel class
+
+MorphTargetChannel 은 MorphTargetDeformer 가 대상 기하학을 정리하는 데 사용됩니다.  FBX 와 같은 일부 파일 형식은 여러 채널을 동시에 지원합니다.  가중치는 0에서 1.0 사이이며, 대상의 기본 가중치는 0.0입니다;
+
+
+## Properties
+
+| 이름 | 설명 |
+| --- | --- |
+| DEFAULT_WEIGHT | 모프 타겟의 기본 무게. |
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor(name) | MorphTargetChannel 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| name | String | 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload() | MorphTargetChannel 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getWeights{#getWeights}
+
+| 이름 | 설명 |
+| --- | --- |
+| getWeights() | 대상 기하학의 전체 무게 값을 가져옵니다. 전체 무게. |
+
+ **Result:**
+
+
+
+---
+
+
+### getChannelWeight{#getChannelWeight}
+
+| 이름 | 설명 |
+| --- | --- |
+| getChannelWeight() | 이 채널의 디포머 무게를 가져오거나 설정합니다. 무게는 0.0에서 1.0 사이입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setChannelWeight{#setChannelWeight}
+
+| 이름 | 설명 |
+| --- | --- |
+| setChannelWeight(value) | 이 채널의 디포머 무게를 가져오거나 설정합니다. 무게는 0.0에서 1.0 사이입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTargets{#getTargets}
+
+| 이름 | 설명 |
+| --- | --- |
+| getTargets() | 채널과 연결된 모든 타겟을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### get{#get}
+
+| 이름 | 설명 |
+| --- | --- |
+| get(target) |  |
+
+ **Result:**
+
+
+
+---
+
+
+### set{#set}
+
+| 이름 | 설명 |
+| --- | --- |
+| set(target, value) |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getWeight{#getWeight}
+
+| 이름 | 설명 |
+| --- | --- |
+| getWeight(target) | 지정된 대상의 무게를 가져옵니다. 대상이 이 채널에 속하지 않으면 기본값 0이 반환됩니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 대상 | 모양 | null |
+
+ **Result:**
+숫자
+
+
+---
+
+
+### setWeight{#setWeight}
+
+| 이름 | 설명 |
+| --- | --- |
+| setWeight(target, weight) | 지정된 대상의 무게를 설정합니다. 기본값은 1이며, 범위는 0~1 사이여야 합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 대상 | 모양 | null |
+| 무게 | 숫자 | null |
+
+ **Result:**
+숫자
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/morphtargetdeformer/_index.md
+++ b/korean/nodejs-java/aspose.threed/morphtargetdeformer/_index.md
@@ -1,0 +1,235 @@
+---
+title: "MorphTargetDeformer"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/morphtargetdeformer/
+---
+## MorphTargetDeformer class
+
+MorphTargetDeformer 는 정점별 애니메이션을 제공합니다.  MorphTargetDeformer 는 모든 대상을 MorphTargetChannel 을 통해 조직하며, 각 채널은 여러 대상을 조직할 수 있습니다.  morph target deformer 의 일반적인 사용 사례는 캐릭터에 얼굴 표정을 적용하는 것입니다.  자세한 내용은 https://en.wikipedia.org/wiki/Morph_target_animation 에서 확인할 수 있습니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor(name) | MorphTargetDeformer 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| name | String | 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload() | MorphTargetDeformer 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getChannels{#getChannels}
+
+| 이름 | 설명 |
+| --- | --- |
+| getChannels() | 이 디포머에 포함된 모든 채널을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getOwner{#getOwner}
+
+| 이름 | 설명 |
+| --- | --- |
+| getOwner() | 이 디포머를 소유하는 지오메트리를 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### get{#get}
+
+| 이름 | 설명 |
+| --- | --- |
+| get(target) |  |
+
+ **Result:**
+
+
+
+---
+
+
+### set{#set}
+
+| 이름 | 설명 |
+| --- | --- |
+| set(target, value) |  |
+
+ **Result:**
+
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/node/_index.md
+++ b/korean/nodejs-java/aspose.threed/node/_index.md
@@ -1,0 +1,739 @@
+---
+title: "Node"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/node/
+---
+## Node class
+
+씬 그래프의 요소를 나타냅니다. 씬 그래프는 Node 객체들의 트리 구조입니다. 트리 관리 서비스는 이 클래스에 자체적으로 포함되어 있습니다. Aspose.3D SDK 가 구성된 씬 그래프의 유효성을 검사하지 않음을 유의하십시오. 호출자는 노드 계층 구조에서 순환 그래프가 생성되지 않도록 책임을 져야 합니다. 트리 관리 외에도, 이 클래스는 씬 내 객체의 위치를 설명하는 데 필요한 모든 속성을 정의합니다. 이 정보에는 기본적인 Translation, Rotation, Scaling 속성뿐만 아니라 피벗, 제한, IK 조인트 속성(예: 강성 및 감쇠)과 같은 고급 옵션이 포함됩니다. 처음 생성될 때 Node 객체는 \"empty\"(즉, 그래픽 표현이 없고 위치 정보만 포함하는 객체) 상태입니다. 이 상태에서는 노드 트리 구조에서 부모를 나타내는 데 사용할 수 있지만 그 이상은 사용할 수 없습니다. 이러한 유형의 객체의 일반적인 사용 방법은 노드를 특화시킬 엔티티를 추가하는 것입니다(예: \"Entity\" 참조). 엔티티 자체가 객체이며 Node와 연결됩니다. 이는 동일한 엔티티를 여러 노드가 공유할 수 있음을 의미합니다. Camera, Light, Mesh 등은 모두 엔티티이며 모두 기본 클래스 Entity에서 파생됩니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | Node 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload(name, entity) | Node 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| name | String | 이름. |
+| entity | Entity | 기본 엔터티. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload2(name) | Node 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| name | String | 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAssetInfo{#getAssetInfo}
+
+| 이름 | 설명 |
+| --- | --- |
+| getAssetInfo() | 노드당 자산 정보 |
+
+ **Result:**
+
+
+
+---
+
+
+### setAssetInfo{#setAssetInfo}
+
+| 이름 | 설명 |
+| --- | --- |
+| setAssetInfo(value) | 노드당 자산 정보 |
+
+ **Result:**
+
+
+
+---
+
+
+### getVisible{#getVisible}
+
+| 이름 | 설명 |
+| --- | --- |
+| getVisible() | 노드를 표시하도록 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### setVisible{#setVisible}
+
+| 이름 | 설명 |
+| --- | --- |
+| setVisible(value) | 노드를 표시하도록 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getChildNodes{#getChildNodes}
+
+| 이름 | 설명 |
+| --- | --- |
+| getChildNodes() | 자식 노드를 가져옵니다. 노드들. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntity{#getEntity}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEntity() | 이 노드에 연결된 첫 번째 엔터티를 가져오거나 설정합니다. 설정할 경우 다른 엔터티가 모두 삭제됩니다. 노드 엔터티. |
+
+ **Result:**
+
+
+
+---
+
+
+### setEntity{#setEntity}
+
+| 이름 | 설명 |
+| --- | --- |
+| setEntity(value) | 이 노드에 연결된 첫 번째 엔터티를 가져오거나 설정합니다. 설정할 경우 다른 엔터티가 모두 삭제됩니다. 노드 엔터티. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExcluded() | 내보내기 중에 이 노드와 모든 자식 노드/엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExcluded(value) | 내보내기 중에 이 노드와 모든 자식 노드/엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntities{#getEntities}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEntities() | 모든 노드 엔터티를 가져옵니다. 노드 엔터티들. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMetaDatas{#getMetaDatas}
+
+| 이름 | 설명 |
+| --- | --- |
+| getMetaDatas() | 이 노드에 정의된 메타 데이터를 가져옵니다. 메타 데이터들. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMaterials{#getMaterials}
+
+| 이름 | 설명 |
+| --- | --- |
+| getMaterials() | 이 노드와 연결된 재료를 가져옵니다. 재료들. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMaterial{#getMaterial}
+
+| 이름 | 설명 |
+| --- | --- |
+| getMaterial() | 이 노드와 연결된 첫 번째 재료를 가져오거나 설정합니다. 설정할 경우 다른 재료가 모두 삭제됩니다. 재료. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMaterial{#setMaterial}
+
+| 이름 | 설명 |
+| --- | --- |
+| setMaterial(value) | 이 노드와 연결된 첫 번째 재료를 가져오거나 설정합니다. 설정할 경우 다른 재료가 모두 삭제됩니다. 재료. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNode() | 부모 노드를 가져오거나 설정합니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setParentNode(value) | 부모 노드를 가져오거나 설정합니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTransform{#getTransform}
+
+| 이름 | 설명 |
+| --- | --- |
+| getTransform() | 로컬 변환을 가져옵니다. 변환. |
+
+ **Result:**
+
+
+
+---
+
+
+### getGlobalTransform{#getGlobalTransform}
+
+| 이름 | 설명 |
+| --- | --- |
+| getGlobalTransform() | 글로벌 변환을 가져옵니다. 글로벌 변환. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 이름 | 설명 |
+| --- | --- |
+| getScene() | 이 객체가 속한 씬을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### createChildNode{#createChildNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| createChildNode() | 자식 노드를 생성합니다 |
+
+ **Result:**
+Node
+
+
+---
+
+
+### merge{#merge}
+
+| 이름 | 설명 |
+| --- | --- |
+| merge(node) | 노드 아래의 모든 것을 분리하고 현재 노드에 연결합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| nod | Node | null |
+
+ **Result:**
+Node
+
+
+---
+
+
+### createChildNode{#createChildNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| createChildNode(nodeName) | 지정된 노드 이름으로 새 자식 노드를 생성합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| nodeName | String | 새 자식 노드의 이름 |
+
+ **Result:**
+Node
+
+
+---
+
+
+### createChildNode{#createChildNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| createChildNode(entity) | 지정된 엔터티가 연결된 새 자식 노드를 생성합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| entity | Entity | 노드에 연결된 기본 엔터티 |
+
+ **Result:**
+Node
+
+
+---
+
+
+### createChildNode{#createChildNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| createChildNode(nodeName, entity) | 지정된 노드 이름으로 새 자식 노드를 생성합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| nodeName | String | 새 자식 노드의 이름 |
+| entity | Entity | 노드에 연결된 기본 엔터티 |
+
+ **Result:**
+Node
+
+
+---
+
+
+### createChildNode{#createChildNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| createChildNode(nodeName, entity, material) | 지정된 노드 이름으로 새 자식 노드를 생성하고, 지정된 엔터티와 재료를 연결합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| nodeName | String | 새 자식 노드의 이름 |
+| entity | Entity | 노드에 연결된 기본 엔터티 |
+| material | 재료 | 노드에 연결된 재료 |
+
+ **Result:**
+Node
+
+
+---
+
+
+### evaluateGlobalTransform{#evaluateGlobalTransform}
+
+| 이름 | 설명 |
+| --- | --- |
+| evaluateGlobalTransform(withGeometricTransform) | 글로벌 변환을 평가합니다. 기하학적 변환을 포함할지 여부. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| withGeometricTransform | boolean | 기하학적 변환이 필요한지 여부. |
+
+ **Result:**
+Matrix4
+
+
+---
+
+
+### getChild{#getChild}
+
+| 이름 | 설명 |
+| --- | --- |
+| getChild(index) | 지정된 인덱스에 있는 자식 노드를 가져옵니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 인덱스 | 숫자 | 인덱스. |
+
+ **Result:**
+Node
+
+
+---
+
+
+### getChild{#getChild}
+
+| 이름 | 설명 |
+| --- | --- |
+| getChild(nodeName) | 지정된 이름을 가진 자식 노드를 가져옵니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| nodeName | String | 찾을 자식 이름입니다. |
+
+ **Result:**
+Node
+
+
+---
+
+
+### accept{#accept}
+
+| 이름 | 설명 |
+| --- | --- |
+| accept(visitor) | 모든 하위 노드(현재 노드 포함)를 순회하며 노드와 함께 방문자를 호출합니다. 방문자는 false를 반환하여 순회를 중단할 수 있습니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| visitor | NodeVisitor | 노드를 방문하기 위한 Visitor 콜백 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### toString{#toString}
+
+| 이름 | 설명 |
+| --- | --- |
+| toString() | 이 노드의 문자열 표현을 가져옵니다. |
+
+ **Result:**
+String
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBoundingBox() | 노드의 경계 상자를 계산합니다. |
+
+ **Result:**
+BoundingBox
+
+
+---
+
+
+### addEntity{#addEntity}
+
+| 이름 | 설명 |
+| --- | --- |
+| addEntity(entity) | 노드에 엔터티를 추가합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| entity | Entity | 노드에 첨부될 엔터티입니다. |
+
+ **Result:**
+BoundingBox
+
+
+---
+
+
+### addChildNode{#addChildNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| addChildNode(node) | 이 노드에 자식 노드를 추가합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| node | Node | 첨부될 자식 노드입니다. |
+
+ **Result:**
+BoundingBox
+
+
+---
+
+
+### selectSingleObject{#selectSingleObject}
+
+| 이름 | 설명 |
+| --- | --- |
+| selectSingleObject(path) | XPath와 유사한 쿼리 구문을 사용하여 현재 노드 아래의 단일 객체를 선택합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| pat | String | null |
+
+ **Result:**
+Object
+
+
+---
+
+
+### selectObjects{#selectObjects}
+
+| 이름 | 설명 |
+| --- | --- |
+| selectObjects(path) | XPath와 유사한 쿼리 구문을 사용하여 현재 노드 아래의 여러 객체를 선택합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| pat | String | null |
+
+ **Result:**
+0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/nurbscurve/_index.md
+++ b/korean/nodejs-java/aspose.threed/nurbscurve/_index.md
@@ -1,0 +1,494 @@
+---
+title: "NurbsCurve"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/nurbscurve/
+---
+## NurbsCurve class
+
+NURBS 곡선은 NURBS(Non-uniform rational basis spline) 로 표현되는 곡선이며, NURBS 곡선은 Order, 가중치가 적용된 Geometry.ControlPoints 집합 및 KnotVectors 로 정의됩니다. 컨트롤 포인트의 w 구성 요소는 해당 포인트의 가중치로 사용되며, CurveDimension.TWO_DIMENSIONAL 이든 CurveDimension.THREE_DIMENSIONAL 이든 동일합니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | NurbsCurve 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload(name) | NurbsCurve 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| name | String | 이름 |
+
+ **Result:**
+
+
+
+---
+
+
+### getControlPoints{#getControlPoints}
+
+| 이름 | 설명 |
+| --- | --- |
+| getControlPoints() | 모든 제어점을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMultiplicity{#getMultiplicity}
+
+| 이름 | 설명 |
+| --- | --- |
+| getMultiplicity() | 중복성을 가져옵니다. 중복성입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getOrder{#getOrder}
+
+| 이름 | 설명 |
+| --- | --- |
+| getOrder() | NURBS 곡선의 차수를 가져오거나 설정합니다. 차수는 곡선상의 임의의 점에 영향을 주는 인접 제어점의 수를 정의합니다. 차수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setOrder{#setOrder}
+
+| 이름 | 설명 |
+| --- | --- |
+| setOrder(value) | NURBS 곡선의 차수를 가져오거나 설정합니다. 차수는 곡선상의 임의의 점에 영향을 주는 인접 제어점의 수를 정의합니다. 차수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDimension{#getDimension}
+
+| 이름 | 설명 |
+| --- | --- |
+| getDimension() | 곡선의 차원을 가져오거나 설정합니다. 이 속성의 값은 CurveDimension 정수 상수입니다. CurveDimension.TWO_DIMENSIONAL 곡선의 경우, 제어점의 z 구성 요소는 사용되지 않습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDimension{#setDimension}
+
+| 이름 | 설명 |
+| --- | --- |
+| setDimension(value) | 곡선의 차원을 가져오거나 설정합니다. 이 속성의 값은 CurveDimension 정수 상수입니다. CurveDimension.TWO_DIMENSIONAL 곡선의 경우, 제어점의 z 구성 요소는 사용되지 않습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getCurveType{#getCurveType}
+
+| 이름 | 설명 |
+| --- | --- |
+| getCurveType() | 곡선의 유형을 가져오거나 설정합니다. 속성 값은 NurbsType 정수 상수입니다. 곡선의 유형. |
+
+ **Result:**
+
+
+
+---
+
+
+### setCurveType{#setCurveType}
+
+| 이름 | 설명 |
+| --- | --- |
+| setCurveType(value) | 곡선의 유형을 가져오거나 설정합니다. 속성 값은 NurbsType 정수 상수입니다. 곡선의 유형. |
+
+ **Result:**
+
+
+
+---
+
+
+### getKnotVectors{#getKnotVectors}
+
+| 이름 | 설명 |
+| --- | --- |
+| getKnotVectors() | 노트 벡터를 가져옵니다. 이는 매개변수 값들의 시퀀스로, 제어점이 NURBS 곡선에 영향을 주는 위치와 방식을 결정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getRational{#getRational}
+
+| 이름 | 설명 |
+| --- | --- |
+| getRational() | 합리적인지 여부를 가져오거나 설정합니다. 이 값은 NurbsCurve가 유리 스플라인인지 비유리 스플라인인지를 나타냅니다. 비유리 B-스플라인은 유리 B-스플라인의 특수한 경우입니다. 유리 스플라인이면 true; 그렇지 않으면 비유리 스플라인은 false. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRational{#setRational}
+
+| 이름 | 설명 |
+| --- | --- |
+| setRational(value) | 합리적인지 여부를 가져오거나 설정합니다. 이 값은 NurbsCurve가 유리 스플라인인지 비유리 스플라인인지를 나타냅니다. 비유리 B-스플라인은 유리 B-스플라인의 특수한 경우입니다. 유리 스플라인이면 true; 그렇지 않으면 비유리 스플라인은 false. |
+
+ **Result:**
+
+
+
+---
+
+
+### getColor{#getColor}
+
+| 이름 | 설명 |
+| --- | --- |
+| getColor() | 선의 색상을 가져오거나 설정합니다. 기본값은 흰색(1, 1, 1)입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setColor{#setColor}
+
+| 이름 | 설명 |
+| --- | --- |
+| setColor(value) | 선의 색상을 가져오거나 설정합니다. 기본값은 흰색(1, 1, 1)입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNodes() | 모든 부모 노드를 가져옵니다. 엔터티는 기하학 인스턴싱을 위해 여러 부모 노드에 부착될 수 있습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExcluded() | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExcluded(value) | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNode() | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setParentNode(value) | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 이름 | 설명 |
+| --- | --- |
+| getScene() | 이 객체가 속한 씬을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### evaluate{#evaluate}
+
+| 이름 | 설명 |
+| --- | --- |
+| evaluate(steps) | NURBS 곡선을 평가합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 단계 | 숫자 | 두 인접 노트 사이의 평가 빈도, 기본값은 20입니다. |
+
+ **Result:**
+Vector4[]
+
+
+---
+
+
+### evaluateAt{#evaluateAt}
+
+| 이름 | 설명 |
+| --- | --- |
+| evaluateAt(u) | 지정된 위치에서 곡선의 점을 평가합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| u | 숫자 | 곡선 내 위치, 0과 1 사이 |
+
+ **Result:**
+Vector4
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEntityRendererKey() | 렌더러에 등록된 엔터티 렌더러의 키를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBoundingBox() | 현재 엔터티의 객체 공간 좌표계에서 경계 상자를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/nurbsdirection/_index.md
+++ b/korean/nodejs-java/aspose.threed/nurbsdirection/_index.md
@@ -1,0 +1,159 @@
+---
+title: "NurbsDirection"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/nurbsdirection/
+---
+## NurbsDirection class
+
+3D NurbsSurface는 두 방향, 즉 NurbsSurface.U와 NurbsSurface.V를 가지고 있으며, NurbsDirection은 각 방향에 대한 데이터를 정의합니다. 방향은 실제로 NURBS 곡선이며, 따라서 Order, KnotVectors 및 가중치가 적용된 컨트롤 포인트 집합( NurbsSurface 에 정의됨) 으로도 정의됩니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getKnotVectors{#getKnotVectors}
+
+| 이름 | 설명 |
+| --- | --- |
+| getKnotVectors() | 노트 벡터를 가져옵니다. 이는 매개변수 값들의 시퀀스로, 제어점이 NURBS 곡선에 영향을 주는 위치와 방식을 결정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMultiplicity{#getMultiplicity}
+
+| 이름 | 설명 |
+| --- | --- |
+| getMultiplicity() | 중복성을 가져옵니다. 중복성입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getOrder{#getOrder}
+
+| 이름 | 설명 |
+| --- | --- |
+| getOrder() | NURBS 곡선의 차수를 가져오거나 설정합니다. 이는 곡선상의 임의의 점에 영향을 주는 인접 제어점의 수를 정의합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setOrder{#setOrder}
+
+| 이름 | 설명 |
+| --- | --- |
+| setOrder(value) | NURBS 곡선의 차수를 가져오거나 설정합니다. 이는 곡선상의 임의의 점에 영향을 주는 인접 제어점의 수를 정의합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDivisions{#getDivisions}
+
+| 이름 | 설명 |
+| --- | --- |
+| getDivisions() | 현재 방향에서 인접 제어점 사이의 분할 수를 가져오거나 설정합니다. 단계. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDivisions{#setDivisions}
+
+| 이름 | 설명 |
+| --- | --- |
+| setDivisions(value) | 현재 방향에서 인접 제어점 사이의 분할 수를 가져오거나 설정합니다. 단계. |
+
+ **Result:**
+
+
+
+---
+
+
+### getType{#getType}
+
+| 이름 | 설명 |
+| --- | --- |
+| getType() | 현재 방향의 유형을 가져오거나 설정합니다. 속성 값은 NurbsType 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setType{#setType}
+
+| 이름 | 설명 |
+| --- | --- |
+| setType(value) | 현재 방향의 유형을 가져오거나 설정합니다. 속성 값은 NurbsType 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getCount{#getCount}
+
+| 이름 | 설명 |
+| --- | --- |
+| getCount() | 현재 방향의 제어점 수를 가져오거나 설정합니다. 개수. |
+
+ **Result:**
+
+
+
+---
+
+
+### setCount{#setCount}
+
+| 이름 | 설명 |
+| --- | --- |
+| setCount(value) | 현재 방향의 제어점 수를 가져오거나 설정합니다. 개수. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/nurbssurface/_index.md
+++ b/korean/nodejs-java/aspose.threed/nurbssurface/_index.md
@@ -1,0 +1,580 @@
+---
+title: "NurbsSurface"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/nurbssurface/
+---
+## NurbsSurface class
+
+NurbsSurface는 NURBS(Non-uniform rational basis spline) 로 표현되는 서피스이며, NurbsSurface는 두 개의 NurbsDirectionU와 V 로 정의됩니다. 컨트롤 포인트의 w 구성 요소는 해당 포인트의 가중치로 사용되며, 방향의 유형이 CurveDimension.TWO_DIMENSIONAL 이든 CurveDimension.THREE_DIMENSIONAL 이든 관계없이 적용됩니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | NurbsSurface 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload(name) | NurbsSurface 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| name | String | 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getU{#getU}
+
+| 이름 | 설명 |
+| --- | --- |
+| getU() | NURBS 표면의 U 방향을 가져옵니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getV{#getV}
+
+| 이름 | 설명 |
+| --- | --- |
+| getV() | NURBS 표면의 V 방향을 가져옵니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getVisible{#getVisible}
+
+| 이름 | 설명 |
+| --- | --- |
+| getVisible() | 지오메트리가 보이는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setVisible{#setVisible}
+
+| 이름 | 설명 |
+| --- | --- |
+| setVisible(value) | 지오메트리가 보이는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDeformers{#getDeformers}
+
+| 이름 | 설명 |
+| --- | --- |
+| getDeformers() | 이 지오메트리와 연결된 모든 디포머를 가져옵니다. 디포머. |
+
+ **Result:**
+
+
+
+---
+
+
+### getControlPoints{#getControlPoints}
+
+| 이름 | 설명 |
+| --- | --- |
+| getControlPoints() | 모든 제어점을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastShadows{#getCastShadows}
+
+| 이름 | 설명 |
+| --- | --- |
+| getCastShadows() | 이 지오메트리가 그림자를 드리울 수 있는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastShadows{#setCastShadows}
+
+| 이름 | 설명 |
+| --- | --- |
+| setCastShadows(value) | 이 지오메트리가 그림자를 드리울 수 있는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReceiveShadows{#getReceiveShadows}
+
+| 이름 | 설명 |
+| --- | --- |
+| getReceiveShadows() | 이 지오메트리가 그림자를 받을 수 있는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReceiveShadows{#setReceiveShadows}
+
+| 이름 | 설명 |
+| --- | --- |
+| setReceiveShadows(value) | 이 지오메트리가 그림자를 받을 수 있는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElements{#getVertexElements}
+
+| 이름 | 설명 |
+| --- | --- |
+| getVertexElements() | 모든 정점 요소를 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNodes() | 모든 부모 노드를 가져옵니다. 엔터티는 기하학 인스턴싱을 위해 여러 부모 노드에 부착될 수 있습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExcluded() | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExcluded(value) | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNode() | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setParentNode(value) | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 이름 | 설명 |
+| --- | --- |
+| getScene() | 이 객체가 속한 씬을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### toMesh{#toMesh}
+
+| 이름 | 설명 |
+| --- | --- |
+| toMesh() | NURBS 표면을 메시로 변환합니다 |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getElement{#getElement}
+
+| 이름 | 설명 |
+| --- | --- |
+| getElement(type) | 지정된 타입의 정점 요소를 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| type | VertexElementType | VertexElementType |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### getVertexElementOfUV{#getVertexElementOfUV}
+
+| 이름 | 설명 |
+| --- | --- |
+| getVertexElementOfUV(textureMapping) | 주어진 텍스처 매핑 타입으로 VertexElementUV 인스턴스를 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| textureMapping | TextureMapping | TextureMapping |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### createElement{#createElement}
+
+| 이름 | 설명 |
+| --- | --- |
+| createElement(type) | 지정된 타입의 정점 요소를 생성하고 이를 지오메트리에 추가합니다. 타입이 VertexElementType.UV인 경우, TextureMapping.DIFFUSE 타입의 텍스처 매핑을 가진 VertexElementUV가 생성됩니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| type | VertexElementType | VertexElementType |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### addElement{#addElement}
+
+| 이름 | 설명 |
+| --- | --- |
+| addElement(element) | 기존 정점 요소를 현재 지오메트리에 추가합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| element | VertexElement | 추가할 정점 요소 |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### createElement{#createElement}
+
+| 이름 | 설명 |
+| --- | --- |
+| createElement(type, mappingMode, referenceMode) | 지정된 타입의 정점 요소를 생성하고 이를 지오메트리에 추가합니다. 타입이 VertexElementType.UV인 경우, TextureMapping.DIFFUSE 타입의 텍스처 매핑을 가진 VertexElementUV가 생성됩니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| type | VertexElementType | VertexElementType |
+| mappingMode | MappingMode | MappingMode |
+| referenceMode | ReferenceMode | ReferenceMode |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### createElementUV{#createElementUV}
+
+| 이름 | 설명 |
+| --- | --- |
+| createElementUV(uvMapping) | 주어진 텍스처 매핑 유형으로 VertexElementUV를 생성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| uvMapping | TextureMapping | TextureMapping |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### createElementUV{#createElementUV}
+
+| 이름 | 설명 |
+| --- | --- |
+| createElementUV(uvMapping, mappingMode, referenceMode) | 주어진 텍스처 매핑 유형으로 VertexElementUV를 생성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| uvMapping | TextureMapping | TextureMapping |
+| mappingMode | MappingMode | MappingMode |
+| referenceMode | ReferenceMode | ReferenceMode |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBoundingBox() | 현재 엔터티의 객체 공간 좌표계에서 경계 상자를 가져옵니다. |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEntityRendererKey() | 렌더러에 등록된 엔터티 렌더러의 키를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/objloadoptions/_index.md
+++ b/korean/nodejs-java/aspose.threed/objloadoptions/_index.md
@@ -1,0 +1,224 @@
+---
+title: "ObjLoadOptions"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/objloadoptions/
+---
+## ObjLoadOptions class
+
+Wavefront OBJ 로드 옵션
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | ObjLoadOptions의 생성자 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlipCoordinateSystem{#getFlipCoordinateSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFlipCoordinateSystem() | 가져오거나 설정하여 제어점/법선의 좌표계 반전을 수행할지 여부를 지정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlipCoordinateSystem{#setFlipCoordinateSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFlipCoordinateSystem(value) | 가져오거나 설정하여 제어점/법선의 좌표계 반전을 수행할지 여부를 지정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEnableMaterials{#getEnableMaterials}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEnableMaterials() | 각 객체에 대한 재료를 가져올지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setEnableMaterials{#setEnableMaterials}
+
+| 이름 | 설명 |
+| --- | --- |
+| setEnableMaterials(value) | 각 객체에 대한 재료를 가져올지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScale{#getScale}
+
+| 이름 | 설명 |
+| --- | --- |
+| getScale() | x/y/z 축에 대한 스케일이며, 기본값은 1.0입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setScale{#setScale}
+
+| 이름 | 설명 |
+| --- | --- |
+| setScale(value) | x/y/z 축에 대한 스케일이며, 기본값은 1.0입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getNormalizeNormal{#getNormalizeNormal}
+
+| 이름 | 설명 |
+| --- | --- |
+| getNormalizeNormal() | 로드 중에 법선 벡터를 정규화할지 여부를 가져오거나 설정합니다. 기본값은 true입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setNormalizeNormal{#setNormalizeNormal}
+
+| 이름 | 설명 |
+| --- | --- |
+| setNormalizeNormal(value) | 로드 중에 법선 벡터를 정규화할지 여부를 가져오거나 설정합니다. 기본값은 true입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileFormat() | 현재 저장/로드 옵션에 지정된 파일 형식을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEncoding() | 텍스트 기반 파일에 대한 기본 인코딩을 가져오거나 설정합니다. 기본값은 null이며, 이는 가져오기/내보내기 프로그램이 사용할 인코딩을 결정함을 의미합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileSystem() | 로드/저장 중 외부 종속성을 관리하는 방법을 사용자가 처리하도록 허용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFileSystem(value) | 로드/저장 중 외부 종속성을 관리하는 방법을 사용자가 처리하도록 허용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| 이름 | 설명 |
+| --- | --- |
+| getLookupPaths() | OBJ와 같은 일부 파일은 외부 파일에 의존하며, 조회 경로를 통해 Aspose.3D가 외부 파일을 찾아 로드할 수 있도록 합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileName() | 내보내기/가져오기 씬의 파일 이름입니다. 선택 사항이지만 OBJ의 재질과 같은 외부 자산을 직렬화할 때 유용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFileName(value) | 내보내기/가져오기 씬의 파일 이름입니다. 선택 사항이지만 OBJ의 재질과 같은 외부 자산을 직렬화할 때 유용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/objsaveoptions/_index.md
+++ b/korean/nodejs-java/aspose.threed/objsaveoptions/_index.md
@@ -1,0 +1,302 @@
+---
+title: "ObjSaveOptions"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/objsaveoptions/
+---
+## ObjSaveOptions class
+
+Wavefront OBJ 파일 저장 옵션
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | ObjSaveOptions의 생성자 |
+
+ **Result:**
+
+
+
+---
+
+
+### getApplyUnitScale{#getApplyUnitScale}
+
+| 이름 | 설명 |
+| --- | --- |
+| getApplyUnitScale() | AssetInfo.UnitScaleFactor를 메시에 적용합니다. 기본값은 false입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setApplyUnitScale{#setApplyUnitScale}
+
+| 이름 | 설명 |
+| --- | --- |
+| setApplyUnitScale(value) | AssetInfo.UnitScaleFactor를 메시에 적용합니다. 기본값은 false입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getPointCloud{#getPointCloud}
+
+| 이름 | 설명 |
+| --- | --- |
+| getPointCloud() | 내보내기가 장면을 위상 구조 없이 포인트 클라우드로 내보내야 하는지 여부를 나타내는 플래그를 가져오거나 설정합니다, 기본값은 false |
+
+ **Result:**
+
+
+
+---
+
+
+### setPointCloud{#setPointCloud}
+
+| 이름 | 설명 |
+| --- | --- |
+| setPointCloud(value) | 내보내기가 장면을 위상 구조 없이 포인트 클라우드로 내보내야 하는지 여부를 나타내는 플래그를 가져오거나 설정합니다, 기본값은 false |
+
+ **Result:**
+
+
+
+---
+
+
+### getVerbose{#getVerbose}
+
+| 이름 | 설명 |
+| --- | --- |
+| getVerbose() | 각 섹션에 대한 주석을 생성할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setVerbose{#setVerbose}
+
+| 이름 | 설명 |
+| --- | --- |
+| setVerbose(value) | 각 섹션에 대한 주석을 생성할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getSerializeW{#getSerializeW}
+
+| 이름 | 설명 |
+| --- | --- |
+| getSerializeW() | 모델의 정점 위치에서 W 구성 요소를 직렬화할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setSerializeW{#setSerializeW}
+
+| 이름 | 설명 |
+| --- | --- |
+| setSerializeW(value) | 모델의 정점 위치에서 W 구성 요소를 직렬화할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEnableMaterials{#getEnableMaterials}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEnableMaterials() | 각 객체에 대한 재료를 가져오거나 내보낼지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setEnableMaterials{#setEnableMaterials}
+
+| 이름 | 설명 |
+| --- | --- |
+| setEnableMaterials(value) | 각 객체에 대한 재료를 가져오거나 내보낼지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlipCoordinateSystem{#getFlipCoordinateSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFlipCoordinateSystem() | 가져오기/내보내기 중에 제어점/법선의 좌표계 반전 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlipCoordinateSystem{#setFlipCoordinateSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFlipCoordinateSystem(value) | 가져오기/내보내기 중에 제어점/법선의 좌표계 반전 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportTextures{#getExportTextures}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExportTextures() | 씬에서 사용된 텍스처를 출력 디렉터리로 복사합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextures{#setExportTextures}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExportTextures(value) | 씬에서 사용된 텍스처를 출력 디렉터리로 복사합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileFormat() | 현재 저장/로드 옵션에 지정된 파일 형식을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEncoding() | 텍스트 기반 파일에 대한 기본 인코딩을 가져오거나 설정합니다. 기본값은 null이며, 이는 가져오기/내보내기 프로그램이 사용할 인코딩을 결정함을 의미합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileSystem() | 로드/저장 중 외부 종속성을 관리하는 방법을 사용자가 처리하도록 허용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFileSystem(value) | 로드/저장 중 외부 종속성을 관리하는 방법을 사용자가 처리하도록 허용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| 이름 | 설명 |
+| --- | --- |
+| getLookupPaths() | OBJ와 같은 일부 파일은 외부 파일에 의존하며, 조회 경로를 통해 Aspose.3D가 외부 파일을 찾아 로드할 수 있도록 합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileName() | 내보내기/가져오기 씬의 파일 이름입니다. 선택 사항이지만 OBJ의 재질과 같은 외부 자산을 직렬화할 때 유용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFileName(value) | 내보내기/가져오기 씬의 파일 이름입니다. 선택 사항이지만 OBJ의 재질과 같은 외부 자산을 직렬화할 때 유용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/parameterizedprofile/_index.md
+++ b/korean/nodejs-java/aspose.threed/parameterizedprofile/_index.md
@@ -1,0 +1,268 @@
+---
+title: "ParameterizedProfile"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/parameterizedprofile/
+---
+## ParameterizedProfile class
+
+모든 매개변수화된 프로파일의 기본 클래스.  @hideconstructor
+
+
+## 메서드
+
+### getParentNodes{#getParentNodes}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNodes() | 모든 부모 노드를 가져옵니다. 엔터티는 기하학 인스턴싱을 위해 여러 부모 노드에 부착될 수 있습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExcluded() | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExcluded(value) | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNode() | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setParentNode(value) | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 이름 | 설명 |
+| --- | --- |
+| getScene() | 이 객체가 속한 씬을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtent{#getExtent}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExtent() | x 및 y 차원에서의 범위를 가져옵니다. |
+
+ **Result:**
+Vector2
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEntityRendererKey() | 렌더러에 등록된 엔터티 렌더러의 키를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBoundingBox() | 현재 엔터티의 객체 공간 좌표계에서 경계 상자를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/parseexception/_index.md
+++ b/korean/nodejs-java/aspose.threed/parseexception/_index.md
@@ -1,0 +1,35 @@
+---
+title: "ParseException"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/parseexception/
+---
+## ParseException class
+
+Aspose.3D 가 입력을 파싱하지 못했을 때 발생하는 예외.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor(msg) | ParseException의 생성자 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| ms | String | null |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/patch/_index.md
+++ b/korean/nodejs-java/aspose.threed/patch/_index.md
@@ -1,0 +1,567 @@
+---
+title: "Patch"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/patch/
+---
+## Patch class
+
+Patch는 매개변수 모델링 표면으로, NurbsSurface와 유사하며, 두 개의 PatchDirection, U와 V에 의해 정의됩니다. 그러나 Patch와 NurbsSurface의 차이점은 PatchDirection 곡선이 PatchDirectionType.BEZIER, PatchDirectionType.QUADRATIC_BEZIER, PatchDirectionType.BASIS_SPLINE, PatchDirectionType.CARDINAL_SPLINE 및 PatchDirectionType.LINEAR 중 하나가 될 수 있다는 것입니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | Patch 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload(name) | Patch 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| name | String | 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getU{#getU}
+
+| 이름 | 설명 |
+| --- | --- |
+| getU() | u 방향을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getV{#getV}
+
+| 이름 | 설명 |
+| --- | --- |
+| getV() | v 방향을 가져옵니다. 그 v. |
+
+ **Result:**
+
+
+
+---
+
+
+### getVisible{#getVisible}
+
+| 이름 | 설명 |
+| --- | --- |
+| getVisible() | 지오메트리가 보이는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setVisible{#setVisible}
+
+| 이름 | 설명 |
+| --- | --- |
+| setVisible(value) | 지오메트리가 보이는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDeformers{#getDeformers}
+
+| 이름 | 설명 |
+| --- | --- |
+| getDeformers() | 이 지오메트리와 연결된 모든 디포머를 가져옵니다. 디포머. |
+
+ **Result:**
+
+
+
+---
+
+
+### getControlPoints{#getControlPoints}
+
+| 이름 | 설명 |
+| --- | --- |
+| getControlPoints() | 모든 제어점을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastShadows{#getCastShadows}
+
+| 이름 | 설명 |
+| --- | --- |
+| getCastShadows() | 이 지오메트리가 그림자를 드리울 수 있는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastShadows{#setCastShadows}
+
+| 이름 | 설명 |
+| --- | --- |
+| setCastShadows(value) | 이 지오메트리가 그림자를 드리울 수 있는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReceiveShadows{#getReceiveShadows}
+
+| 이름 | 설명 |
+| --- | --- |
+| getReceiveShadows() | 이 지오메트리가 그림자를 받을 수 있는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReceiveShadows{#setReceiveShadows}
+
+| 이름 | 설명 |
+| --- | --- |
+| setReceiveShadows(value) | 이 지오메트리가 그림자를 받을 수 있는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElements{#getVertexElements}
+
+| 이름 | 설명 |
+| --- | --- |
+| getVertexElements() | 모든 정점 요소를 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNodes() | 모든 부모 노드를 가져옵니다. 엔터티는 기하학 인스턴싱을 위해 여러 부모 노드에 부착될 수 있습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExcluded() | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExcluded(value) | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNode() | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setParentNode(value) | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 이름 | 설명 |
+| --- | --- |
+| getScene() | 이 객체가 속한 씬을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getElement{#getElement}
+
+| 이름 | 설명 |
+| --- | --- |
+| getElement(type) | 지정된 타입의 정점 요소를 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| type | VertexElementType | VertexElementType |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### getVertexElementOfUV{#getVertexElementOfUV}
+
+| 이름 | 설명 |
+| --- | --- |
+| getVertexElementOfUV(textureMapping) | 주어진 텍스처 매핑 타입으로 VertexElementUV 인스턴스를 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| textureMapping | TextureMapping | TextureMapping |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### createElement{#createElement}
+
+| 이름 | 설명 |
+| --- | --- |
+| createElement(type) | 지정된 타입의 정점 요소를 생성하고 이를 지오메트리에 추가합니다. 타입이 VertexElementType.UV인 경우, TextureMapping.DIFFUSE 타입의 텍스처 매핑을 가진 VertexElementUV가 생성됩니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| type | VertexElementType | VertexElementType |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### addElement{#addElement}
+
+| 이름 | 설명 |
+| --- | --- |
+| addElement(element) | 기존 정점 요소를 현재 지오메트리에 추가합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| element | VertexElement | 추가할 정점 요소 |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### createElement{#createElement}
+
+| 이름 | 설명 |
+| --- | --- |
+| createElement(type, mappingMode, referenceMode) | 지정된 타입의 정점 요소를 생성하고 이를 지오메트리에 추가합니다. 타입이 VertexElementType.UV인 경우, TextureMapping.DIFFUSE 타입의 텍스처 매핑을 가진 VertexElementUV가 생성됩니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| type | VertexElementType | VertexElementType |
+| mappingMode | MappingMode | MappingMode |
+| referenceMode | ReferenceMode | ReferenceMode |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### createElementUV{#createElementUV}
+
+| 이름 | 설명 |
+| --- | --- |
+| createElementUV(uvMapping) | 주어진 텍스처 매핑 유형으로 VertexElementUV를 생성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| uvMapping | TextureMapping | TextureMapping |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### createElementUV{#createElementUV}
+
+| 이름 | 설명 |
+| --- | --- |
+| createElementUV(uvMapping, mappingMode, referenceMode) | 주어진 텍스처 매핑 유형으로 VertexElementUV를 생성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| uvMapping | TextureMapping | TextureMapping |
+| mappingMode | MappingMode | MappingMode |
+| referenceMode | ReferenceMode | ReferenceMode |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBoundingBox() | 현재 엔터티의 객체 공간 좌표계에서 경계 상자를 가져옵니다. |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEntityRendererKey() | 렌더러에 등록된 엔터티 렌더러의 키를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/patchdirection/_index.md
+++ b/korean/nodejs-java/aspose.threed/patchdirection/_index.md
@@ -1,0 +1,133 @@
+---
+title: "PatchDirection"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/patchdirection/
+---
+## PatchDirection class
+
+Patch의 U 및 V 방향.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getType{#getType}
+
+| 이름 | 설명 |
+| --- | --- |
+| getType() | 패치의 유형을 가져오거나 설정합니다. 속성 값은 PatchDirectionType 정수 상수이며, 유형을 나타냅니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setType{#setType}
+
+| 이름 | 설명 |
+| --- | --- |
+| setType(value) | 패치의 유형을 가져오거나 설정합니다. 속성 값은 PatchDirectionType 정수 상수이며, 유형을 나타냅니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDivisions{#getDivisions}
+
+| 이름 | 설명 |
+| --- | --- |
+| getDivisions() | 인접한 제어점 사이의 구분 수를 가져오거나 설정합니다. 단계. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDivisions{#setDivisions}
+
+| 이름 | 설명 |
+| --- | --- |
+| setDivisions(value) | 인접한 제어점 사이의 구분 수를 가져오거나 설정합니다. 단계. |
+
+ **Result:**
+
+
+
+---
+
+
+### getControlPoints{#getControlPoints}
+
+| 이름 | 설명 |
+| --- | --- |
+| getControlPoints() | 현재 방향의 제어점 수를 가져오거나 설정합니다. 개수. |
+
+ **Result:**
+
+
+
+---
+
+
+### setControlPoints{#setControlPoints}
+
+| 이름 | 설명 |
+| --- | --- |
+| setControlPoints(value) | 현재 방향의 제어점 수를 가져오거나 설정합니다. 개수. |
+
+ **Result:**
+
+
+
+---
+
+
+### getClosed{#getClosed}
+
+| 이름 | 설명 |
+| --- | --- |
+| getClosed() | 이 PatchDirection이 폐곡선인지 여부를 나타내는 값을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setClosed{#setClosed}
+
+| 이름 | 설명 |
+| --- | --- |
+| setClosed(value) | 이 PatchDirection이 폐곡선인지 여부를 나타내는 값을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/pbrmaterial/_index.md
+++ b/korean/nodejs-java/aspose.threed/pbrmaterial/_index.md
@@ -1,0 +1,579 @@
+---
+title: "PbrMaterial"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/pbrmaterial/
+---
+## PbrMaterial class
+
+알베도 색상/메탈릭/거칠기를 기반으로 하는 물리 기반 렌더링용 Material
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | 기본 PBR 재료 인스턴스를 생성합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload(albedo) | 지정된 알베도 색상 값을 사용하여 기본 PBR 재료를 생성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| albedo | Vector3 | 기본 알베도 색상 값 |
+
+ **Result:**
+
+
+
+---
+
+
+### getTransparency{#getTransparency}
+
+| 이름 | 설명 |
+| --- | --- |
+| getTransparency() | 투명도 계수를 가져오거나 설정합니다. 계수는 0(0%, 완전 불투명)과 1(100%, 완전 투명) 사이여야 합니다. 잘못된 계수 값은 클램프됩니다. 투명도 계수. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTransparency{#setTransparency}
+
+| 이름 | 설명 |
+| --- | --- |
+| setTransparency(value) | 투명도 계수를 가져오거나 설정합니다. 계수는 0(0%, 완전 불투명)과 1(100%, 완전 투명) 사이여야 합니다. 잘못된 계수 값은 클램프됩니다. 투명도 계수. |
+
+ **Result:**
+
+
+
+---
+
+
+### getNormalTexture{#getNormalTexture}
+
+| 이름 | 설명 |
+| --- | --- |
+| getNormalTexture() | 노멀 매핑 텍스처를 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### setNormalTexture{#setNormalTexture}
+
+| 이름 | 설명 |
+| --- | --- |
+| setNormalTexture(value) | 노멀 매핑 텍스처를 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getSpecularTexture{#getSpecularTexture}
+
+| 이름 | 설명 |
+| --- | --- |
+| getSpecularTexture() | 반사 색상의 텍스처를 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### setSpecularTexture{#setSpecularTexture}
+
+| 이름 | 설명 |
+| --- | --- |
+| setSpecularTexture(value) | 반사 색상의 텍스처를 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getAlbedoTexture{#getAlbedoTexture}
+
+| 이름 | 설명 |
+| --- | --- |
+| getAlbedoTexture() | 알베도 텍스처를 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### setAlbedoTexture{#setAlbedoTexture}
+
+| 이름 | 설명 |
+| --- | --- |
+| setAlbedoTexture(value) | 알베도 텍스처를 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getAlbedo{#getAlbedo}
+
+| 이름 | 설명 |
+| --- | --- |
+| getAlbedo() | 재료의 기본 색상을 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### setAlbedo{#setAlbedo}
+
+| 이름 | 설명 |
+| --- | --- |
+| setAlbedo(value) | 재료의 기본 색상을 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getOcclusionTexture{#getOcclusionTexture}
+
+| 이름 | 설명 |
+| --- | --- |
+| getOcclusionTexture() | 앰비언트 오클루전 텍스처를 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### setOcclusionTexture{#setOcclusionTexture}
+
+| 이름 | 설명 |
+| --- | --- |
+| setOcclusionTexture(value) | 앰비언트 오클루전 텍스처를 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getOcclusionFactor{#getOcclusionFactor}
+
+| 이름 | 설명 |
+| --- | --- |
+| getOcclusionFactor() | 앰비언트 오클루전 계수를 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### setOcclusionFactor{#setOcclusionFactor}
+
+| 이름 | 설명 |
+| --- | --- |
+| setOcclusionFactor(value) | 앰비언트 오클루전 계수를 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getMetallicFactor{#getMetallicFactor}
+
+| 이름 | 설명 |
+| --- | --- |
+| getMetallicFactor() | 재료의 금속성을 가져오거나 설정합니다. 값이 1이면 재료가 금속이며, 값이 0이면 재료가 유전체임을 의미합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMetallicFactor{#setMetallicFactor}
+
+| 이름 | 설명 |
+| --- | --- |
+| setMetallicFactor(value) | 재료의 금속성을 가져오거나 설정합니다. 값이 1이면 재료가 금속이며, 값이 0이면 재료가 유전체임을 의미합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getRoughnessFactor{#getRoughnessFactor}
+
+| 이름 | 설명 |
+| --- | --- |
+| getRoughnessFactor() | 재료의 거칠기를 가져오거나 설정합니다. 값이 1이면 재료가 완전히 거칠고, 값이 0이면 재료가 완전히 매끄럽습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRoughnessFactor{#setRoughnessFactor}
+
+| 이름 | 설명 |
+| --- | --- |
+| setRoughnessFactor(value) | 재료의 거칠기를 가져오거나 설정합니다. 값이 1이면 재료가 완전히 거칠고, 값이 0이면 재료가 완전히 매끄럽습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMetallicRoughness{#getMetallicRoughness}
+
+| 이름 | 설명 |
+| --- | --- |
+| getMetallicRoughness() | 금속성(빨간색 채널) 및 거칠기(녹색 채널) 텍스처를 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### setMetallicRoughness{#setMetallicRoughness}
+
+| 이름 | 설명 |
+| --- | --- |
+| setMetallicRoughness(value) | 금속성(빨간색 채널) 및 거칠기(녹색 채널) 텍스처를 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEmissiveTexture{#getEmissiveTexture}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEmissiveTexture() | 에미시브 텍스처를 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### setEmissiveTexture{#setEmissiveTexture}
+
+| 이름 | 설명 |
+| --- | --- |
+| setEmissiveTexture(value) | 에미시브 텍스처를 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEmissiveColor{#getEmissiveColor}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEmissiveColor() | 방출 색상을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setEmissiveColor{#setEmissiveColor}
+
+| 이름 | 설명 |
+| --- | --- |
+| setEmissiveColor(value) | 방출 색상을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### fromMaterial{#fromMaterial}
+
+| 이름 | 설명 |
+| --- | --- |
+| fromMaterial(material) | 다른 재료를 PbrMaterial로 변환하도록 허용합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 재료 | 재료 | null |
+
+ **Result:**
+PbrMaterial
+
+
+---
+
+
+### getTexture{#getTexture}
+
+| 이름 | 설명 |
+| --- | --- |
+| getTexture(slotName) | 지정된 슬롯에서 텍스처를 가져옵니다. 이는 재질의 속성 이름이거나 셰이더의 매개변수 이름일 수 있습니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| slotName | String | 슬롯 이름. |
+
+ **Result:**
+TextureBase
+
+
+---
+
+
+### setTexture{#setTexture}
+
+| 이름 | 설명 |
+| --- | --- |
+| setTexture(slotName, texture) | 지정된 슬롯에 텍스처를 설정합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| slotName | String | 슬롯 이름. |
+| texture | TextureBase | 텍스처. |
+
+ **Result:**
+TextureBase
+
+
+---
+
+
+### toString{#toString}
+
+| 이름 | 설명 |
+| --- | --- |
+| toString() | 객체를 문자열로 포맷합니다. |
+
+ **Result:**
+String
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+### iterator{#iterator}
+
+| 이름 | 설명 |
+| --- | --- |
+| iterator() | 내부 사용을 위해 예약되었습니다. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/pbrspecularmaterial/_index.md
+++ b/korean/nodejs-java/aspose.threed/pbrspecularmaterial/_index.md
@@ -1,0 +1,469 @@
+---
+title: "PbrSpecularMaterial"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/pbrspecularmaterial/
+---
+## PbrSpecularMaterial class
+
+확산 색상/스페큘러/광택을 기반으로 하는 물리 기반 렌더링용 Material
+
+
+## Properties
+
+| 이름 | 설명 |
+| --- | --- |
+| MAP_SPECULAR_GLOSSINESS | 반사광택을 위한 텍스처 맵 |
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | PbrSpecularMaterial의 생성자 |
+
+ **Result:**
+
+
+
+---
+
+
+### getTransparency{#getTransparency}
+
+| 이름 | 설명 |
+| --- | --- |
+| getTransparency() | 투명도 계수를 가져오거나 설정합니다. 계수는 0(0%, 완전 불투명)과 1(100%, 완전 투명) 사이여야 합니다. 잘못된 계수 값은 클램프됩니다. 투명도 계수. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTransparency{#setTransparency}
+
+| 이름 | 설명 |
+| --- | --- |
+| setTransparency(value) | 투명도 계수를 가져오거나 설정합니다. 계수는 0(0%, 완전 불투명)과 1(100%, 완전 투명) 사이여야 합니다. 잘못된 계수 값은 클램프됩니다. 투명도 계수. |
+
+ **Result:**
+
+
+
+---
+
+
+### getNormalTexture{#getNormalTexture}
+
+| 이름 | 설명 |
+| --- | --- |
+| getNormalTexture() | 노멀 매핑 텍스처를 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### setNormalTexture{#setNormalTexture}
+
+| 이름 | 설명 |
+| --- | --- |
+| setNormalTexture(value) | 노멀 매핑 텍스처를 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getSpecularGlossinessTexture{#getSpecularGlossinessTexture}
+
+| 이름 | 설명 |
+| --- | --- |
+| getSpecularGlossinessTexture() | 반사 색상의 텍스처를 가져오거나 설정합니다. RGB 채널은 반사 색상을 저장하고 A 채널은 광택을 저장합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setSpecularGlossinessTexture{#setSpecularGlossinessTexture}
+
+| 이름 | 설명 |
+| --- | --- |
+| setSpecularGlossinessTexture(value) | 반사 색상의 텍스처를 가져오거나 설정합니다. RGB 채널은 반사 색상을 저장하고 A 채널은 광택을 저장합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getGlossinessFactor{#getGlossinessFactor}
+
+| 이름 | 설명 |
+| --- | --- |
+| getGlossinessFactor() | 재질의 광택(매끄러움)을 가져오거나 설정합니다. 1은 완전히 매끄럽고 0은 완전히 거친 것을 의미합니다. 기본값은 1이며 범위는 [0, 1]입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setGlossinessFactor{#setGlossinessFactor}
+
+| 이름 | 설명 |
+| --- | --- |
+| setGlossinessFactor(value) | 재질의 광택(매끄러움)을 가져오거나 설정합니다. 1은 완전히 매끄럽고 0은 완전히 거친 것을 의미합니다. 기본값은 1이며 범위는 [0, 1]입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getSpecular{#getSpecular}
+
+| 이름 | 설명 |
+| --- | --- |
+| getSpecular() | 재질의 반사 색상을 가져오거나 설정합니다. 기본값은 (1, 1, 1)입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setSpecular{#setSpecular}
+
+| 이름 | 설명 |
+| --- | --- |
+| setSpecular(value) | 재질의 반사 색상을 가져오거나 설정합니다. 기본값은 (1, 1, 1)입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDiffuseTexture{#getDiffuseTexture}
+
+| 이름 | 설명 |
+| --- | --- |
+| getDiffuseTexture() | 디퓨즈 텍스처를 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### setDiffuseTexture{#setDiffuseTexture}
+
+| 이름 | 설명 |
+| --- | --- |
+| setDiffuseTexture(value) | 디퓨즈 텍스처를 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getDiffuse{#getDiffuse}
+
+| 이름 | 설명 |
+| --- | --- |
+| getDiffuse() | 재질의 디퓨즈 색상을 가져오거나 설정합니다. 기본값은 (1, 1, 1)입니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### setDiffuse{#setDiffuse}
+
+| 이름 | 설명 |
+| --- | --- |
+| setDiffuse(value) | 재질의 디퓨즈 색상을 가져오거나 설정합니다. 기본값은 (1, 1, 1)입니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEmissiveTexture{#getEmissiveTexture}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEmissiveTexture() | 에미시브 텍스처를 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### setEmissiveTexture{#setEmissiveTexture}
+
+| 이름 | 설명 |
+| --- | --- |
+| setEmissiveTexture(value) | 에미시브 텍스처를 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEmissiveColor{#getEmissiveColor}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEmissiveColor() | 에미시브 색상을 가져오거나 설정합니다. 기본값은 (0, 0, 0)입니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### setEmissiveColor{#setEmissiveColor}
+
+| 이름 | 설명 |
+| --- | --- |
+| setEmissiveColor(value) | 에미시브 색상을 가져오거나 설정합니다. 기본값은 (0, 0, 0)입니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTexture{#getTexture}
+
+| 이름 | 설명 |
+| --- | --- |
+| getTexture(slotName) | 지정된 슬롯에서 텍스처를 가져옵니다. 이는 재질의 속성 이름이거나 셰이더의 매개변수 이름일 수 있습니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| slotName | String | 슬롯 이름. |
+
+ **Result:**
+TextureBase
+
+
+---
+
+
+### setTexture{#setTexture}
+
+| 이름 | 설명 |
+| --- | --- |
+| setTexture(slotName, texture) | 지정된 슬롯에 텍스처를 설정합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| slotName | String | 슬롯 이름. |
+| texture | TextureBase | 텍스처. |
+
+ **Result:**
+TextureBase
+
+
+---
+
+
+### toString{#toString}
+
+| 이름 | 설명 |
+| --- | --- |
+| toString() | 객체를 문자열로 포맷합니다. |
+
+ **Result:**
+String
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+### iterator{#iterator}
+
+| 이름 | 설명 |
+| --- | --- |
+| iterator() | 내부 사용을 위해 예약되었습니다. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/pdfformat/_index.md
+++ b/korean/nodejs-java/aspose.threed/pdfformat/_index.md
@@ -1,0 +1,179 @@
+---
+title: "PdfFormat"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/pdfformat/
+---
+## PdfFormat class
+
+Adobe의 Portable Document Format  @hideconstructor
+
+
+## 메서드
+
+### getVersion{#getVersion}
+
+| 이름 | 설명 |
+| --- | --- |
+| getVersion() | 파일 형식 버전을 가져옵니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtension{#getExtension}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExtension() | 이 유형의 확장자 이름을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtensions{#getExtensions}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExtensions() | 이 유형의 확장자 이름들을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getContentType{#getContentType}
+
+| 이름 | 설명 |
+| --- | --- |
+| getContentType() | 파일 형식 콘텐츠 유형을 가져옵니다. 속성 값은 FileContentType 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormatType{#getFileFormatType}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileFormatType() | 파일 형식 유형을 가져옵니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### extract{#extract}
+
+| 이름 | 설명 |
+| --- | --- |
+| extract(fileName, password) | PDF 파일에서 원시 3D 콘텐츠를 추출합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| fileNam | String | null |
+| 비밀번호 | byte[] | null |
+
+ **Result:**
+0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]
+
+
+---
+
+
+### extractScene{#extractScene}
+
+| 이름 | 설명 |
+| --- | --- |
+| extractScene(fileName) | PDF 파일에서 3D 씬을 추출합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| fileNam | String | null |
+
+ **Result:**
+0, Culture=neutral, PublicKeyToken=f071c641d0b4582b]]
+
+
+---
+
+
+### extractScene{#extractScene}
+
+| 이름 | 설명 |
+| --- | --- |
+| extractScene(fileName, password) | PDF 파일에서 3D 씬을 추출합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| fileNam | String | null |
+| 비밀번호 | byte[] | null |
+
+ **Result:**
+0, Culture=neutral, PublicKeyToken=f071c641d0b4582b]]
+
+
+---
+
+
+### createLoadOptions{#createLoadOptions}
+
+| 이름 | 설명 |
+| --- | --- |
+| createLoadOptions() | 이 파일 형식에 대한 기본 로드 옵션을 생성합니다. |
+
+ **Result:**
+LoadOptions
+
+
+---
+
+
+### createSaveOptions{#createSaveOptions}
+
+| 이름 | 설명 |
+| --- | --- |
+| createSaveOptions() | 이 파일 형식에 대한 기본 저장 옵션을 생성합니다. |
+
+ **Result:**
+SaveOptions
+
+
+---
+
+
+### toString{#toString}
+
+| 이름 | 설명 |
+| --- | --- |
+| toString() | 형식을 문자열로 변환 |
+
+ **Result:**
+String
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/pdfloadoptions/_index.md
+++ b/korean/nodejs-java/aspose.threed/pdfloadoptions/_index.md
@@ -1,0 +1,146 @@
+---
+title: "PdfLoadOptions"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/pdfloadoptions/
+---
+## PdfLoadOptions class
+
+PDF 로딩 옵션
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | PdfLoadOptions의 생성자 |
+
+ **Result:**
+
+
+
+---
+
+
+### getPassword{#getPassword}
+
+| 이름 | 설명 |
+| --- | --- |
+| getPassword() | 암호화된 PDF 파일을 해제하기 위한 비밀번호. |
+
+ **Result:**
+
+
+
+---
+
+
+### setPassword{#setPassword}
+
+| 이름 | 설명 |
+| --- | --- |
+| setPassword(value) | 암호화된 PDF 파일을 해제하기 위한 비밀번호. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileFormat() | 현재 저장/로드 옵션에 지정된 파일 형식을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEncoding() | 텍스트 기반 파일에 대한 기본 인코딩을 가져오거나 설정합니다. 기본값은 null이며, 이는 가져오기/내보내기 프로그램이 사용할 인코딩을 결정함을 의미합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileSystem() | 로드/저장 중 외부 종속성을 관리하는 방법을 사용자가 처리하도록 허용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFileSystem(value) | 로드/저장 중 외부 종속성을 관리하는 방법을 사용자가 처리하도록 허용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| 이름 | 설명 |
+| --- | --- |
+| getLookupPaths() | OBJ와 같은 일부 파일은 외부 파일에 의존하며, 조회 경로를 통해 Aspose.3D가 외부 파일을 찾아 로드할 수 있도록 합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileName() | 내보내기/가져오기 씬의 파일 이름입니다. 선택 사항이지만 OBJ의 재질과 같은 외부 자산을 직렬화할 때 유용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFileName(value) | 내보내기/가져오기 씬의 파일 이름입니다. 선택 사항이지만 OBJ의 재질과 같은 외부 자산을 직렬화할 때 유용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/pdfsaveoptions/_index.md
+++ b/korean/nodejs-java/aspose.threed/pdfsaveoptions/_index.md
@@ -1,0 +1,328 @@
+---
+title: "PdfSaveOptions"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/pdfsaveoptions/
+---
+## PdfSaveOptions class
+
+PDF 내보내기 시 저장 옵션.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | PdfSaveOptions의 생성자 |
+
+ **Result:**
+
+
+
+---
+
+
+### getRenderMode{#getRenderMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getRenderMode() | 렌더 모드는 3D 아트워크가 렌더링되는 스타일을 지정합니다. 속성 값은 PdfRenderMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRenderMode{#setRenderMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setRenderMode(value) | 렌더 모드는 3D 아트워크가 렌더링되는 스타일을 지정합니다. 속성 값은 PdfRenderMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLightingScheme{#getLightingScheme}
+
+| 이름 | 설명 |
+| --- | --- |
+| getLightingScheme() | LightingScheme은 3D 아트워크에 적용할 조명을 지정합니다. 속성 값은 PdfLightingScheme 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setLightingScheme{#setLightingScheme}
+
+| 이름 | 설명 |
+| --- | --- |
+| setLightingScheme(value) | LightingScheme은 3D 아트워크에 적용할 조명을 지정합니다. 속성 값은 PdfLightingScheme 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getBackgroundColor{#getBackgroundColor}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBackgroundColor() | PDF 파일의 3D 뷰 배경 색상. |
+
+ **Result:**
+
+
+
+---
+
+
+### setBackgroundColor{#setBackgroundColor}
+
+| 이름 | 설명 |
+| --- | --- |
+| setBackgroundColor(value) | PDF 파일의 3D 뷰 배경 색상. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFaceColor{#getFaceColor}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFaceColor() | 3D 콘텐츠를 렌더링할 때 사용할 면 색상을 가져오거나 설정합니다. 이는 RenderMode가 Illustration 값일 때만 적용됩니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFaceColor{#setFaceColor}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFaceColor(value) | 3D 콘텐츠를 렌더링할 때 사용할 면 색상을 가져오거나 설정합니다. 이는 RenderMode가 Illustration 값일 때만 적용됩니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAuxiliaryColor{#getAuxiliaryColor}
+
+| 이름 | 설명 |
+| --- | --- |
+| getAuxiliaryColor() | 3D 콘텐츠를 렌더링할 때 사용할 보조 색상을 가져오거나 설정합니다. 이 색상의 해석은 RenderMode에 따라 달라집니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setAuxiliaryColor{#setAuxiliaryColor}
+
+| 이름 | 설명 |
+| --- | --- |
+| setAuxiliaryColor(value) | 3D 콘텐츠를 렌더링할 때 사용할 보조 색상을 가져오거나 설정합니다. 이 색상의 해석은 RenderMode에 따라 달라집니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlipCoordinateSystem{#getFlipCoordinateSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFlipCoordinateSystem() | 내보내는 동안 씬의 좌표계를 뒤집는지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlipCoordinateSystem{#setFlipCoordinateSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFlipCoordinateSystem(value) | 내보내는 동안 씬의 좌표계를 뒤집는지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEmbedTextures{#getEmbedTextures}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEmbedTextures() | 외부 텍스처를 PDF 파일에 삽입합니다. 기본값은 false입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setEmbedTextures{#setEmbedTextures}
+
+| 이름 | 설명 |
+| --- | --- |
+| setEmbedTextures(value) | 외부 텍스처를 PDF 파일에 삽입합니다. 기본값은 false입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportTextures{#getExportTextures}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExportTextures() | 씬에서 사용된 텍스처를 출력 디렉터리로 복사합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextures{#setExportTextures}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExportTextures(value) | 씬에서 사용된 텍스처를 출력 디렉터리로 복사합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileFormat() | 현재 저장/로드 옵션에 지정된 파일 형식을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEncoding() | 텍스트 기반 파일에 대한 기본 인코딩을 가져오거나 설정합니다. 기본값은 null이며, 이는 가져오기/내보내기 프로그램이 사용할 인코딩을 결정함을 의미합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileSystem() | 로드/저장 중 외부 종속성을 관리하는 방법을 사용자가 처리하도록 허용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFileSystem(value) | 로드/저장 중 외부 종속성을 관리하는 방법을 사용자가 처리하도록 허용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| 이름 | 설명 |
+| --- | --- |
+| getLookupPaths() | OBJ와 같은 일부 파일은 외부 파일에 의존하며, 조회 경로를 통해 Aspose.3D가 외부 파일을 찾아 로드할 수 있도록 합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileName() | 내보내기/가져오기 씬의 파일 이름입니다. 선택 사항이지만 OBJ의 재질과 같은 외부 자산을 직렬화할 때 유용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFileName(value) | 내보내기/가져오기 씬의 파일 이름입니다. 선택 사항이지만 OBJ의 재질과 같은 외부 자산을 직렬화할 때 유용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/phongmaterial/_index.md
+++ b/korean/nodejs-java/aspose.threed/phongmaterial/_index.md
@@ -1,0 +1,508 @@
+---
+title: "PhongMaterial"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/phongmaterial/
+---
+## PhongMaterial class
+
+blinn-phong 셰이딩 모델용 Material.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | PhongMaterial 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload(name) | PhongMaterial 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| name | String | 이름 |
+
+ **Result:**
+
+
+
+---
+
+
+### getSpecularColor{#getSpecularColor}
+
+| 이름 | 설명 |
+| --- | --- |
+| getSpecularColor() | 반사광 색상을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setSpecularColor{#setSpecularColor}
+
+| 이름 | 설명 |
+| --- | --- |
+| setSpecularColor(value) | 반사광 색상을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getSpecularFactor{#getSpecularFactor}
+
+| 이름 | 설명 |
+| --- | --- |
+| getSpecularFactor() | 반사광 계수를 가져오거나 설정합니다. 반사광 공식: SpecularColor SpecularFactor (N dot H) ^ Shininess |
+
+ **Result:**
+
+
+
+---
+
+
+### setSpecularFactor{#setSpecularFactor}
+
+| 이름 | 설명 |
+| --- | --- |
+| setSpecularFactor(value) | 반사광 계수를 가져오거나 설정합니다. 반사광 공식: SpecularColor SpecularFactor (N dot H) ^ Shininess |
+
+ **Result:**
+
+
+
+---
+
+
+### getShininess{#getShininess}
+
+| 이름 | 설명 |
+| --- | --- |
+| getShininess() | 광택도를 가져오거나 설정합니다. 이는 반사광 하이라이트의 크기를 제어합니다. 반사광 공식: SpecularColor SpecularFactor (N dot H) ^ Shininess 광택도. |
+
+ **Result:**
+
+
+
+---
+
+
+### setShininess{#setShininess}
+
+| 이름 | 설명 |
+| --- | --- |
+| setShininess(value) | 광택도를 가져오거나 설정합니다. 이는 반사광 하이라이트의 크기를 제어합니다. 반사광 공식: SpecularColor SpecularFactor (N dot H) ^ Shininess 광택도. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReflectionColor{#getReflectionColor}
+
+| 이름 | 설명 |
+| --- | --- |
+| getReflectionColor() | 반사 색상을 가져오거나 설정합니다. 반사. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReflectionColor{#setReflectionColor}
+
+| 이름 | 설명 |
+| --- | --- |
+| setReflectionColor(value) | 반사 색상을 가져오거나 설정합니다. 반사. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReflectionFactor{#getReflectionFactor}
+
+| 이름 | 설명 |
+| --- | --- |
+| getReflectionFactor() | 반사 색상의 감쇠를 가져오거나 설정합니다. 반사 계수. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReflectionFactor{#setReflectionFactor}
+
+| 이름 | 설명 |
+| --- | --- |
+| setReflectionFactor(value) | 반사 색상의 감쇠를 가져오거나 설정합니다. 반사 계수. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEmissiveColor{#getEmissiveColor}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEmissiveColor() | 방출 색상을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setEmissiveColor{#setEmissiveColor}
+
+| 이름 | 설명 |
+| --- | --- |
+| setEmissiveColor(value) | 방출 색상을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAmbientColor{#getAmbientColor}
+
+| 이름 | 설명 |
+| --- | --- |
+| getAmbientColor() | 주변 색상을 가져오거나 설정합니다. 예시: var mat = new LambertMaterial(); mat.AmbientColor = new Vector3(1, 1, 1); ambient. |
+
+ **Result:**
+
+
+
+---
+
+
+### setAmbientColor{#setAmbientColor}
+
+| 이름 | 설명 |
+| --- | --- |
+| setAmbientColor(value) | 주변 색상을 가져오거나 설정합니다. 예시: var mat = new LambertMaterial(); mat.AmbientColor = new Vector3(1, 1, 1); ambient. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDiffuseColor{#getDiffuseColor}
+
+| 이름 | 설명 |
+| --- | --- |
+| getDiffuseColor() | 확산 색상을 가져오거나 설정합니다. 예시: var mat = new LambertMaterial(); mat.DiffuseColor = new Vector3(1, 0, 0); 확산. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDiffuseColor{#setDiffuseColor}
+
+| 이름 | 설명 |
+| --- | --- |
+| setDiffuseColor(value) | 확산 색상을 가져오거나 설정합니다. 예시: var mat = new LambertMaterial(); mat.DiffuseColor = new Vector3(1, 0, 0); 확산. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTransparentColor{#getTransparentColor}
+
+| 이름 | 설명 |
+| --- | --- |
+| getTransparentColor() | 투명 색상을 가져오거나 설정합니다. 예시: var mat = new LambertMaterial(); mat.TransparentColor = new Vector3(0.3, 0.5, 0.2); 투명 색상. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTransparentColor{#setTransparentColor}
+
+| 이름 | 설명 |
+| --- | --- |
+| setTransparentColor(value) | 투명 색상을 가져오거나 설정합니다. 예시: var mat = new LambertMaterial(); mat.TransparentColor = new Vector3(0.3, 0.5, 0.2); 투명 색상. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTransparency{#getTransparency}
+
+| 이름 | 설명 |
+| --- | --- |
+| getTransparency() | 투명도 계수를 가져오거나 설정합니다. 이 계수는 0(0%, 완전 불투명)과 1(100%, 완전 투명) 사이여야 합니다. 잘못된 계수 값은 클램프됩니다. 예시: var mat = new LambertMaterial(); mat.Transparency = 0.3; 투명도 계수. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTransparency{#setTransparency}
+
+| 이름 | 설명 |
+| --- | --- |
+| setTransparency(value) | 투명도 계수를 가져오거나 설정합니다. 이 계수는 0(0%, 완전 불투명)과 1(100%, 완전 투명) 사이여야 합니다. 잘못된 계수 값은 클램프됩니다. 예시: var mat = new LambertMaterial(); mat.Transparency = 0.3; 투명도 계수. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTexture{#getTexture}
+
+| 이름 | 설명 |
+| --- | --- |
+| getTexture(slotName) | 지정된 슬롯에서 텍스처를 가져옵니다. 이는 재질의 속성 이름이거나 셰이더의 매개변수 이름일 수 있습니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| slotName | String | 슬롯 이름. |
+
+ **Result:**
+TextureBase
+
+
+---
+
+
+### setTexture{#setTexture}
+
+| 이름 | 설명 |
+| --- | --- |
+| setTexture(slotName, texture) | 지정된 슬롯에 텍스처를 설정합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| slotName | String | 슬롯 이름. |
+| texture | TextureBase | 텍스처. |
+
+ **Result:**
+TextureBase
+
+
+---
+
+
+### toString{#toString}
+
+| 이름 | 설명 |
+| --- | --- |
+| toString() | 객체를 문자열로 포맷합니다. |
+
+ **Result:**
+String
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+### iterator{#iterator}
+
+| 이름 | 설명 |
+| --- | --- |
+| iterator() | 내부 사용을 위해 예약되었습니다. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/pixelmapping/_index.md
+++ b/korean/nodejs-java/aspose.threed/pixelmapping/_index.md
@@ -1,0 +1,68 @@
+---
+title: "PixelMapping"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/pixelmapping/
+---
+## PixelMapping class
+
+@hideconstructor
+
+
+## 메서드
+
+### getStride{#getStride}
+
+| 이름 | 설명 |
+| --- | --- |
+| getStride() | 한 행의 픽셀 바이트. |
+
+ **Result:**
+
+
+
+---
+
+
+### getHeight{#getHeight}
+
+| 이름 | 설명 |
+| --- | --- |
+| getHeight() | 픽셀의 행 |
+
+ **Result:**
+
+
+
+---
+
+
+### getWidth{#getWidth}
+
+| 이름 | 설명 |
+| --- | --- |
+| getWidth() | 픽셀의 열 |
+
+ **Result:**
+
+
+
+---
+
+
+### getData{#getData}
+
+| 이름 | 설명 |
+| --- | --- |
+| getData() | 맵핑된 픽셀 바이트. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/plane/_index.md
+++ b/korean/nodejs-java/aspose.threed/plane/_index.md
@@ -1,0 +1,506 @@
+---
+title: "Plane"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/plane/
+---
+## Plane class
+
+매개변수화된 평면.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | Plane의 새 인스턴스를 기본 크기 1x1로 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload(length, width) | Plane의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 길이 | 숫자 | 평면의 길이. |
+| 너비 | 숫자 | 평면의 너비. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload2(name, length, width, lengthSegments, widthSegments) | Plane의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| name | String | 이름. |
+| 길이 | 숫자 | 평면의 길이. |
+| 너비 | 숫자 | 평면의 너비. |
+| lengthSegments | 숫자 | 길이 세그먼트. |
+| widthSegments | 숫자 | 너비 세그먼트. |
+
+ **Result:**
+
+
+
+---
+
+
+### getUp{#getUp}
+
+| 이름 | 설명 |
+| --- | --- |
+| getUp() | 평면의 up 벡터를 가져오거나 설정합니다. 기본값은 (0, 1, 0)이며, 이는 평면 생성에 영향을 줍니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setUp{#setUp}
+
+| 이름 | 설명 |
+| --- | --- |
+| setUp(value) | 평면의 up 벡터를 가져오거나 설정합니다. 기본값은 (0, 1, 0)이며, 이는 평면 생성에 영향을 줍니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLength{#getLength}
+
+| 이름 | 설명 |
+| --- | --- |
+| getLength() | 평면의 길이를 가져오거나 설정합니다. 길이. |
+
+ **Result:**
+
+
+
+---
+
+
+### setLength{#setLength}
+
+| 이름 | 설명 |
+| --- | --- |
+| setLength(value) | 평면의 길이를 가져오거나 설정합니다. 길이. |
+
+ **Result:**
+
+
+
+---
+
+
+### getWidth{#getWidth}
+
+| 이름 | 설명 |
+| --- | --- |
+| getWidth() | 평면의 너비를 가져오거나 설정합니다. 너비. |
+
+ **Result:**
+
+
+
+---
+
+
+### setWidth{#setWidth}
+
+| 이름 | 설명 |
+| --- | --- |
+| setWidth(value) | 평면의 너비를 가져오거나 설정합니다. 너비. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLengthSegments{#getLengthSegments}
+
+| 이름 | 설명 |
+| --- | --- |
+| getLengthSegments() | 길이 세그먼트를 가져오거나 설정합니다. 길이 세그먼트. |
+
+ **Result:**
+
+
+
+---
+
+
+### setLengthSegments{#setLengthSegments}
+
+| 이름 | 설명 |
+| --- | --- |
+| setLengthSegments(value) | 길이 세그먼트를 가져오거나 설정합니다. 길이 세그먼트. |
+
+ **Result:**
+
+
+
+---
+
+
+### getWidthSegments{#getWidthSegments}
+
+| 이름 | 설명 |
+| --- | --- |
+| getWidthSegments() | 너비 세그먼트를 가져오거나 설정합니다. 너비 세그먼트. |
+
+ **Result:**
+
+
+
+---
+
+
+### setWidthSegments{#setWidthSegments}
+
+| 이름 | 설명 |
+| --- | --- |
+| setWidthSegments(value) | 너비 세그먼트를 가져오거나 설정합니다. 너비 세그먼트. |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastShadows{#getCastShadows}
+
+| 이름 | 설명 |
+| --- | --- |
+| getCastShadows() | 이 지오메트리가 그림자를 드리울 수 있는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastShadows{#setCastShadows}
+
+| 이름 | 설명 |
+| --- | --- |
+| setCastShadows(value) | 이 지오메트리가 그림자를 드리울 수 있는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReceiveShadows{#getReceiveShadows}
+
+| 이름 | 설명 |
+| --- | --- |
+| getReceiveShadows() | 이 지오메트리가 그림자를 받을 수 있는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReceiveShadows{#setReceiveShadows}
+
+| 이름 | 설명 |
+| --- | --- |
+| setReceiveShadows(value) | 이 지오메트리가 그림자를 받을 수 있는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNodes() | 모든 부모 노드를 가져옵니다. 엔터티는 기하학 인스턴싱을 위해 여러 부모 노드에 부착될 수 있습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExcluded() | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExcluded(value) | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNode() | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setParentNode(value) | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 이름 | 설명 |
+| --- | --- |
+| getScene() | 이 객체가 속한 씬을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### toMesh{#toMesh}
+
+| 이름 | 설명 |
+| --- | --- |
+| toMesh() | 현재 객체를 메시로 변환합니다 |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBoundingBox() | 현재 엔터티의 객체 공간 좌표계에서 경계 상자를 가져옵니다. |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEntityRendererKey() | 렌더러에 등록된 엔터티 렌더러의 키를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/plyformat/_index.md
+++ b/korean/nodejs-java/aspose.threed/plyformat/_index.md
@@ -1,0 +1,200 @@
+---
+title: "PlyFormat"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/plyformat/
+---
+## PlyFormat class
+
+PLY 형식.  @hideconstructor
+
+
+## 메서드
+
+### getVersion{#getVersion}
+
+| 이름 | 설명 |
+| --- | --- |
+| getVersion() | 파일 형식 버전을 가져옵니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtension{#getExtension}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExtension() | 이 유형의 확장자 이름을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtensions{#getExtensions}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExtensions() | 이 유형의 확장자 이름들을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getContentType{#getContentType}
+
+| 이름 | 설명 |
+| --- | --- |
+| getContentType() | 파일 형식 콘텐츠 유형을 가져옵니다. 속성 값은 FileContentType 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormatType{#getFileFormatType}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileFormatType() | 파일 형식 유형을 가져옵니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### encode{#encode}
+
+| 이름 | 설명 |
+| --- | --- |
+| encode(entity, fileName) | 엔티티를 인코딩하고 결과를 외부 파일에 저장합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| entity | Entity | 인코딩할 엔티티 |
+| fileName | String | 작성할 파일 |
+
+ **Result:**
+
+
+
+---
+
+
+### encode{#encode}
+
+| 이름 | 설명 |
+| --- | --- |
+| encode(entity, fileName, opt) | 엔티티를 인코딩하고 결과를 외부 파일에 저장합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| entity | Entity | 인코딩할 엔티티 |
+| fileName | String | 작성할 파일 |
+| opt | PlySaveOptions | 저장 옵션 |
+
+ **Result:**
+
+
+
+---
+
+
+### decode{#decode}
+
+| 이름 | 설명 |
+| --- | --- |
+| decode(fileName) | 지정된 스트림에서 포인트 클라우드 또는 메쉬를 디코딩합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| fileName | String | 입력 스트림 |
+
+ **Result:**
+Geometry
+
+
+---
+
+
+### decode{#decode}
+
+| 이름 | 설명 |
+| --- | --- |
+| decode(fileName, opt) | 지정된 스트림에서 포인트 클라우드 또는 메쉬를 디코딩합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| fileName | String | 입력 스트림 |
+| opt | PlyLoadOptions | PLY 형식의 로드 옵션 |
+
+ **Result:**
+Geometry
+
+
+---
+
+
+### createLoadOptions{#createLoadOptions}
+
+| 이름 | 설명 |
+| --- | --- |
+| createLoadOptions() | 이 파일 형식에 대한 기본 로드 옵션을 생성합니다. |
+
+ **Result:**
+LoadOptions
+
+
+---
+
+
+### createSaveOptions{#createSaveOptions}
+
+| 이름 | 설명 |
+| --- | --- |
+| createSaveOptions() | 이 파일 형식에 대한 기본 저장 옵션을 생성합니다. |
+
+ **Result:**
+SaveOptions
+
+
+---
+
+
+### toString{#toString}
+
+| 이름 | 설명 |
+| --- | --- |
+| toString() | 형식을 문자열로 변환 |
+
+ **Result:**
+String
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/plyloadoptions/_index.md
+++ b/korean/nodejs-java/aspose.threed/plyloadoptions/_index.md
@@ -1,0 +1,146 @@
+---
+title: "PlyLoadOptions"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/plyloadoptions/
+---
+## PlyLoadOptions class
+
+PLY 파일 로드 옵션
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | PlyLoadOptions의 생성자 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlipCoordinateSystem{#getFlipCoordinateSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFlipCoordinateSystem() | 가져오거나 설정합니다 제어점/법선의 플립 좌표계를 가져오기/내보내기 중에. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlipCoordinateSystem{#setFlipCoordinateSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFlipCoordinateSystem(value) | 가져오거나 설정합니다 제어점/법선의 플립 좌표계를 가져오기/내보내기 중에. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileFormat() | 현재 저장/로드 옵션에 지정된 파일 형식을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEncoding() | 텍스트 기반 파일에 대한 기본 인코딩을 가져오거나 설정합니다. 기본값은 null이며, 이는 가져오기/내보내기 프로그램이 사용할 인코딩을 결정함을 의미합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileSystem() | 로드/저장 중 외부 종속성을 관리하는 방법을 사용자가 처리하도록 허용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFileSystem(value) | 로드/저장 중 외부 종속성을 관리하는 방법을 사용자가 처리하도록 허용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| 이름 | 설명 |
+| --- | --- |
+| getLookupPaths() | OBJ와 같은 일부 파일은 외부 파일에 의존하며, 조회 경로를 통해 Aspose.3D가 외부 파일을 찾아 로드할 수 있도록 합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileName() | 내보내기/가져오기 씬의 파일 이름입니다. 선택 사항이지만 OBJ의 재질과 같은 외부 자산을 직렬화할 때 유용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFileName(value) | 내보내기/가져오기 씬의 파일 이름입니다. 선택 사항이지만 OBJ의 재질과 같은 외부 자산을 직렬화할 때 유용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/plysaveoptions/_index.md
+++ b/korean/nodejs-java/aspose.threed/plysaveoptions/_index.md
@@ -1,0 +1,347 @@
+---
+title: "PlySaveOptions"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/plysaveoptions/
+---
+## PlySaveOptions class
+
+씬을 PLY 파일로 내보내기 위한 저장 옵션.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | PlySaveOptions의 생성자 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload(contentType) | PlySaveOptions의 생성자 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| contentType | FileContentType | FileContentType |
+
+ **Result:**
+
+
+
+---
+
+
+### getPointCloud{#getPointCloud}
+
+| 이름 | 설명 |
+| --- | --- |
+| getPointCloud() | 씬을 포인트 클라우드로 내보냅니다. 기본값은 false입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setPointCloud{#setPointCloud}
+
+| 이름 | 설명 |
+| --- | --- |
+| setPointCloud(value) | 씬을 포인트 클라우드로 내보냅니다. 기본값은 false입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlipCoordinate{#getFlipCoordinate}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFlipCoordinate() | 씬을 저장하는 동안 좌표를 뒤집습니다. 기본값은 true입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlipCoordinate{#setFlipCoordinate}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFlipCoordinate(value) | 씬을 저장하는 동안 좌표를 뒤집습니다. 기본값은 true입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElement{#getVertexElement}
+
+| 이름 | 설명 |
+| --- | --- |
+| getVertexElement() | 정점 데이터의 요소 이름이며, 기본값은 "vertex"입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setVertexElement{#setVertexElement}
+
+| 이름 | 설명 |
+| --- | --- |
+| setVertexElement(value) | 정점 데이터의 요소 이름이며, 기본값은 "vertex"입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getPositionComponents{#getPositionComponents}
+
+| 이름 | 설명 |
+| --- | --- |
+| getPositionComponents() | 위치 데이터의 구성 요소 이름이며, 기본값은 ("x", "y", "z")입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getNormalComponents{#getNormalComponents}
+
+| 이름 | 설명 |
+| --- | --- |
+| getNormalComponents() | 노멀 데이터의 구성 요소 이름이며, 기본값은 ("nx", "ny", "nz")입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTextureCoordinateComponents{#getTextureCoordinateComponents}
+
+| 이름 | 설명 |
+| --- | --- |
+| getTextureCoordinateComponents() | 텍스처 좌표 데이터의 구성 요소 이름이며, 기본값은 ("u", "v")입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getColorComponents{#getColorComponents}
+
+| 이름 | 설명 |
+| --- | --- |
+| getColorComponents() | 버텍스 색상의 구성 요소 이름이며, 기본값은 ("red", "green", "blue")입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFaceElement{#getFaceElement}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFaceElement() | 페이스 데이터의 요소 이름이며, 기본값은 "face"입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFaceElement{#setFaceElement}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFaceElement(value) | 페이스 데이터의 요소 이름이며, 기본값은 "face"입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFaceProperty{#getFaceProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFaceProperty() | 페이스 데이터의 속성 이름이며, 기본값은 "vertex_index"입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFaceProperty{#setFaceProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFaceProperty(value) | 페이스 데이터의 속성 이름이며, 기본값은 "vertex_index"입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportTextures{#getExportTextures}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExportTextures() | 씬에서 사용된 텍스처를 출력 디렉터리로 복사합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextures{#setExportTextures}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExportTextures(value) | 씬에서 사용된 텍스처를 출력 디렉터리로 복사합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileFormat() | 현재 저장/로드 옵션에 지정된 파일 형식을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEncoding() | 텍스트 기반 파일에 대한 기본 인코딩을 가져오거나 설정합니다. 기본값은 null이며, 이는 가져오기/내보내기 프로그램이 사용할 인코딩을 결정함을 의미합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileSystem() | 로드/저장 중 외부 종속성을 관리하는 방법을 사용자가 처리하도록 허용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFileSystem(value) | 로드/저장 중 외부 종속성을 관리하는 방법을 사용자가 처리하도록 허용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| 이름 | 설명 |
+| --- | --- |
+| getLookupPaths() | OBJ와 같은 일부 파일은 외부 파일에 의존하며, 조회 경로를 통해 Aspose.3D가 외부 파일을 찾아 로드할 수 있도록 합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileName() | 내보내기/가져오기 씬의 파일 이름입니다. 선택 사항이지만 OBJ의 재질과 같은 외부 자산을 직렬화할 때 유용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFileName(value) | 내보내기/가져오기 씬의 파일 이름입니다. 선택 사항이지만 OBJ의 재질과 같은 외부 자산을 직렬화할 때 유용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/pointcloud/_index.md
+++ b/korean/nodejs-java/aspose.threed/pointcloud/_index.md
@@ -1,0 +1,580 @@
+---
+title: "PointCloud"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/pointcloud/
+---
+## PointCloud class
+
+포인트 클라우드에는 토폴로지 정보가 없고 제어점과 정점 요소만 포함됩니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor(name) | PointCloud의 생성자 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| name | String | 이 엔터티의 이름 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload() | PointCloud의 생성자 |
+
+ **Result:**
+
+
+
+---
+
+
+### getVisible{#getVisible}
+
+| 이름 | 설명 |
+| --- | --- |
+| getVisible() | 지오메트리가 보이는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setVisible{#setVisible}
+
+| 이름 | 설명 |
+| --- | --- |
+| setVisible(value) | 지오메트리가 보이는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDeformers{#getDeformers}
+
+| 이름 | 설명 |
+| --- | --- |
+| getDeformers() | 이 지오메트리와 연결된 모든 디포머를 가져옵니다. 디포머. |
+
+ **Result:**
+
+
+
+---
+
+
+### getControlPoints{#getControlPoints}
+
+| 이름 | 설명 |
+| --- | --- |
+| getControlPoints() | 모든 제어점을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastShadows{#getCastShadows}
+
+| 이름 | 설명 |
+| --- | --- |
+| getCastShadows() | 이 지오메트리가 그림자를 드리울 수 있는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastShadows{#setCastShadows}
+
+| 이름 | 설명 |
+| --- | --- |
+| setCastShadows(value) | 이 지오메트리가 그림자를 드리울 수 있는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReceiveShadows{#getReceiveShadows}
+
+| 이름 | 설명 |
+| --- | --- |
+| getReceiveShadows() | 이 지오메트리가 그림자를 받을 수 있는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReceiveShadows{#setReceiveShadows}
+
+| 이름 | 설명 |
+| --- | --- |
+| setReceiveShadows(value) | 이 지오메트리가 그림자를 받을 수 있는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElements{#getVertexElements}
+
+| 이름 | 설명 |
+| --- | --- |
+| getVertexElements() | 모든 정점 요소를 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNodes() | 모든 부모 노드를 가져옵니다. 엔터티는 기하학 인스턴싱을 위해 여러 부모 노드에 부착될 수 있습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExcluded() | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExcluded(value) | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNode() | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setParentNode(value) | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 이름 | 설명 |
+| --- | --- |
+| getScene() | 이 객체가 속한 씬을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEntityRendererKey() | 렌더러에 등록된 엔터티 렌더러의 키를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### fromGeometry{#fromGeometry}
+
+| 이름 | 설명 |
+| --- | --- |
+| fromGeometry(g) | 지오메트리 객체에서 새로운 PointCloud 인스턴스를 생성합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+|  | Geometry | null |
+
+ **Result:**
+PointCloud
+
+
+---
+
+
+### fromGeometry{#fromGeometry}
+
+| 이름 | 설명 |
+| --- | --- |
+| fromGeometry(g, density) | 지오메트리 객체에서 새로운 포인트 클라우드 인스턴스를 생성합니다. 밀도는 단위 삼각형당 포인트 수를 의미합니다(단위 삼각형은 메시에서 최대 표면적을 가진 삼각형입니다). |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| g | Geometry | Mesh 또는 기타 지오메트리 인스턴스 |
+| density | 숫자 | 단위 삼각형당 포인트 수 |
+
+ **Result:**
+PointCloud
+
+
+---
+
+
+### getElement{#getElement}
+
+| 이름 | 설명 |
+| --- | --- |
+| getElement(type) | 지정된 타입의 정점 요소를 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| type | VertexElementType | VertexElementType |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### getVertexElementOfUV{#getVertexElementOfUV}
+
+| 이름 | 설명 |
+| --- | --- |
+| getVertexElementOfUV(textureMapping) | 주어진 텍스처 매핑 타입으로 VertexElementUV 인스턴스를 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| textureMapping | TextureMapping | TextureMapping |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### createElement{#createElement}
+
+| 이름 | 설명 |
+| --- | --- |
+| createElement(type) | 지정된 타입의 정점 요소를 생성하고 이를 지오메트리에 추가합니다. 타입이 VertexElementType.UV인 경우, TextureMapping.DIFFUSE 타입의 텍스처 매핑을 가진 VertexElementUV가 생성됩니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| type | VertexElementType | VertexElementType |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### addElement{#addElement}
+
+| 이름 | 설명 |
+| --- | --- |
+| addElement(element) | 기존 정점 요소를 현재 지오메트리에 추가합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| element | VertexElement | 추가할 정점 요소 |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### createElement{#createElement}
+
+| 이름 | 설명 |
+| --- | --- |
+| createElement(type, mappingMode, referenceMode) | 지정된 타입의 정점 요소를 생성하고 이를 지오메트리에 추가합니다. 타입이 VertexElementType.UV인 경우, TextureMapping.DIFFUSE 타입의 텍스처 매핑을 가진 VertexElementUV가 생성됩니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| type | VertexElementType | VertexElementType |
+| mappingMode | MappingMode | MappingMode |
+| referenceMode | ReferenceMode | ReferenceMode |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### createElementUV{#createElementUV}
+
+| 이름 | 설명 |
+| --- | --- |
+| createElementUV(uvMapping) | 주어진 텍스처 매핑 유형으로 VertexElementUV를 생성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| uvMapping | TextureMapping | TextureMapping |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### createElementUV{#createElementUV}
+
+| 이름 | 설명 |
+| --- | --- |
+| createElementUV(uvMapping, mappingMode, referenceMode) | 주어진 텍스처 매핑 유형으로 VertexElementUV를 생성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| uvMapping | TextureMapping | TextureMapping |
+| mappingMode | MappingMode | MappingMode |
+| referenceMode | ReferenceMode | ReferenceMode |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBoundingBox() | 현재 엔터티의 객체 공간 좌표계에서 경계 상자를 가져옵니다. |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/polygonbuilder/_index.md
+++ b/korean/nodejs-java/aspose.threed/polygonbuilder/_index.md
@@ -1,0 +1,80 @@
+---
+title: "PolygonBuilder"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/polygonbuilder/
+---
+## PolygonBuilder class
+
+Mesh용 폴리곤을 구축하기 위한 헬퍼 클래스
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor(mesh) | PolygonBuilder 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| mesh | Mesh | 다각형을 만들 메쉬를 지정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### begin{#begin}
+
+| 이름 | 설명 |
+| --- | --- |
+| begin() | 새 다각형 추가를 시작합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### addVertex{#addVertex}
+
+| 이름 | 설명 |
+| --- | --- |
+| addVertex(index) | 다각형에 정점 인덱스를 추가합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| inde | 숫자 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### end{#end}
+
+| 이름 | 설명 |
+| --- | --- |
+| end() | 다각형 생성을 완료합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/polygonmodifier/_index.md
+++ b/korean/nodejs-java/aspose.threed/polygonmodifier/_index.md
@@ -1,0 +1,266 @@
+---
+title: "PolygonModifier"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/polygonmodifier/
+---
+## PolygonModifier class
+
+폴리곤을 수정하기 위한 유틸리티  @hideconstructor
+
+
+## 메서드
+
+### triangulate{#triangulate}
+
+| 이름 | 설명 |
+| --- | --- |
+| triangulate(scene) | 폴리곤 기반 메쉬를 모두 전체 삼각형 메쉬로 변환합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| scene | Scene | 처리할 씬 |
+
+ **Result:**
+
+
+
+---
+
+
+### triangulate{#triangulate}
+
+| 이름 | 설명 |
+| --- | --- |
+| triangulate(mesh) | 폴리곤 기반 메쉬를 전체 삼각형 메쉬로 변환합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| mesh | Mesh | 원본 비삼각형 메쉬 |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### mergeMesh{#mergeMesh}
+
+| 이름 | 설명 |
+| --- | --- |
+| mergeMesh(scene) | 전체 씬을 단일 변환 메쉬로 변환합니다. 노멀/텍스처 좌표와 같은 정점 요소는 아직 지원되지 않습니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| scene | Scene | 병합할 씬 |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### mergeMesh{#mergeMesh}
+
+| 이름 | 설명 |
+| --- | --- |
+| mergeMesh(node) | 전체 노드를 단일 변환 메쉬로 변환합니다. 노멀/텍스처 좌표와 같은 정점 요소는 아직 지원되지 않습니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| node | Node | 병합할 노드 |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### scale{#scale}
+
+| 이름 | 설명 |
+| --- | --- |
+| scale(scene, scale) | 이 씬의 모든 기하학을 스케일합니다(제어점을 스케일하고 변환 행렬은 스케일하지 않음). |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| scene | Scene | 스케일할 씬 |
+| 스케일 | Vector3 | 스케일 팩터 |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### scale{#scale}
+
+| 이름 | 설명 |
+| --- | --- |
+| scale(node, scale) | 이 노드의 모든 기하학을 스케일합니다(제어점을 스케일하고 변환 행렬은 스케일하지 않음). |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| node | Node | 스케일할 노드 |
+| 스케일 | Vector3 | 스케일 팩터 |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### generateNormal{#generateNormal}
+
+| 이름 | 설명 |
+| --- | --- |
+| generateNormal(mesh) | Mesh 정의에서 노멀 데이터를 생성합니다 |
+
+ **Result:**
+VertexElementNormal
+
+
+---
+
+
+### generateUV{#generateUV}
+
+| 이름 | 설명 |
+| --- | --- |
+| generateUV(mesh, normals) | 주어진 입력 Mesh와 지정된 노멀 데이터를 사용하여 UV 데이터를 생성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| mesh | Mesh | 입력 Mesh |
+| 노멀 | VertexElementNormal | 노멀 데이터 |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### generateUV{#generateUV}
+
+| 이름 | 설명 |
+| --- | --- |
+| generateUV(mesh) | 주어진 입력 Mesh에서 UV 데이터를 생성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| mesh | Mesh | 입력 Mesh |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### splitMesh{#splitMesh}
+
+| 이름 | 설명 |
+| --- | --- |
+| splitMesh(node, policy, createChildNodes, removeOldMesh) | VertexElementMaterial에 따라 Mesh를 서브 Mesh로 분할합니다. 각 서브 Mesh는 하나의 재질만 사용합니다. 노드에서 Mesh 분할을 수행합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| nod | Node | null |
+| 정책 | SplitMeshPolicy | SplitMeshPolicy |
+| createChildNodes | boolean | 각 서브 Mesh에 대한 자식 노드를 생성합니다. |
+| removeOldMesh | boolean | 분할 후 기존 Mesh를 제거합니다. 이 매개변수가 false이면 기존 Mesh와 새로운 Mesh가 동시에 존재합니다. |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### splitMesh{#splitMesh}
+
+| 이름 | 설명 |
+| --- | --- |
+| splitMesh(scene, policy, removeOldMesh) | VertexElementMaterial에 따라 Mesh를 서브 Mesh로 분할합니다. 각 서브 Mesh는 하나의 재질만 사용합니다. 씬의 모든 노드에서 Mesh 분할을 수행합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 씬 | Scene | null |
+| 정책 | SplitMeshPolicy | SplitMeshPolicy |
+| removeOldMes | boolean | null |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### splitMesh{#splitMesh}
+
+| 이름 | 설명 |
+| --- | --- |
+| splitMesh(mesh, policy) | VertexElementMaterial에 따라 Mesh를 서브 Mesh로 분할합니다. 각 서브 Mesh는 하나의 재질만 사용합니다. 원본 Mesh는 변경되지 않습니다. |
+
+ **Result:**
+Mesh[]
+
+
+---
+
+
+### buildTangentBinormal{#buildTangentBinormal}
+
+| 이름 | 설명 |
+| --- | --- |
+| buildTangentBinormal(scene) | 이 기능은 씬의 모든 Mesh에 접선(tangent)과 바이노멀(binormal)을 생성합니다. 노멀은 필수이며, Mesh에 노멀 데이터가 없을 경우 위치 정보를 사용하여 노멀 데이터를 생성합니다. UV도 필수이며, UV가 정의되지 않은 경우 해당 Mesh는 무시됩니다. |
+
+ **Result:**
+Mesh[]
+
+
+---
+
+
+### buildTangentBinormal{#buildTangentBinormal}
+
+| 이름 | 설명 |
+| --- | --- |
+| buildTangentBinormal(mesh) | 이것은 메시에서 탄젠트와 바이노멀을 생성합니다. 노멀은 필요하며, 메시에 노멀 데이터가 없을 경우 위치에서 노멀 데이터를 생성합니다. UV도 필요하며, UV가 없을 경우 예외가 발생합니다. |
+
+ **Result:**
+Mesh[]
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/pose/_index.md
+++ b/korean/nodejs-java/aspose.threed/pose/_index.md
@@ -1,0 +1,263 @@
+---
+title: "포즈"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/pose/
+---
+## Pose class
+
+포즈는 지오메트리가 스키닝될 때 변환 행렬을 저장하는 데 사용됩니다. 포즈는 BonePose의 집합이며, 각 BonePose는 본 노드의 구체적인 변환 정보를 저장합니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor(name) | Pose 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| name | String | 이름 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload() | Pose 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getPoseType{#getPoseType}
+
+| 이름 | 설명 |
+| --- | --- |
+| getPoseType() | 포즈의 유형을 가져오거나 설정합니다. 속성 값은 PoseType 정수 상수입니다. 포즈의 유형. |
+
+ **Result:**
+
+
+
+---
+
+
+### setPoseType{#setPoseType}
+
+| 이름 | 설명 |
+| --- | --- |
+| setPoseType(value) | 포즈의 유형을 가져오거나 설정합니다. 속성 값은 PoseType 정수 상수입니다. 포즈의 유형. |
+
+ **Result:**
+
+
+
+---
+
+
+### getBonePoses{#getBonePoses}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBonePoses() | 모든 BonePose를 가져옵니다. 노드들. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### addBonePose{#addBonePose}
+
+| 이름 | 설명 |
+| --- | --- |
+| addBonePose(node, matrix, localMatrix) | 주어진 본 노드에 대한 포즈 변환 행렬을 저장합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| node | Node | 본 노드. |
+| matrix | Matrix4 | 변환 행렬. |
+| localMatrix | boolean | 설정된 경우 |
+
+ **Result:**
+
+
+
+---
+
+
+### addBonePose{#addBonePose}
+
+| 이름 | 설명 |
+| --- | --- |
+| addBonePose(node, matrix) | 주어진 본 노드에 대한 포즈 변환 행렬을 저장합니다. 전역 변환 행렬이 암시됩니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| node | Node | 본 노드. |
+| matrix | Matrix4 | 변환 행렬. |
+
+ **Result:**
+
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/postprocessing/_index.md
+++ b/korean/nodejs-java/aspose.threed/postprocessing/_index.md
@@ -1,0 +1,177 @@
+---
+title: "후처리"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/postprocessing/
+---
+## PostProcessing class
+
+후처리 효과  @hideconstructor
+
+
+## 메서드
+
+### getInput{#getInput}
+
+| 이름 | 설명 |
+| --- | --- |
+| getInput() | 이 후처리의 입력 |
+
+ **Result:**
+
+
+
+---
+
+
+### setInput{#setInput}
+
+| 이름 | 설명 |
+| --- | --- |
+| setInput(value) | 이 후처리의 입력 |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/primitive/_index.md
+++ b/korean/nodejs-java/aspose.threed/primitive/_index.md
@@ -1,0 +1,339 @@
+---
+title: "프리미티브"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/primitive/
+---
+## Primitive class
+
+모든 프리미티브의 기본 클래스
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor(name) | Primitive 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| name | String | 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastShadows{#getCastShadows}
+
+| 이름 | 설명 |
+| --- | --- |
+| getCastShadows() | 이 지오메트리가 그림자를 드리울 수 있는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastShadows{#setCastShadows}
+
+| 이름 | 설명 |
+| --- | --- |
+| setCastShadows(value) | 이 지오메트리가 그림자를 드리울 수 있는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReceiveShadows{#getReceiveShadows}
+
+| 이름 | 설명 |
+| --- | --- |
+| getReceiveShadows() | 이 지오메트리가 그림자를 받을 수 있는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReceiveShadows{#setReceiveShadows}
+
+| 이름 | 설명 |
+| --- | --- |
+| setReceiveShadows(value) | 이 지오메트리가 그림자를 받을 수 있는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNodes() | 모든 부모 노드를 가져옵니다. 엔터티는 기하학 인스턴싱을 위해 여러 부모 노드에 부착될 수 있습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExcluded() | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExcluded(value) | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNode() | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setParentNode(value) | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 이름 | 설명 |
+| --- | --- |
+| getScene() | 이 객체가 속한 씬을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### toMesh{#toMesh}
+
+| 이름 | 설명 |
+| --- | --- |
+| toMesh() | 현재 객체를 메시로 변환합니다 |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBoundingBox() | 현재 엔터티의 객체 공간 좌표계에서 경계 상자를 가져옵니다. |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEntityRendererKey() | 렌더러에 등록된 엔터티 렌더러의 키를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/profile/_index.md
+++ b/korean/nodejs-java/aspose.threed/profile/_index.md
@@ -1,0 +1,255 @@
+---
+title: "Profile"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/profile/
+---
+## Profile class
+
+xy 평면의 2D 프로파일  @hideconstructor
+
+
+## 메서드
+
+### getParentNodes{#getParentNodes}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNodes() | 모든 부모 노드를 가져옵니다. 엔터티는 기하학 인스턴싱을 위해 여러 부모 노드에 부착될 수 있습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExcluded() | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExcluded(value) | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNode() | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setParentNode(value) | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 이름 | 설명 |
+| --- | --- |
+| getScene() | 이 객체가 속한 씬을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEntityRendererKey() | 렌더러에 등록된 엔터티 렌더러의 키를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBoundingBox() | 현재 엔터티의 객체 공간 좌표계에서 경계 상자를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/property/_index.md
+++ b/korean/nodejs-java/aspose.threed/property/_index.md
@@ -1,0 +1,230 @@
+---
+title: "속성"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/property/
+---
+## Property class
+
+사용자 정의 속성을 보유하는 클래스.  @hideconstructor
+
+
+## 메서드
+
+### getValue{#getValue}
+
+| 이름 | 설명 |
+| --- | --- |
+| getValue() | 값을 가져오거나 설정합니다. 값. |
+
+ **Result:**
+
+
+
+---
+
+
+### setValue{#setValue}
+
+| 이름 | 설명 |
+| --- | --- |
+| setValue(value) | 값을 가져오거나 설정합니다. 값. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getValueType{#getValueType}
+
+| 이름 | 설명 |
+| --- | --- |
+| getValueType() | 속성 값의 유형을 가져옵니다. 값의 유형. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getBindPoint{#getBindPoint}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBindPoint(anim, create) | 지정된 애니메이션 인스턴스에서 속성 바인드 포인트를 가져옵니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| anim | AnimationNode | 바인드 포인트를 생성할 애니메이션을 선택합니다. |
+| 생성 | boolean | 속성 바인드 포인트가 없으면 생성합니다. |
+
+ **Result:**
+BindPoint
+
+
+---
+
+
+### getKeyframeSequence{#getKeyframeSequence}
+
+| 이름 | 설명 |
+| --- | --- |
+| getKeyframeSequence(anim, create) | 지정된 애니메이션 인스턴스의 키프레임 시퀀스를 가져옵니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| anim | AnimationNode | 키프레임 시퀀스를 생성할 애니메이션을 선택합니다. |
+| 생성 | boolean | 키프레임 시퀀스가 없으면 생성합니다. |
+
+ **Result:**
+KeyframeSequence
+
+
+---
+
+
+### toString{#toString}
+
+| 이름 | 설명 |
+| --- | --- |
+| toString() | 현재 속성을 나타내는 문자열을 반환합니다. |
+
+ **Result:**
+String
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/propertycollection/_index.md
+++ b/korean/nodejs-java/aspose.threed/propertycollection/_index.md
@@ -1,0 +1,125 @@
+---
+title: "속성 컬렉션"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/propertycollection/
+---
+## PropertyCollection class
+
+속성 컬렉션  @hideconstructor
+
+
+## 메서드
+
+### get{#get}
+
+| 이름 | 설명 |
+| --- | --- |
+| get(idx) |  |
+
+ **Result:**
+
+
+
+---
+
+
+### get{#get}
+
+| 이름 | 설명 |
+| --- | --- |
+| get(property) |  |
+
+ **Result:**
+
+
+
+---
+
+
+### set{#set}
+
+| 이름 | 설명 |
+| --- | --- |
+| set(property, value) |  |
+
+ **Result:**
+
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(property) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### iterator{#iterator}
+
+| 이름 | 설명 |
+| --- | --- |
+| iterator() | 내부 사용을 위해 예약되었습니다. |
+
+ **Result:**
+boolean
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/pushconstant/_index.md
+++ b/korean/nodejs-java/aspose.threed/pushconstant/_index.md
@@ -1,0 +1,166 @@
+---
+title: "PushConstant"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/pushconstant/
+---
+## PushConstant class
+
+푸시 상수를 통해 셰이더에 데이터를 제공하는 유틸리티.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | PushConstant의 생성자 |
+
+ **Result:**
+
+
+
+---
+
+
+### write{#write}
+
+| 이름 | 설명 |
+| --- | --- |
+| write(mat) | 행렬을 상수에 기록합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| mat | FMatrix4 | 작성할 행렬 |
+
+ **Result:**
+
+
+
+---
+
+
+### write{#write}
+
+| 이름 | 설명 |
+| --- | --- |
+| write(n) | int 값을 상수에 기록합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+|  | 숫자 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### write{#write}
+
+| 이름 | 설명 |
+| --- | --- |
+| write(f) | float 값을 상수에 기록합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+|  | 숫자 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### write{#write}
+
+| 이름 | 설명 |
+| --- | --- |
+| write(vec) | 4-요소 벡터를 상수에 기록합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| ve | FVector4 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### write{#write}
+
+| 이름 | 설명 |
+| --- | --- |
+| write(vec) | 3-요소 벡터를 상수에 기록합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| ve | FVector3 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### write{#write}
+
+| 이름 | 설명 |
+| --- | --- |
+| write(x, y, z, w) | 4-요소 벡터를 상수에 기록합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+|  | 숫자 | null |
+|  | 숫자 | null |
+|  | 숫자 | null |
+|  | 숫자 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### commit{#commit}
+
+| 이름 | 설명 |
+| --- | --- |
+| commit(stage, commandList) | 준비된 데이터를 그래픽 파이프라인에 커밋합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| stage | 숫자 | ShaderStage |
+| commandLis | ICommandList | null |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/pyramid/_index.md
+++ b/korean/nodejs-java/aspose.threed/pyramid/_index.md
@@ -1,0 +1,505 @@
+---
+title: "Pyramid"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/pyramid/
+---
+## Pyramid class
+
+매개변수화된 피라미드.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | 기본 바닥 영역(10, 10)과 기본 높이(5)로 새로운 피라미드 인스턴스를 생성합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload(xbottom, ybottom, height) | 지정된 바닥 영역으로 새로운 피라미드 인스턴스를 생성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| xbottom | 숫자 | 바닥의 x 방향 길이 |
+| ybottom | 숫자 | 바닥의 y 방향 길이 |
+| height | 숫자 | 피라미드의 높이 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload2(xbottom, ybottom, xtop, ytop, height) | 지정된 바닥 영역, 상단 영역 및 높이로 새로운 피라미드 인스턴스를 생성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| xbottom | 숫자 | 바닥 영역의 x 방향 길이 |
+| ybottom | 숫자 | 바닥 영역의 y 방향 길이 |
+| xtop | 숫자 | 상단 영역의 x 방향 길이 |
+| ytop | 숫자 | 상단 영역의 y 방향 길이 |
+| height | 숫자 | 피라미드의 높이 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload3{#constructor_overload3}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload3(name, xbottom, ybottom, xtop, ytop, height) | 지정된 바닥 영역, 상단 영역 및 높이로 새로운 피라미드 인스턴스를 생성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| name | String | 피라미드의 이름 |
+| xbottom | 숫자 | 바닥 영역의 x 방향 길이 |
+| ybottom | 숫자 | 바닥 영역의 y 방향 길이 |
+| xtop | 숫자 | 상단 영역의 x 방향 길이 |
+| ytop | 숫자 | 상단 영역의 y 방향 길이 |
+| height | 숫자 | 피라미드의 높이 |
+
+ **Result:**
+
+
+
+---
+
+
+### getBottomArea{#getBottomArea}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBottomArea() | 바닥 캡의 면적 |
+
+ **Result:**
+
+
+
+---
+
+
+### setBottomArea{#setBottomArea}
+
+| 이름 | 설명 |
+| --- | --- |
+| setBottomArea(value) | 바닥 캡의 면적 |
+
+ **Result:**
+
+
+
+---
+
+
+### getTopArea{#getTopArea}
+
+| 이름 | 설명 |
+| --- | --- |
+| getTopArea() | 상단 캡의 면적 |
+
+ **Result:**
+
+
+
+---
+
+
+### setTopArea{#setTopArea}
+
+| 이름 | 설명 |
+| --- | --- |
+| setTopArea(value) | 상단 캡의 면적 |
+
+ **Result:**
+
+
+
+---
+
+
+### getBottomOffset{#getBottomOffset}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBottomOffset() | 바닥 꼭짓점의 오프셋 |
+
+ **Result:**
+
+
+
+---
+
+
+### setBottomOffset{#setBottomOffset}
+
+| 이름 | 설명 |
+| --- | --- |
+| setBottomOffset(value) | 바닥 꼭짓점의 오프셋 |
+
+ **Result:**
+
+
+
+---
+
+
+### getHeight{#getHeight}
+
+| 이름 | 설명 |
+| --- | --- |
+| getHeight() | 피라미드의 높이 |
+
+ **Result:**
+
+
+
+---
+
+
+### setHeight{#setHeight}
+
+| 이름 | 설명 |
+| --- | --- |
+| setHeight(value) | 피라미드의 높이 |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastShadows{#getCastShadows}
+
+| 이름 | 설명 |
+| --- | --- |
+| getCastShadows() | 이 지오메트리가 그림자를 드리울 수 있는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastShadows{#setCastShadows}
+
+| 이름 | 설명 |
+| --- | --- |
+| setCastShadows(value) | 이 지오메트리가 그림자를 드리울 수 있는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReceiveShadows{#getReceiveShadows}
+
+| 이름 | 설명 |
+| --- | --- |
+| getReceiveShadows() | 이 지오메트리가 그림자를 받을 수 있는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReceiveShadows{#setReceiveShadows}
+
+| 이름 | 설명 |
+| --- | --- |
+| setReceiveShadows(value) | 이 지오메트리가 그림자를 받을 수 있는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNodes() | 모든 부모 노드를 가져옵니다. 엔터티는 기하학 인스턴싱을 위해 여러 부모 노드에 부착될 수 있습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExcluded() | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExcluded(value) | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNode() | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setParentNode(value) | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 이름 | 설명 |
+| --- | --- |
+| getScene() | 이 객체가 속한 씬을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### toMesh{#toMesh}
+
+| 이름 | 설명 |
+| --- | --- |
+| toMesh() | 현재 객체를 메시로 변환합니다 |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBoundingBox() | 현재 엔터티의 객체 공간 좌표계에서 경계 상자를 가져옵니다. |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEntityRendererKey() | 렌더러에 등록된 엔터티 렌더러의 키를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/quaternion/_index.md
+++ b/korean/nodejs-java/aspose.threed/quaternion/_index.md
@@ -1,0 +1,323 @@
+---
+title: "Quaternion"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/quaternion/
+---
+## Quaternion class
+
+Quaternion은 일반적으로 컴퓨터 그래픽스에서 회전을 수행하는 데 사용됩니다.
+
+
+## Properties
+
+| 이름 | 설명 |
+| --- | --- |
+| w | w 구성 요소입니다. |
+| x | x 구성 요소. |
+| y | y 구성 요소. |
+| z | z 구성 요소. |
+| IDENTITY | 단위 사원수. |
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload(w, x, y, z) | Quaternion 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| w | 숫자 | 사원수의 w 구성 요소 |
+| x | 숫자 | 사원수의 x 구성 요소 |
+| y | 숫자 | 사원수의 y 구성 요소 |
+| z | 숫자 | 사원수의 z 구성 요소 |
+
+ **Result:**
+
+
+
+---
+
+
+### getLength{#getLength}
+
+| 이름 | 설명 |
+| --- | --- |
+| getLength() | 사원수의 길이를 가져옵니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### equals{#equals}
+
+| 이름 | 설명 |
+| --- | --- |
+| equals(obj) | 두 사원수가 같은지 확인합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| obj | Object | 동등성을 확인할 객체입니다. |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### hashCode{#hashCode}
+
+| 이름 | 설명 |
+| --- | --- |
+| hashCode() | Quaternion의 해시 코드를 가져옵니다 |
+
+ **Result:**
+숫자
+
+
+---
+
+
+### conjugate{#conjugate}
+
+| 이름 | 설명 |
+| --- | --- |
+| conjugate() | 현재 사원수의 켤레 사원수를 반환합니다 |
+
+ **Result:**
+Quaternion
+
+
+---
+
+
+### inverse{#inverse}
+
+| 이름 | 설명 |
+| --- | --- |
+| inverse() | 현재 사원수의 역 사원수를 반환합니다 |
+
+ **Result:**
+Quaternion
+
+
+---
+
+
+### dot{#dot}
+
+| 이름 | 설명 |
+| --- | --- |
+| dot(q) | 점곱 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| q | Quaternion | 쿼터니언 |
+
+ **Result:**
+숫자
+
+
+---
+
+
+### eulerAngles{#eulerAngles}
+
+| 이름 | 설명 |
+| --- | --- |
+| eulerAngles() | 쿼터니언을 오일러 각으로 표현된 회전으로 변환합니다. 모든 구성 요소는 라디안 단위입니다. |
+
+ **Result:**
+Vector3
+
+
+---
+
+
+### normalize{#normalize}
+
+| 이름 | 설명 |
+| --- | --- |
+| normalize() | 쿼터니언을 정규화합니다. |
+
+ **Result:**
+Quaternion
+
+
+---
+
+
+### concat{#concat}
+
+| 이름 | 설명 |
+| --- | --- |
+| concat(rhs) | 두 개의 쿼터니언을 연결합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| rh | Quaternion | null |
+
+ **Result:**
+Quaternion
+
+
+---
+
+
+### fromAngleAxis{#fromAngleAxis}
+
+| 이름 | 설명 |
+| --- | --- |
+| fromAngleAxis(a, axis) | 주어진 축을 중심으로 시계 방향으로 회전하는 쿼터니언을 생성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| a | 숫자 | 시계 방향 회전 (라디안) |
+| axis | Vector3 | 축 |
+
+ **Result:**
+Quaternion
+
+
+---
+
+
+### fromRotation{#fromRotation}
+
+| 이름 | 설명 |
+| --- | --- |
+| fromRotation(orig, dest) | 원래 방향에서 목적지 방향으로 회전하는 쿼터니언을 생성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| orig | Vector3 | 원래 방향 |
+| dest | Vector3 | 목적지 방향 |
+
+ **Result:**
+Quaternion
+
+
+---
+
+
+### fromEulerAngle{#fromEulerAngle}
+
+| 이름 | 설명 |
+| --- | --- |
+| fromEulerAngle(pitch, yaw, roll) | 주어진 오일러 각으로부터 쿼터니언을 생성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| pitch | 숫자 | 피치 (라디안) |
+| yaw | 숫자 | 요 (라디안) |
+| 롤 | 숫자 | 라디안 단위 롤 |
+
+ **Result:**
+Quaternion
+
+
+---
+
+
+### fromEulerAngle{#fromEulerAngle}
+
+| 이름 | 설명 |
+| --- | --- |
+| fromEulerAngle(eulerAngle) | 주어진 오일러 각으로부터 쿼터니언을 생성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| eulerAngle | Vector3 | 라디안 단위 Euler 각 |
+
+ **Result:**
+Quaternion
+
+
+---
+
+
+### toMatrix{#toMatrix}
+
+| 이름 | 설명 |
+| --- | --- |
+| toMatrix() | 쿼터니언으로 표현된 회전을 변환 행렬로 변환합니다. |
+
+ **Result:**
+Matrix4
+
+
+---
+
+
+### toString{#toString}
+
+| 이름 | 설명 |
+| --- | --- |
+| toString() | 쿼터니언을 문자열로 표현한 값을 가져옵니다 |
+
+ **Result:**
+String
+
+
+---
+
+
+### interpolate{#interpolate}
+
+| 이름 | 설명 |
+| --- | --- |
+| interpolate(t, from, to) | 주어진 quaternion 인수들 사이에서 t가 from와 to 사이일 때, 이 quaternion을 보간된 값으로 채웁니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| t | 숫자 | 보간에 사용할 계수. |
+| from | Quaternion | 소스 quaternion. |
+| to | Quaternion | 대상 quaternion. |
+
+ **Result:**
+Quaternion
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/rect/_index.md
+++ b/korean/nodejs-java/aspose.threed/rect/_index.md
@@ -1,0 +1,227 @@
+---
+title: "Rect"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/rect/
+---
+## Rect class
+
+사각형을 나타내는 클래스
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload(x, y, width, height) | Rect 클래스의 생성자 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+|  | 숫자 | null |
+|  | 숫자 | null |
+| 너비 | 숫자 | null |
+| 높이 | 숫자 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### getWidth{#getWidth}
+
+| 이름 | 설명 |
+| --- | --- |
+| getWidth() | 크기의 너비를 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### setWidth{#setWidth}
+
+| 이름 | 설명 |
+| --- | --- |
+| setWidth(value) | 크기의 너비를 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getHeight{#getHeight}
+
+| 이름 | 설명 |
+| --- | --- |
+| getHeight() | 크기의 높이를 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### setHeight{#setHeight}
+
+| 이름 | 설명 |
+| --- | --- |
+| setHeight(value) | 크기의 높이를 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getX{#getX}
+
+| 이름 | 설명 |
+| --- | --- |
+| getX() | 크기의 x를 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### setX{#setX}
+
+| 이름 | 설명 |
+| --- | --- |
+| setX(value) | 크기의 x를 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getY{#getY}
+
+| 이름 | 설명 |
+| --- | --- |
+| getY() | 크기의 y를 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### setY{#setY}
+
+| 이름 | 설명 |
+| --- | --- |
+| setY(value) | 크기의 y를 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getLeft{#getLeft}
+
+| 이름 | 설명 |
+| --- | --- |
+| getLeft() | 사각형의 왼쪽을 가져옵니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getRight{#getRight}
+
+| 이름 | 설명 |
+| --- | --- |
+| getRight() | 사각형의 오른쪽을 가져옵니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getTop{#getTop}
+
+| 이름 | 설명 |
+| --- | --- |
+| getTop() | 사각형의 위쪽을 가져옵니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getBottom{#getBottom}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBottom() | 사각형의 아래쪽을 가져옵니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### contains{#contains}
+
+| 이름 | 설명 |
+| --- | --- |
+| contains(x, y) | 주어진 점이 사각형 내부에 있으면 true를 반환합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+|  | 숫자 | null |
+|  | 숫자 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/rectangleshape/_index.md
+++ b/korean/nodejs-java/aspose.threed/rectangleshape/_index.md
@@ -1,0 +1,359 @@
+---
+title: "RectangleShape"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/rectangleshape/
+---
+## RectangleShape class
+
+코너가 둥근 IFC 호환 사각형 형태.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | RectangleShape의 생성자 |
+
+ **Result:**
+
+
+
+---
+
+
+### getRoundingRadius{#getRoundingRadius}
+
+| 이름 | 설명 |
+| --- | --- |
+| getRoundingRadius() | 네 모서리 모두의 원형 호 반경을 가져오거나 설정합니다(단위:도). 기본값은 0.0입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRoundingRadius{#setRoundingRadius}
+
+| 이름 | 설명 |
+| --- | --- |
+| setRoundingRadius(value) | 네 모서리 모두의 원형 호 반경을 가져오거나 설정합니다(단위:도). 기본값은 0.0입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getXDim{#getXDim}
+
+| 이름 | 설명 |
+| --- | --- |
+| getXDim() | x축 방향으로 사각형의 크기를 가져오거나 설정합니다. 기본값은 2.0입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setXDim{#setXDim}
+
+| 이름 | 설명 |
+| --- | --- |
+| setXDim(value) | x축 방향으로 사각형의 크기를 가져오거나 설정합니다. 기본값은 2.0입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getYDim{#getYDim}
+
+| 이름 | 설명 |
+| --- | --- |
+| getYDim() | y축 방향으로 사각형의 크기를 가져오거나 설정합니다. 기본값은 2.0입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setYDim{#setYDim}
+
+| 이름 | 설명 |
+| --- | --- |
+| setYDim(value) | y축 방향으로 사각형의 크기를 가져오거나 설정합니다. 기본값은 2.0입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNodes() | 모든 부모 노드를 가져옵니다. 엔터티는 기하학 인스턴싱을 위해 여러 부모 노드에 부착될 수 있습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExcluded() | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExcluded(value) | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNode() | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setParentNode(value) | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 이름 | 설명 |
+| --- | --- |
+| getScene() | 이 객체가 속한 씬을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtent{#getExtent}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExtent() | x 및 y 차원에서의 범위를 가져옵니다. |
+
+ **Result:**
+Vector2
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEntityRendererKey() | 렌더러에 등록된 엔터티 렌더러의 키를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBoundingBox() | 현재 엔터티의 객체 공간 좌표계에서 경계 상자를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/rectangulartorus/_index.md
+++ b/korean/nodejs-java/aspose.threed/rectangulartorus/_index.md
@@ -1,0 +1,502 @@
+---
+title: "RectangularTorus"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/rectangulartorus/
+---
+## RectangularTorus class
+
+매개변수화된 사각형 토러스.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | RectangularTorus 생성자 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload(name) | RectangularTorus 생성자 |
+
+ **Result:**
+
+
+
+---
+
+
+### getInnerRadius{#getInnerRadius}
+
+| 이름 | 설명 |
+| --- | --- |
+| getInnerRadius() | 직사각형 토러스의 내부 반경, 기본값은 17입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setInnerRadius{#setInnerRadius}
+
+| 이름 | 설명 |
+| --- | --- |
+| setInnerRadius(value) | 직사각형 토러스의 내부 반경, 기본값은 17입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getOuterRadius{#getOuterRadius}
+
+| 이름 | 설명 |
+| --- | --- |
+| getOuterRadius() | 직사각형 토러스의 외부 반경, 기본값은 20입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setOuterRadius{#setOuterRadius}
+
+| 이름 | 설명 |
+| --- | --- |
+| setOuterRadius(value) | 직사각형 토러스의 외부 반경, 기본값은 20입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getHeight{#getHeight}
+
+| 이름 | 설명 |
+| --- | --- |
+| getHeight() | 직사각형 토러스의 높이. 기본값은 20입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setHeight{#setHeight}
+
+| 이름 | 설명 |
+| --- | --- |
+| setHeight(value) | 직사각형 토러스의 높이. 기본값은 20입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getArc{#getArc}
+
+| 이름 | 설명 |
+| --- | --- |
+| getArc() | 호의 전체 각도, 라디안 단위로 측정. 기본값은 PI입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setArc{#setArc}
+
+| 이름 | 설명 |
+| --- | --- |
+| setArc(value) | 호의 전체 각도, 라디안 단위로 측정. 기본값은 PI입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAngleStart{#getAngleStart}
+
+| 이름 | 설명 |
+| --- | --- |
+| getAngleStart() | 호의 시작 각도, 라디안 단위로 측정. 기본값은 0입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setAngleStart{#setAngleStart}
+
+| 이름 | 설명 |
+| --- | --- |
+| setAngleStart(value) | 호의 시작 각도, 라디안 단위로 측정. 기본값은 0입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getRadialSegments{#getRadialSegments}
+
+| 이름 | 설명 |
+| --- | --- |
+| getRadialSegments() | 방사형 세그먼트, 기본값은 10입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRadialSegments{#setRadialSegments}
+
+| 이름 | 설명 |
+| --- | --- |
+| setRadialSegments(value) | 방사형 세그먼트, 기본값은 10입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastShadows{#getCastShadows}
+
+| 이름 | 설명 |
+| --- | --- |
+| getCastShadows() | 이 지오메트리가 그림자를 드리울 수 있는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastShadows{#setCastShadows}
+
+| 이름 | 설명 |
+| --- | --- |
+| setCastShadows(value) | 이 지오메트리가 그림자를 드리울 수 있는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReceiveShadows{#getReceiveShadows}
+
+| 이름 | 설명 |
+| --- | --- |
+| getReceiveShadows() | 이 지오메트리가 그림자를 받을 수 있는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReceiveShadows{#setReceiveShadows}
+
+| 이름 | 설명 |
+| --- | --- |
+| setReceiveShadows(value) | 이 지오메트리가 그림자를 받을 수 있는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNodes() | 모든 부모 노드를 가져옵니다. 엔터티는 기하학 인스턴싱을 위해 여러 부모 노드에 부착될 수 있습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExcluded() | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExcluded(value) | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNode() | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setParentNode(value) | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 이름 | 설명 |
+| --- | --- |
+| getScene() | 이 객체가 속한 씬을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### toMesh{#toMesh}
+
+| 이름 | 설명 |
+| --- | --- |
+| toMesh() |  |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBoundingBox() | 현재 엔터티의 객체 공간 좌표계에서 경계 상자를 가져옵니다. |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEntityRendererKey() | 렌더러에 등록된 엔터티 렌더러의 키를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/relativerectangle/_index.md
+++ b/korean/nodejs-java/aspose.threed/relativerectangle/_index.md
@@ -1,0 +1,316 @@
+---
+title: "RelativeRectangle"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/relativerectangle/
+---
+## RelativeRectangle class
+
+상대 사각형  상대 구성 요소와 절대 값 사이의 공식은:  Scale (Reference Width) + offset  따라서 절대 값을 나타내려면 모든 scale 필드를 0으로 두고, offset 필드를 대신 사용하십시오.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload(left, top, width, height) | RelativeRectangle를 생성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| lef | 숫자 | null |
+| to | 숫자 | null |
+| 너비 | 숫자 | null |
+| 높이 | 숫자 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### getScaleX{#getScaleX}
+
+| 이름 | 설명 |
+| --- | --- |
+| getScaleX() | 상대 좌표 X |
+
+ **Result:**
+
+
+
+---
+
+
+### setScaleX{#setScaleX}
+
+| 이름 | 설명 |
+| --- | --- |
+| setScaleX(value) | 상대 좌표 X |
+
+ **Result:**
+
+
+
+---
+
+
+### getScaleY{#getScaleY}
+
+| 이름 | 설명 |
+| --- | --- |
+| getScaleY() | 상대 좌표 Y |
+
+ **Result:**
+
+
+
+---
+
+
+### setScaleY{#setScaleY}
+
+| 이름 | 설명 |
+| --- | --- |
+| setScaleY(value) | 상대 좌표 Y |
+
+ **Result:**
+
+
+
+---
+
+
+### getScaleWidth{#getScaleWidth}
+
+| 이름 | 설명 |
+| --- | --- |
+| getScaleWidth() | 상대 너비 |
+
+ **Result:**
+
+
+
+---
+
+
+### setScaleWidth{#setScaleWidth}
+
+| 이름 | 설명 |
+| --- | --- |
+| setScaleWidth(value) | 상대 너비 |
+
+ **Result:**
+
+
+
+---
+
+
+### getScaleHeight{#getScaleHeight}
+
+| 이름 | 설명 |
+| --- | --- |
+| getScaleHeight() | 상대 높이 |
+
+ **Result:**
+
+
+
+---
+
+
+### setScaleHeight{#setScaleHeight}
+
+| 이름 | 설명 |
+| --- | --- |
+| setScaleHeight(value) | 상대 높이 |
+
+ **Result:**
+
+
+
+---
+
+
+### getOffsetX{#getOffsetX}
+
+| 이름 | 설명 |
+| --- | --- |
+| getOffsetX() | 좌표 X에 대한 오프셋을 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### setOffsetX{#setOffsetX}
+
+| 이름 | 설명 |
+| --- | --- |
+| setOffsetX(value) | 좌표 X에 대한 오프셋을 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getOffsetY{#getOffsetY}
+
+| 이름 | 설명 |
+| --- | --- |
+| getOffsetY() | 좌표 Y에 대한 오프셋을 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### setOffsetY{#setOffsetY}
+
+| 이름 | 설명 |
+| --- | --- |
+| setOffsetY(value) | 좌표 Y에 대한 오프셋을 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getOffsetWidth{#getOffsetWidth}
+
+| 이름 | 설명 |
+| --- | --- |
+| getOffsetWidth() | 너비에 대한 오프셋을 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### setOffsetWidth{#setOffsetWidth}
+
+| 이름 | 설명 |
+| --- | --- |
+| setOffsetWidth(value) | 너비에 대한 오프셋을 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getOffsetHeight{#getOffsetHeight}
+
+| 이름 | 설명 |
+| --- | --- |
+| getOffsetHeight() | 높이에 대한 오프셋을 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### setOffsetHeight{#setOffsetHeight}
+
+| 이름 | 설명 |
+| --- | --- |
+| setOffsetHeight(value) | 높이에 대한 오프셋을 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### toAbsolute{#toAbsolute}
+
+| 이름 | 설명 |
+| --- | --- |
+| toAbsolute(left, top, width, height) | 상대 사각형을 절대 사각형으로 변환합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 왼쪽 | 숫자 | 사각형의 왼쪽 |
+| 위쪽 | 숫자 | 사각형의 위쪽 |
+| 너비 | 숫자 | 사각형의 너비 |
+| height | 숫자 | 사각형의 높이 |
+
+ **Result:**
+Rect
+
+
+---
+
+
+### fromScale{#fromScale}
+
+| 이름 | 설명 |
+| --- | --- |
+| fromScale(scaleX, scaleY, scaleWidth, scaleHeight) | 주어진 매개변수로 스케일 필드를 설정하고 모든 오프셋 필드를 0으로 하여 RelativeRectangle를 생성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 스케일 | 숫자 | null |
+| 스케일 | 숫자 | null |
+| scaleWidt | 숫자 | null |
+| scaleHeigh | 숫자 | null |
+
+ **Result:**
+RelativeRectangle
+
+
+---
+
+
+### toString{#toString}
+
+| 이름 | 설명 |
+| --- | --- |
+| toString() | 이 인스턴스의 값을 java.lang.String으로 변환합니다. |
+
+ **Result:**
+RelativeRectangle
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/renderer/_index.md
+++ b/korean/nodejs-java/aspose.threed/renderer/_index.md
@@ -1,0 +1,398 @@
+---
+title: "Renderer"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/renderer/
+---
+## Renderer class
+
+렌더러에 대한 컨텍스트.  @hideconstructor
+
+
+## 메서드
+
+### getShaderSet{#getShaderSet}
+
+| 이름 | 설명 |
+| --- | --- |
+| getShaderSet() | 씬을 렌더링하는 데 사용되는 셰이더 세트를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setShaderSet{#setShaderSet}
+
+| 이름 | 설명 |
+| --- | --- |
+| setShaderSet(value) | 씬을 렌더링하는 데 사용되는 셰이더 세트를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getVariables{#getVariables}
+
+| 이름 | 설명 |
+| --- | --- |
+| getVariables() | 렌더링에 사용되는 내부 변수에 접근합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getPresetShaders{#getPresetShaders}
+
+| 이름 | 설명 |
+| --- | --- |
+| getPresetShaders() | 프리셋 셰이더 세트를 가져오거나 설정합니다. 속성값은 PresetShaders 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setPresetShaders{#setPresetShaders}
+
+| 이름 | 설명 |
+| --- | --- |
+| setPresetShaders(value) | 프리셋 셰이더 세트를 가져오거나 설정합니다. 속성값은 PresetShaders 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getRenderFactory{#getRenderFactory}
+
+| 이름 | 설명 |
+| --- | --- |
+| getRenderFactory() | 렌더링 관련 객체를 생성하는 팩토리를 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAssetDirectories{#getAssetDirectories}
+
+| 이름 | 설명 |
+| --- | --- |
+| getAssetDirectories() | 외부 자산을 저장하는 디렉터리 |
+
+ **Result:**
+
+
+
+---
+
+
+### getPostProcessings{#getPostProcessings}
+
+| 이름 | 설명 |
+| --- | --- |
+| getPostProcessings() | 활성화된 후처리 체인 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEnableShadows{#getEnableShadows}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEnableShadows() | 그림자를 활성화할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setEnableShadows{#setEnableShadows}
+
+| 이름 | 설명 |
+| --- | --- |
+| setEnableShadows(value) | 그림자를 활성화할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getRenderTarget{#getRenderTarget}
+
+| 이름 | 설명 |
+| --- | --- |
+| getRenderTarget() | 다음 렌더링 작업이 수행될 렌더 대상을 지정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getNode{#getNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getNode() | 월드 변환 행렬을 제공하는 데 사용되는 Node 인스턴스를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setNode{#setNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setNode(value) | 월드 변환 행렬을 제공하는 데 사용되는 Node 인스턴스를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFrustum{#getFrustum}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFrustum() | 뷰 행렬을 제공하는 데 사용되는 프러스텀을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFrustum{#setFrustum}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFrustum(value) | 뷰 행렬을 제공하는 데 사용되는 프러스텀을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getRenderStage{#getRenderStage}
+
+| 이름 | 설명 |
+| --- | --- |
+| getRenderStage() | 현재 렌더 단계를 가져옵니다. 이 속성의 값은 RenderStage 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMaterial{#getMaterial}
+
+| 이름 | 설명 |
+| --- | --- |
+| getMaterial() | 셰이더에서 사용되는 재질 정보를 제공하는 데 사용되는 재질을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMaterial{#setMaterial}
+
+| 이름 | 설명 |
+| --- | --- |
+| setMaterial(value) | 셰이더에서 사용되는 재질 정보를 제공하는 데 사용되는 재질을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getShader{#getShader}
+
+| 이름 | 설명 |
+| --- | --- |
+| getShader() | 지오메트리를 렌더링하는 데 사용되는 셰이더 인스턴스를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setShader{#setShader}
+
+| 이름 | 설명 |
+| --- | --- |
+| setShader(value) | 지오메트리를 렌더링하는 데 사용되는 셰이더 인스턴스를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFallbackEntityRenderer{#getFallbackEntityRenderer}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFallbackEntityRenderer() | 엔티티에 특수 렌더러가 정의되지 않은 경우 대체 엔티티 렌더러를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFallbackEntityRenderer{#setFallbackEntityRenderer}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFallbackEntityRenderer(value) | 엔티티에 특수 렌더러가 정의되지 않은 경우 대체 엔티티 렌더러를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### clearCache{#clearCache}
+
+| 이름 | 설명 |
+| --- | --- |
+| clearCache() | 캐시를 수동으로 지웁니다. Aspose.3D는 재질/지오메트리와 같은 일부 객체를 렌더 파이프라인과 호환되는 내부 타입에 캐시합니다. 씬에 큰 변경이 있을 때 수동으로 호출해야 합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getPostProcessing{#getPostProcessing}
+
+| 이름 | 설명 |
+| --- | --- |
+| getPostProcessing(name) | 렌더러에서 지원하는 내장 포스트 프로세서를 가져옵니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| nam | String | null |
+
+ **Result:**
+후처리
+
+
+---
+
+
+### execute{#execute}
+
+| 이름 | 설명 |
+| --- | --- |
+| execute(postProcessing, result) | 지정된 렌더 대상에서 포스트 프로세싱을 실행합니다. |
+
+ **Result:**
+후처리
+
+
+---
+
+
+### createRenderer{#createRenderer}
+
+| 이름 | 설명 |
+| --- | --- |
+| createRenderer() | 기본 프로필로 새로운 Renderer를 생성합니다. |
+
+ **Result:**
+Renderer
+
+
+---
+
+
+### registerEntityRenderer{#registerEntityRenderer}
+
+| 이름 | 설명 |
+| --- | --- |
+| registerEntityRenderer(renderer) | 지정된 엔터티에 대한 엔터티 렌더러를 등록합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| rendere | EntityRenderer | null |
+
+ **Result:**
+Renderer
+
+
+---
+
+
+### render{#render}
+
+| 이름 | 설명 |
+| --- | --- |
+| render(renderTarget) | 지정된 대상을 렌더링합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| renderTarge | IRenderTarget | null |
+
+ **Result:**
+Renderer
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/renderervariablemanager/_index.md
+++ b/korean/nodejs-java/aspose.threed/renderervariablemanager/_index.md
@@ -1,0 +1,328 @@
+---
+title: "RendererVariableManager"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/renderervariablemanager/
+---
+## RendererVariableManager class
+
+이 클래스는 렌더링에 사용되는 변수를 관리합니다  @hideconstructor
+
+
+## 메서드
+
+### getWorldTime{#getWorldTime}
+
+| 이름 | 설명 |
+| --- | --- |
+| getWorldTime() | 시간(초) |
+
+ **Result:**
+
+
+
+---
+
+
+### setWorldTime{#setWorldTime}
+
+| 이름 | 설명 |
+| --- | --- |
+| setWorldTime(value) | 시간(초) |
+
+ **Result:**
+
+
+
+---
+
+
+### getShadowCaster{#getShadowCaster}
+
+| 이름 | 설명 |
+| --- | --- |
+| getShadowCaster() | 월드 좌표계에서 그림자 캐스터의 위치 |
+
+ **Result:**
+
+
+
+---
+
+
+### setShadowCaster{#setShadowCaster}
+
+| 이름 | 설명 |
+| --- | --- |
+| setShadowCaster(value) | 월드 좌표계에서 그림자 캐스터의 위치 |
+
+ **Result:**
+
+
+
+---
+
+
+### getShadowmap{#getShadowmap}
+
+| 이름 | 설명 |
+| --- | --- |
+| getShadowmap() | 그림자 매핑에 사용되는 깊이 텍스처 |
+
+ **Result:**
+
+
+
+---
+
+
+### setShadowmap{#setShadowmap}
+
+| 이름 | 설명 |
+| --- | --- |
+| setShadowmap(value) | 그림자 매핑에 사용되는 깊이 텍스처 |
+
+ **Result:**
+
+
+
+---
+
+
+### getMatrixLightSpace{#getMatrixLightSpace}
+
+| 이름 | 설명 |
+| --- | --- |
+| getMatrixLightSpace() | 광원 공간 변환을 위한 행렬 |
+
+ **Result:**
+
+
+
+---
+
+
+### setMatrixLightSpace{#setMatrixLightSpace}
+
+| 이름 | 설명 |
+| --- | --- |
+| setMatrixLightSpace(value) | 광원 공간 변환을 위한 행렬 |
+
+ **Result:**
+
+
+
+---
+
+
+### getMatrixViewProjection{#getMatrixViewProjection}
+
+| 이름 | 설명 |
+| --- | --- |
+| getMatrixViewProjection() | 뷰와 투영 변환을 위한 행렬. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMatrixWorldViewProjection{#getMatrixWorldViewProjection}
+
+| 이름 | 설명 |
+| --- | --- |
+| getMatrixWorldViewProjection() | 월드 뷰 및 투영 변환을 위한 행렬 |
+
+ **Result:**
+
+
+
+---
+
+
+### getMatrixWorld{#getMatrixWorld}
+
+| 이름 | 설명 |
+| --- | --- |
+| getMatrixWorld() | 월드 변환을 위한 행렬 |
+
+ **Result:**
+
+
+
+---
+
+
+### getMatrixWorldNormal{#getMatrixWorldNormal}
+
+| 이름 | 설명 |
+| --- | --- |
+| getMatrixWorldNormal() | 오브젝트에서 월드 공간으로 노멀을 변환하기 위한 행렬. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMatrixProjection{#getMatrixProjection}
+
+| 이름 | 설명 |
+| --- | --- |
+| getMatrixProjection() | 투영 변환을 위한 행렬 |
+
+ **Result:**
+
+
+
+---
+
+
+### setMatrixProjection{#setMatrixProjection}
+
+| 이름 | 설명 |
+| --- | --- |
+| setMatrixProjection(value) | 투영 변환을 위한 행렬 |
+
+ **Result:**
+
+
+
+---
+
+
+### getMatrixView{#getMatrixView}
+
+| 이름 | 설명 |
+| --- | --- |
+| getMatrixView() | 뷰 변환을 위한 행렬 |
+
+ **Result:**
+
+
+
+---
+
+
+### setMatrixView{#setMatrixView}
+
+| 이름 | 설명 |
+| --- | --- |
+| setMatrixView(value) | 뷰 변환을 위한 행렬 |
+
+ **Result:**
+
+
+
+---
+
+
+### getCameraPosition{#getCameraPosition}
+
+| 이름 | 설명 |
+| --- | --- |
+| getCameraPosition() | 월드 좌표계에서 카메라의 위치 |
+
+ **Result:**
+
+
+
+---
+
+
+### setCameraPosition{#setCameraPosition}
+
+| 이름 | 설명 |
+| --- | --- |
+| setCameraPosition(value) | 월드 좌표계에서 카메라의 위치 |
+
+ **Result:**
+
+
+
+---
+
+
+### getDepthBias{#getDepthBias}
+
+| 이름 | 설명 |
+| --- | --- |
+| getDepthBias() | 그림자 매핑을 위한 깊이 바이어스, 기본값은 0.001 |
+
+ **Result:**
+
+
+
+---
+
+
+### setDepthBias{#setDepthBias}
+
+| 이름 | 설명 |
+| --- | --- |
+| setDepthBias(value) | 그림자 매핑을 위한 깊이 바이어스, 기본값은 0.001 |
+
+ **Result:**
+
+
+
+---
+
+
+### getViewportSize{#getViewportSize}
+
+| 이름 | 설명 |
+| --- | --- |
+| getViewportSize() | 뷰포트 크기, 픽셀 단위 |
+
+ **Result:**
+
+
+
+---
+
+
+### setViewportSize{#setViewportSize}
+
+| 이름 | 설명 |
+| --- | --- |
+| setViewportSize(value) | 뷰포트 크기, 픽셀 단위 |
+
+ **Result:**
+
+
+
+---
+
+
+### getWorldAmbient{#getWorldAmbient}
+
+| 이름 | 설명 |
+| --- | --- |
+| getWorldAmbient() | 뷰포트에 정의된 주변 색상. |
+
+ **Result:**
+
+
+
+---
+
+
+### setWorldAmbient{#setWorldAmbient}
+
+| 이름 | 설명 |
+| --- | --- |
+| setWorldAmbient(value) | 뷰포트에 정의된 주변 색상. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/renderfactory/_index.md
+++ b/korean/nodejs-java/aspose.threed/renderfactory/_index.md
@@ -1,0 +1,243 @@
+---
+title: "RenderFactory"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/renderfactory/
+---
+## RenderFactory class
+
+RenderFactory는 렌더링 파이프라인에 표시되는 모든 리소스를 생성합니다.  @hideconstructor
+
+
+## 메서드
+
+### createRenderTexture{#createRenderTexture}
+
+| 이름 | 설명 |
+| --- | --- |
+| createRenderTexture(parameters, targets, width, height) | 텍스처에 렌더링하는 렌더 타깃을 생성합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| parameters | RenderParameters | 렌더 텍스처를 생성하기 위한 렌더 파라미터 |
+| targets | 숫자 | 색상 출력 타깃 수 |
+| 너비 | 숫자 | 렌더 텍스처의 너비 |
+| height | 숫자 | 렌더 텍스처의 높이 |
+
+ **Result:**
+IRenderTexture
+
+
+---
+
+
+### createRenderTexture{#createRenderTexture}
+
+| 이름 | 설명 |
+| --- | --- |
+| createRenderTexture(parameters, width, height) | 텍스처에 렌더링하는 1개의 타깃을 포함하는 렌더 타깃을 생성합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| parameters | RenderParameters | 렌더 텍스처를 생성하기 위한 렌더 파라미터 |
+| 너비 | 숫자 | 렌더 텍스처의 너비 |
+| height | 숫자 | 렌더 텍스처의 높이 |
+
+ **Result:**
+IRenderTexture
+
+
+---
+
+
+### createDescriptorSet{#createDescriptorSet}
+
+| 이름 | 설명 |
+| --- | --- |
+| createDescriptorSet(shader) | 지정된 셰이더 프로그램에 대한 디스크립터 세트를 생성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| shader | ShaderProgram | 셰이더 프로그램 |
+
+ **Result:**
+IDescriptorSet
+
+
+---
+
+
+### createCubeRenderTexture{#createCubeRenderTexture}
+
+| 이름 | 설명 |
+| --- | --- |
+| createCubeRenderTexture(parameters, width, height) | 1개의 큐브 텍스처를 포함하는 렌더 타깃을 생성합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| parameters | RenderParameters | 렌더 텍스처를 생성하기 위한 렌더 파라미터 |
+| 너비 | 숫자 | 렌더 텍스처의 너비 |
+| height | 숫자 | 렌더 텍스처의 높이 |
+
+ **Result:**
+IRenderTexture
+
+
+---
+
+
+### createRenderWindow{#createRenderWindow}
+
+| 이름 | 설명 |
+| --- | --- |
+| createRenderWindow(parameters, handle) | 네이티브 윈도우에 렌더링하는 렌더 타깃을 생성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| parameters | RenderParameters | 렌더 윈도우를 생성하기 위한 렌더 파라미터 |
+| handle | WindowHandle | 렌더링할 윈도우의 핸들 |
+
+ **Result:**
+IRenderWindow
+
+
+---
+
+
+### createVertexBuffer{#createVertexBuffer}
+
+| 이름 | 설명 |
+| --- | --- |
+| createVertexBuffer(declaration) | 다각형의 정점 정보를 저장하기 위해 com.aspose.threed.IVertexBuffer 인스턴스를 생성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| declaratio | VertexDeclaration | null |
+
+ **Result:**
+IVertexBuffer
+
+
+---
+
+
+### createIndexBuffer{#createIndexBuffer}
+
+| 이름 | 설명 |
+| --- | --- |
+| createIndexBuffer() | 다각형의 면 정보를 저장하기 위해 com.aspose.threed.IIndexBuffer 인스턴스를 생성합니다. |
+
+ **Result:**
+IIndexBuffer
+
+
+---
+
+
+### createTextureUnit{#createTextureUnit}
+
+| 이름 | 설명 |
+| --- | --- |
+| createTextureUnit(textureType) | 셰이더에서 접근할 수 있는 텍스처 유닛을 생성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| textureType | TextureType | TextureType |
+
+ **Result:**
+ITextureUnit
+
+
+---
+
+
+### createTextureUnit{#createTextureUnit}
+
+| 이름 | 설명 |
+| --- | --- |
+| createTextureUnit() | 셰이더에서 접근할 수 있는 2D 텍스처 유닛을 생성합니다. |
+
+ **Result:**
+ITextureUnit
+
+
+---
+
+
+### createShaderProgram{#createShaderProgram}
+
+| 이름 | 설명 |
+| --- | --- |
+| createShaderProgram(shaderSource) | ShaderProgram 객체를 생성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| shaderSource | ShaderSource | 셰이더의 소스 코드 |
+
+ **Result:**
+ShaderProgram
+
+
+---
+
+
+### createPipeline{#createPipeline}
+
+| 이름 | 설명 |
+| --- | --- |
+| createPipeline(shader, renderState, vertexDeclaration, drawOperation) | 사전 구성된 셰이더/렌더 상태/버텍스 선언 및 그리기 작업이 포함된 그래픽 파이프라인을 생성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| shader | ShaderProgram | 렌더링에 사용되는 셰이더 |
+| renderState | RenderState | 렌더링에 사용되는 렌더 상태 |
+| vertexDeclaration | VertexDeclaration | 입력 정점 데이터의 버텍스 선언 |
+| drawOperation | DrawOperation | DrawOperation |
+
+ **Result:**
+IPipeline
+
+
+---
+
+
+### createUniformBuffer{#createUniformBuffer}
+
+| 이름 | 설명 |
+| --- | --- |
+| createUniformBuffer(size) | GPU 측에서 사전 할당된 크기로 새로운 유니폼 버퍼를 생성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 크기 | 숫자 | 유니폼 버퍼의 크기 |
+
+ **Result:**
+IBuffer
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/renderparameters/_index.md
+++ b/korean/nodejs-java/aspose.threed/renderparameters/_index.md
@@ -1,0 +1,133 @@
+---
+title: "RenderParameters"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/renderparameters/
+---
+## RenderParameters class
+
+렌더 타깃의 매개변수를 설명합니다
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| 생성자(doubleBuffering, colorBits, depthBits, stencilBits) | PixelFormat의 인스턴스를 초기화합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getDoubleBuffering{#getDoubleBuffering}
+
+| 이름 | 설명 |
+| --- | --- |
+| getDoubleBuffering() | double buffer가 사용되는지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDoubleBuffering{#setDoubleBuffering}
+
+| 이름 | 설명 |
+| --- | --- |
+| setDoubleBuffering(value) | double buffer가 사용되는지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getColorBits{#getColorBits}
+
+| 이름 | 설명 |
+| --- | --- |
+| getColorBits() | color buffer에 사용될 비트 수를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setColorBits{#setColorBits}
+
+| 이름 | 설명 |
+| --- | --- |
+| setColorBits(value) | color buffer에 사용될 비트 수를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDepthBits{#getDepthBits}
+
+| 이름 | 설명 |
+| --- | --- |
+| getDepthBits() | depth buffer에 사용될 비트 수를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDepthBits{#setDepthBits}
+
+| 이름 | 설명 |
+| --- | --- |
+| setDepthBits(value) | depth buffer에 사용될 비트 수를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getStencilBits{#getStencilBits}
+
+| 이름 | 설명 |
+| --- | --- |
+| getStencilBits() | stencil buffer에 사용될 비트 수를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setStencilBits{#setStencilBits}
+
+| 이름 | 설명 |
+| --- | --- |
+| setStencilBits(value) | stencil buffer에 사용될 비트 수를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/renderresource/_index.md
+++ b/korean/nodejs-java/aspose.threed/renderresource/_index.md
@@ -1,0 +1,13 @@
+---
+title: "RenderResource"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/renderresource/
+---
+## RenderResource class
+
+모든 렌더 리소스의 추상 클래스  렌더러가 해제될 때 모든 렌더 리소스가 폐기됩니다.  Mesh/Texture와 같은 클래스는 해당하는 RenderResource를 가집니다  @hideconstructor
+
+

--- a/korean/nodejs-java/aspose.threed/renderstate/_index.md
+++ b/korean/nodejs-java/aspose.threed/renderstate/_index.md
@@ -1,0 +1,477 @@
+---
+title: "RenderState"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/renderstate/
+---
+## RenderState class
+
+파이프라인 구축을 위한 렌더 상태  렌더 상태에 대한 변경은 생성된 파이프라인 인스턴스에 영향을 주지 않습니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | RenderState의 생성자 |
+
+ **Result:**
+
+
+
+---
+
+
+### getBlend{#getBlend}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBlend() | 프래그먼트 블렌딩을 활성화하거나 비활성화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setBlend{#setBlend}
+
+| 이름 | 설명 |
+| --- | --- |
+| setBlend(value) | 프래그먼트 블렌딩을 활성화하거나 비활성화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getBlendColor{#getBlendColor}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBlendColor() | BlendFactor.CONSTANT_COLOR에서 사용되는 블렌드 색상을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setBlendColor{#setBlendColor}
+
+| 이름 | 설명 |
+| --- | --- |
+| setBlendColor(value) | BlendFactor.CONSTANT_COLOR에서 사용되는 블렌드 색상을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getSourceBlendFactor{#getSourceBlendFactor}
+
+| 이름 | 설명 |
+| --- | --- |
+| getSourceBlendFactor() | 색상이 블렌드되는 방식을 가져오거나 설정합니다. 해당 속성의 값은 BlendFactor 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setSourceBlendFactor{#setSourceBlendFactor}
+
+| 이름 | 설명 |
+| --- | --- |
+| setSourceBlendFactor(value) | 색상이 블렌드되는 방식을 가져오거나 설정합니다. 해당 속성의 값은 BlendFactor 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDestinationBlendFactor{#getDestinationBlendFactor}
+
+| 이름 | 설명 |
+| --- | --- |
+| getDestinationBlendFactor() | 색상이 블렌드되는 방식을 가져오거나 설정합니다. 해당 속성의 값은 BlendFactor 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDestinationBlendFactor{#setDestinationBlendFactor}
+
+| 이름 | 설명 |
+| --- | --- |
+| setDestinationBlendFactor(value) | 색상이 블렌드되는 방식을 가져오거나 설정합니다. 해당 속성의 값은 BlendFactor 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getCullFace{#getCullFace}
+
+| 이름 | 설명 |
+| --- | --- |
+| getCullFace() | 컬 페이스를 활성화하거나 비활성화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setCullFace{#setCullFace}
+
+| 이름 | 설명 |
+| --- | --- |
+| setCullFace(value) | 컬 페이스를 활성화하거나 비활성화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getCullFaceMode{#getCullFaceMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getCullFaceMode() | 제거될 면을 가져오거나 설정합니다. 속성값은 CullFaceMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setCullFaceMode{#setCullFaceMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setCullFaceMode(value) | 제거될 면을 가져오거나 설정합니다. 속성값은 CullFaceMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFrontFace{#getFrontFace}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFrontFace() | 전면이 되는 순서를 가져오거나 설정합니다. 속성값은 FrontFace 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFrontFace{#setFrontFace}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFrontFace(value) | 전면이 되는 순서를 가져오거나 설정합니다. 속성값은 FrontFace 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDepthTest{#getDepthTest}
+
+| 이름 | 설명 |
+| --- | --- |
+| getDepthTest() | 깊이 테스트를 활성화하거나 비활성화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDepthTest{#setDepthTest}
+
+| 이름 | 설명 |
+| --- | --- |
+| setDepthTest(value) | 깊이 테스트를 활성화하거나 비활성화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDepthMask{#getDepthMask}
+
+| 이름 | 설명 |
+| --- | --- |
+| getDepthMask() | 깊이 쓰기를 활성화하거나 비활성화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDepthMask{#setDepthMask}
+
+| 이름 | 설명 |
+| --- | --- |
+| setDepthMask(value) | 깊이 쓰기를 활성화하거나 비활성화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDepthFunction{#getDepthFunction}
+
+| 이름 | 설명 |
+| --- | --- |
+| getDepthFunction() | 깊이 테스트에 사용되는 비교 함수를 가져오거나 설정합니다. 속성값은 CompareFunction 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDepthFunction{#setDepthFunction}
+
+| 이름 | 설명 |
+| --- | --- |
+| setDepthFunction(value) | 깊이 테스트에 사용되는 비교 함수를 가져오거나 설정합니다. 속성값은 CompareFunction 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getStencilTest{#getStencilTest}
+
+| 이름 | 설명 |
+| --- | --- |
+| getStencilTest() | 스텐실 테스트를 활성화하거나 비활성화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setStencilTest{#setStencilTest}
+
+| 이름 | 설명 |
+| --- | --- |
+| setStencilTest(value) | 스텐실 테스트를 활성화하거나 비활성화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getStencilReference{#getStencilReference}
+
+| 이름 | 설명 |
+| --- | --- |
+| getStencilReference() | 스텐실 테스트에 대한 참조 값을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setStencilReference{#setStencilReference}
+
+| 이름 | 설명 |
+| --- | --- |
+| setStencilReference(value) | 스텐실 테스트에 대한 참조 값을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getStencilMask{#getStencilMask}
+
+| 이름 | 설명 |
+| --- | --- |
+| getStencilMask() | 테스트가 완료될 때 참조값과 저장된 스텐실 값 모두와 AND 연산되는 마스크를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getStencilFrontFace{#getStencilFrontFace}
+
+| 이름 | 설명 |
+| --- | --- |
+| getStencilFrontFace() | 전면에 대한 스텐실 상태를 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getStencilBackFace{#getStencilBackFace}
+
+| 이름 | 설명 |
+| --- | --- |
+| getStencilBackFace() | 뒷면에 대한 스텐실 상태를 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScissorTest{#getScissorTest}
+
+| 이름 | 설명 |
+| --- | --- |
+| getScissorTest() | 스크리너 테스트를 활성화하거나 비활성화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setScissorTest{#setScissorTest}
+
+| 이름 | 설명 |
+| --- | --- |
+| setScissorTest(value) | 스크리너 테스트를 활성화하거나 비활성화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getPolygonMode{#getPolygonMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getPolygonMode() | 다각형의 렌더링 모드를 가져오거나 설정합니다. 이 속성의 값은 PolygonMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setPolygonMode{#setPolygonMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setPolygonMode(value) | 다각형의 렌더링 모드를 가져오거나 설정합니다. 이 속성의 값은 PolygonMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### equals{#equals}
+
+| 이름 | 설명 |
+| --- | --- |
+| equals(obj) | 이 인스턴스가 지정된 객체와 같은지 여부를 나타내는 값을 반환합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### hashCode{#hashCode}
+
+| 이름 | 설명 |
+| --- | --- |
+| hashCode() | 이 인스턴스의 해시 코드를 반환합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### compareTo{#compareTo}
+
+| 이름 | 설명 |
+| --- | --- |
+| compareTo(other) | 렌더 상태를 다른 인스턴스와 비교합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| othe | RenderState | null |
+
+ **Result:**
+숫자
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/revolvedareasolid/_index.md
+++ b/korean/nodejs-java/aspose.threed/revolvedareasolid/_index.md
@@ -1,0 +1,411 @@
+---
+title: "RevolvedAreaSolid"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/revolvedareasolid/
+---
+## RevolvedAreaSolid class
+
+이 클래스는 프로파일이 제공하는 단면을 축을 중심으로 회전시켜 고체 모델을 나타냅니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getAngleStart{#getAngleStart}
+
+| 이름 | 설명 |
+| --- | --- |
+| getAngleStart() | 회전 절차의 시작 각도를 가져오거나 설정합니다. 라디안으로 측정되며, 기본값은 0입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setAngleStart{#setAngleStart}
+
+| 이름 | 설명 |
+| --- | --- |
+| setAngleStart(value) | 회전 절차의 시작 각도를 가져오거나 설정합니다. 라디안으로 측정되며, 기본값은 0입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAngleEnd{#getAngleEnd}
+
+| 이름 | 설명 |
+| --- | --- |
+| getAngleEnd() | 회전 절차의 종료 각도를 가져오거나 설정합니다. 라디안으로 측정되며, 기본값은 π입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setAngleEnd{#setAngleEnd}
+
+| 이름 | 설명 |
+| --- | --- |
+| setAngleEnd(value) | 회전 절차의 종료 각도를 가져오거나 설정합니다. 라디안으로 측정되며, 기본값은 π입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAxis{#getAxis}
+
+| 이름 | 설명 |
+| --- | --- |
+| getAxis() | 축 방향을 가져오거나 설정합니다. 기본값은 (0, 1, 0)입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setAxis{#setAxis}
+
+| 이름 | 설명 |
+| --- | --- |
+| setAxis(value) | 축 방향을 가져오거나 설정합니다. 기본값은 (0, 1, 0)입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getOrigin{#getOrigin}
+
+| 이름 | 설명 |
+| --- | --- |
+| getOrigin() | 회전의 원점 위치를 가져오거나 설정합니다. 기본값은 (0, 0, 0)입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setOrigin{#setOrigin}
+
+| 이름 | 설명 |
+| --- | --- |
+| setOrigin(value) | 회전의 원점 위치를 가져오거나 설정합니다. 기본값은 (0, 0, 0)입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getShape{#getShape}
+
+| 이름 | 설명 |
+| --- | --- |
+| getShape() | 회전에 사용되는 기본 프로파일을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setShape{#setShape}
+
+| 이름 | 설명 |
+| --- | --- |
+| setShape(value) | 회전에 사용되는 기본 프로파일을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNodes() | 모든 부모 노드를 가져옵니다. 엔터티는 기하학 인스턴싱을 위해 여러 부모 노드에 부착될 수 있습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExcluded() | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExcluded(value) | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNode() | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setParentNode(value) | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 이름 | 설명 |
+| --- | --- |
+| getScene() | 이 객체가 속한 씬을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### toMesh{#toMesh}
+
+| 이름 | 설명 |
+| --- | --- |
+| toMesh() | RevolvedAreaSolid을 메시로 변환합니다. |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBoundingBox() | 현재 엔터티의 객체 공간 좌표계에서 경계 상자를 가져옵니다. |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEntityRendererKey() | 렌더러에 등록된 엔터티 렌더러의 키를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/rvmformat/_index.md
+++ b/korean/nodejs-java/aspose.threed/rvmformat/_index.md
@@ -1,0 +1,141 @@
+---
+title: "RvmFormat"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/rvmformat/
+---
+## RvmFormat class
+
+RVM 포맷  @hideconstructor
+
+
+## 메서드
+
+### getVersion{#getVersion}
+
+| 이름 | 설명 |
+| --- | --- |
+| getVersion() | 파일 형식 버전을 가져옵니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtension{#getExtension}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExtension() | 이 유형의 확장자 이름을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtensions{#getExtensions}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExtensions() | 이 유형의 확장자 이름들을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getContentType{#getContentType}
+
+| 이름 | 설명 |
+| --- | --- |
+| getContentType() | 파일 형식 콘텐츠 유형을 가져옵니다. 속성 값은 FileContentType 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormatType{#getFileFormatType}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileFormatType() | 파일 형식 유형을 가져옵니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### loadAttributes{#loadAttributes}
+
+| 이름 | 설명 |
+| --- | --- |
+| loadAttributes(scene, fileName, prefix) | 지정된 파일 이름에서 속성을 로드합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| scene | Scene | 속성이 적용될 씬 |
+| fileName | String | 속성을 포함하는 파일 이름 |
+| prefix | String | 이름 충돌을 방지하기 위해 사용되는 속성의 접두사이며, 기본값은 "rvm:"입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### createLoadOptions{#createLoadOptions}
+
+| 이름 | 설명 |
+| --- | --- |
+| createLoadOptions() | 이 파일 형식에 대한 기본 로드 옵션을 생성합니다. |
+
+ **Result:**
+LoadOptions
+
+
+---
+
+
+### createSaveOptions{#createSaveOptions}
+
+| 이름 | 설명 |
+| --- | --- |
+| createSaveOptions() | 이 파일 형식에 대한 기본 저장 옵션을 생성합니다. |
+
+ **Result:**
+SaveOptions
+
+
+---
+
+
+### toString{#toString}
+
+| 이름 | 설명 |
+| --- | --- |
+| toString() | 형식을 문자열로 변환 |
+
+ **Result:**
+String
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/rvmloadoptions/_index.md
+++ b/korean/nodejs-java/aspose.threed/rvmloadoptions/_index.md
@@ -1,0 +1,373 @@
+---
+title: "RvmLoadOptions"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/rvmloadoptions/
+---
+## RvmLoadOptions class
+
+AVEVA Plant Design Management System의 RVM 파일에 대한 로드 옵션.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor(contentType) | RvmLoadOptions 인스턴스를 생성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| contentType | FileContentType | FileContentType |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload() | RvmLoadOptions 인스턴스를 생성합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getGenerateMaterials{#getGenerateMaterials}
+
+| 이름 | 설명 |
+| --- | --- |
+| getGenerateMaterials() | RVM 파일에 색상 테이블이 내보내지지 않은 경우, 씬의 각 객체에 대해 무작위 색상으로 재료를 생성합니다. 기본값은 true입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setGenerateMaterials{#setGenerateMaterials}
+
+| 이름 | 설명 |
+| --- | --- |
+| setGenerateMaterials(value) | RVM 파일에 색상 테이블이 내보내지지 않은 경우, 씬의 각 객체에 대해 무작위 색상으로 재료를 생성합니다. 기본값은 true입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getCylinderRadialSegments{#getCylinderRadialSegments}
+
+| 이름 | 설명 |
+| --- | --- |
+| getCylinderRadialSegments() | 실린더의 방사형 세그먼트 수를 가져오거나 설정합니다. 기본값은 16입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setCylinderRadialSegments{#setCylinderRadialSegments}
+
+| 이름 | 설명 |
+| --- | --- |
+| setCylinderRadialSegments(value) | 실린더의 방사형 세그먼트 수를 가져오거나 설정합니다. 기본값은 16입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDishLongitudeSegments{#getDishLongitudeSegments}
+
+| 이름 | 설명 |
+| --- | --- |
+| getDishLongitudeSegments() | 디시의 경도 세그먼트 수를 가져오거나 설정합니다. 기본값은 12입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDishLongitudeSegments{#setDishLongitudeSegments}
+
+| 이름 | 설명 |
+| --- | --- |
+| setDishLongitudeSegments(value) | 디시의 경도 세그먼트 수를 가져오거나 설정합니다. 기본값은 12입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDishLatitudeSegments{#getDishLatitudeSegments}
+
+| 이름 | 설명 |
+| --- | --- |
+| getDishLatitudeSegments() | 디시의 위도 세그먼트 수를 가져오거나 설정합니다. 기본값은 8입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDishLatitudeSegments{#setDishLatitudeSegments}
+
+| 이름 | 설명 |
+| --- | --- |
+| setDishLatitudeSegments(value) | 디시의 위도 세그먼트 수를 가져오거나 설정합니다. 기본값은 8입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTorusTubularSegments{#getTorusTubularSegments}
+
+| 이름 | 설명 |
+| --- | --- |
+| getTorusTubularSegments() | 토러스의 튜블러 세그먼트 수를 가져오거나 설정합니다. 기본값은 20입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTorusTubularSegments{#setTorusTubularSegments}
+
+| 이름 | 설명 |
+| --- | --- |
+| setTorusTubularSegments(value) | 토러스의 튜블러 세그먼트 수를 가져오거나 설정합니다. 기본값은 20입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getRectangularTorusSegments{#getRectangularTorusSegments}
+
+| 이름 | 설명 |
+| --- | --- |
+| getRectangularTorusSegments() | 직사각형 토러스의 방사형 세그먼트 수를 가져오거나 설정합니다. 기본값은 20입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRectangularTorusSegments{#setRectangularTorusSegments}
+
+| 이름 | 설명 |
+| --- | --- |
+| setRectangularTorusSegments(value) | 직사각형 토러스의 방사형 세그먼트 수를 가져오거나 설정합니다. 기본값은 20입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getCenterScene{#getCenterScene}
+
+| 이름 | 설명 |
+| --- | --- |
+| getCenterScene() | 로드된 후 장면을 중앙에 배치합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setCenterScene{#setCenterScene}
+
+| 이름 | 설명 |
+| --- | --- |
+| setCenterScene(value) | 로드된 후 장면을 중앙에 배치합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAttributePrefix{#getAttributePrefix}
+
+| 이름 | 설명 |
+| --- | --- |
+| getAttributePrefix() | 외부 속성 파일에서 정의된 속성들의 접두사를 가져오거나 설정합니다. 접두사는 이름 충돌을 방지하기 위해 사용되며, 기본값은 "rvm:"입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setAttributePrefix{#setAttributePrefix}
+
+| 이름 | 설명 |
+| --- | --- |
+| setAttributePrefix(value) | 외부 속성 파일에서 정의된 속성들의 접두사를 가져오거나 설정합니다. 접두사는 이름 충돌을 방지하기 위해 사용되며, 기본값은 "rvm:"입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupAttributes{#getLookupAttributes}
+
+| 이름 | 설명 |
+| --- | --- |
+| getLookupAttributes() | 외부 속성 목록 파일(.att/.attrib/.txt)에서 속성을 로드할지 여부를 가져오거나 설정합니다. 기본값은 true입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setLookupAttributes{#setLookupAttributes}
+
+| 이름 | 설명 |
+| --- | --- |
+| setLookupAttributes(value) | 외부 속성 목록 파일(.att/.attrib/.txt)에서 속성을 로드할지 여부를 가져오거나 설정합니다. 기본값은 true입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileFormat() | 현재 저장/로드 옵션에 지정된 파일 형식을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEncoding() | 텍스트 기반 파일에 대한 기본 인코딩을 가져오거나 설정합니다. 기본값은 null이며, 이는 가져오기/내보내기 프로그램이 사용할 인코딩을 결정함을 의미합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileSystem() | 로드/저장 중 외부 종속성을 관리하는 방법을 사용자가 처리하도록 허용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFileSystem(value) | 로드/저장 중 외부 종속성을 관리하는 방법을 사용자가 처리하도록 허용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| 이름 | 설명 |
+| --- | --- |
+| getLookupPaths() | OBJ와 같은 일부 파일은 외부 파일에 의존하며, 조회 경로를 통해 Aspose.3D가 외부 파일을 찾아 로드할 수 있도록 합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileName() | 내보내기/가져오기 씬의 파일 이름입니다. 선택 사항이지만 OBJ의 재질과 같은 외부 자산을 직렬화할 때 유용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFileName(value) | 내보내기/가져오기 씬의 파일 이름입니다. 선택 사항이지만 OBJ의 재질과 같은 외부 자산을 직렬화할 때 유용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/rvmsaveoptions/_index.md
+++ b/korean/nodejs-java/aspose.threed/rvmsaveoptions/_index.md
@@ -1,0 +1,321 @@
+---
+title: "RvmSaveOptions"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/rvmsaveoptions/
+---
+## RvmSaveOptions class
+
+Aveva PDMS RVM 파일에 대한 저장 옵션.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | RvmSaveOptions의 생성자 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload(contentType) | RvmSaveOptions의 생성자 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| contentType | FileContentType | FileContentType |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileNote{#getFileNote}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileNote() | 파일 헤더에 있는 파일 메모. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileNote{#setFileNote}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFileNote(value) | 파일 헤더에 있는 파일 메모. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAuthor{#getAuthor}
+
+| 이름 | 설명 |
+| --- | --- |
+| getAuthor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### setAuthor{#setAuthor}
+
+| 이름 | 설명 |
+| --- | --- |
+| setAuthor(value) |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getCreationTime{#getCreationTime}
+
+| 이름 | 설명 |
+| --- | --- |
+| getCreationTime() | 이 파일을 내보낸 타임스탬프이며, 기본값은 현재 시간입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setCreationTime{#setCreationTime}
+
+| 이름 | 설명 |
+| --- | --- |
+| setCreationTime(value) | 이 파일을 내보낸 타임스탬프이며, 기본값은 현재 시간입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAttributePrefix{#getAttributePrefix}
+
+| 이름 | 설명 |
+| --- | --- |
+| getAttributePrefix() | 내보낼 속성의 접두사를 가져오거나 설정합니다. 내보낸 속성은 접두사가 없으며, 다른 접두사를 가진 사용자 정의 속성은 내보내지 않습니다. 기본값은 'rvm:'입니다. 예를 들어 속성이 rvm:Refno=345인 경우, 내보낸 속성은 Refno = 345가 되며, 접두사가 제거됩니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setAttributePrefix{#setAttributePrefix}
+
+| 이름 | 설명 |
+| --- | --- |
+| setAttributePrefix(value) | 내보낼 속성의 접두사를 가져오거나 설정합니다. 내보낸 속성은 접두사가 없으며, 다른 접두사를 가진 사용자 정의 속성은 내보내지 않습니다. 기본값은 'rvm:'입니다. 예를 들어 속성이 rvm:Refno=345인 경우, 내보낸 속성은 Refno = 345가 되며, 접두사가 제거됩니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAttributeListFile{#getAttributeListFile}
+
+| 이름 | 설명 |
+| --- | --- |
+| getAttributeListFile() | 속성 목록 파일의 파일 이름을 가져오거나 설정합니다. 이 속성이 정의되지 않은 경우 내보내기 프로그램은 .rvm 파일 이름을 기반으로 이름을 생성합니다. 기본값은 null입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setAttributeListFile{#setAttributeListFile}
+
+| 이름 | 설명 |
+| --- | --- |
+| setAttributeListFile(value) | 속성 목록 파일의 파일 이름을 가져오거나 설정합니다. 이 속성이 정의되지 않은 경우 내보내기 프로그램은 .rvm 파일 이름을 기반으로 이름을 생성합니다. 기본값은 null입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportAttributes{#getExportAttributes}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExportAttributes() | 속성 목록을 외부 .att 파일로 내보낼지 여부를 가져오거나 설정합니다. 기본값은 false입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportAttributes{#setExportAttributes}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExportAttributes(value) | 속성 목록을 외부 .att 파일로 내보낼지 여부를 가져오거나 설정합니다. 기본값은 false입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportTextures{#getExportTextures}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExportTextures() | 씬에서 사용된 텍스처를 출력 디렉터리로 복사합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextures{#setExportTextures}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExportTextures(value) | 씬에서 사용된 텍스처를 출력 디렉터리로 복사합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileFormat() | 현재 저장/로드 옵션에 지정된 파일 형식을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEncoding() | 텍스트 기반 파일에 대한 기본 인코딩을 가져오거나 설정합니다. 기본값은 null이며, 이는 가져오기/내보내기 프로그램이 사용할 인코딩을 결정함을 의미합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileSystem() | 로드/저장 중 외부 종속성을 관리하는 방법을 사용자가 처리하도록 허용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFileSystem(value) | 로드/저장 중 외부 종속성을 관리하는 방법을 사용자가 처리하도록 허용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| 이름 | 설명 |
+| --- | --- |
+| getLookupPaths() | OBJ와 같은 일부 파일은 외부 파일에 의존하며, 조회 경로를 통해 Aspose.3D가 외부 파일을 찾아 로드할 수 있도록 합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileName() | 내보내기/가져오기 씬의 파일 이름입니다. 선택 사항이지만 OBJ의 재질과 같은 외부 자산을 직렬화할 때 유용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFileName(value) | 내보내기/가져오기 씬의 파일 이름입니다. 선택 사항이지만 OBJ의 재질과 같은 외부 자산을 직렬화할 때 유용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/saveoptions/_index.md
+++ b/korean/nodejs-java/aspose.threed/saveoptions/_index.md
@@ -1,0 +1,133 @@
+---
+title: "SaveOptions"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/saveoptions/
+---
+## SaveOptions class
+
+다양한 유형에 대한 파일 저장 옵션을 구성하기 위한 기본 클래스  @hideconstructor
+
+
+## 메서드
+
+### getExportTextures{#getExportTextures}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExportTextures() | 씬에서 사용된 텍스처를 출력 디렉터리로 복사합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextures{#setExportTextures}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExportTextures(value) | 씬에서 사용된 텍스처를 출력 디렉터리로 복사합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileFormat() | 현재 저장/로드 옵션에 지정된 파일 형식을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEncoding() | 텍스트 기반 파일에 대한 기본 인코딩을 가져오거나 설정합니다. 기본값은 null이며, 이는 가져오기/내보내기 프로그램이 사용할 인코딩을 결정함을 의미합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileSystem() | 로드/저장 중 외부 종속성을 관리하는 방법을 사용자가 처리하도록 허용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFileSystem(value) | 로드/저장 중 외부 종속성을 관리하는 방법을 사용자가 처리하도록 허용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| 이름 | 설명 |
+| --- | --- |
+| getLookupPaths() | OBJ와 같은 일부 파일은 외부 파일에 의존하며, 조회 경로를 통해 Aspose.3D가 외부 파일을 찾아 로드할 수 있도록 합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileName() | 내보내기/가져오기 씬의 파일 이름입니다. 선택 사항이지만 OBJ의 재질과 같은 외부 자산을 직렬화할 때 유용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFileName(value) | 내보내기/가져오기 씬의 파일 이름입니다. 선택 사항이지만 OBJ의 재질과 같은 외부 자산을 직렬화할 때 유용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/scene/_index.md
+++ b/korean/nodejs-java/aspose.threed/scene/_index.md
@@ -1,0 +1,626 @@
+---
+title: "Scene"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/scene/
+---
+## Scene class
+
+Scene은 노드, 기하학, 재질, 텍스처, 애니메이션, 포즈, 서브 씬 등을 포함하는 최상위 객체입니다.  Scene은 서브 씬을 가질 수 있으며, collada/blender/fbx와 같은 파일에서 다중 문서 지원 역할을 합니다.  Node 계층 구조는 RootNodeLibrary를 통해 접근할 수 있으며, 직렬화 중에 연결되지 않은 객체(메타 데이터 또는 사용자 정의 객체 등)의 참조를 유지하기 위해 사용되어 라이브러리로 활용됩니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | Scene 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload(entity) | 새 노드에 엔터티가 연결된 상태로 Scene 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| entity | Entity | 씬에 연결된 초기 엔터티 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload2(parentScene, name) | Scene 클래스의 새 인스턴스를 서브 씬으로 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| parentScene | Scene | 부모 씬입니다. |
+| name | String | 씬 이름입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload3{#constructor_overload3}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload3(fileName) | Scene 클래스의 새 인스턴스를 초기화하고 파일을 즉시 엽니다. 이 생성자는 더 이상 사용되지 않으며, #Error Cref: M:Aspose.ThreeD.Scene.FromFile(System.String,System.Threading.CancellationToken)를 사용하십시오. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| fileName | String | 열 파일의 이름입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getSubScenes{#getSubScenes}
+
+| 이름 | 설명 |
+| --- | --- |
+| getSubScenes() | 모든 서브 씬을 가져옵니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getLibrary{#getLibrary}
+
+| 이름 | 설명 |
+| --- | --- |
+| getLibrary() | 씬 계층 구조에 직접 사용되지 않는 객체는 Library에 정의할 수 있습니다. 이는 서브 씬을 사용하고 재사용 가능한 컴포넌트를 서브 씬 아래에 배치할 때 유용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAnimationClips{#getAnimationClips}
+
+| 이름 | 설명 |
+| --- | --- |
+| getAnimationClips() | 씬에 정의된 모든 AnimationClip을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getCurrentAnimationClip{#getCurrentAnimationClip}
+
+| 이름 | 설명 |
+| --- | --- |
+| getCurrentAnimationClip() | 활성 AnimationClip을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setCurrentAnimationClip{#setCurrentAnimationClip}
+
+| 이름 | 설명 |
+| --- | --- |
+| setCurrentAnimationClip(value) | 활성 AnimationClip을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAssetInfo{#getAssetInfo}
+
+| 이름 | 설명 |
+| --- | --- |
+| getAssetInfo() | 최상위 자산 정보인 문서 정보를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setAssetInfo{#setAssetInfo}
+
+| 이름 | 설명 |
+| --- | --- |
+| setAssetInfo(value) | 최상위 자산 정보인 문서 정보를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getPoses{#getPoses}
+
+| 이름 | 설명 |
+| --- | --- |
+| getPoses() | 이 씬에서 사용되는 모든 Pose를 가져옵니다. Pose들. |
+
+ **Result:**
+
+
+
+---
+
+
+### getRootNode{#getRootNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getRootNode() | 씬의 루트 노드를 가져옵니다. 루트 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 이름 | 설명 |
+| --- | --- |
+| getScene() | 이 객체가 속한 씬을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAnimationClip{#getAnimationClip}
+
+| 이름 | 설명 |
+| --- | --- |
+| getAnimationClip(name) | 지정된 이름의 AnimationClip을 가져옵니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| name | String | 그 |
+
+ **Result:**
+AnimationClip
+
+
+---
+
+
+### clear{#clear}
+
+| 이름 | 설명 |
+| --- | --- |
+| clear() | 씬 내용을 지우고 기본 설정을 복원합니다. |
+
+ **Result:**
+AnimationClip
+
+
+---
+
+
+### createAnimationClip{#createAnimationClip}
+
+| 이름 | 설명 |
+| --- | --- |
+| createAnimationClip(name) | AnimationClip을 생성하고 등록하는 간단한 함수입니다. 첫 번째 AnimationClip은 CurrentAnimationClip에 할당됩니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| name | String | Animation clip의 이름 |
+
+ **Result:**
+AnimationClip
+
+
+---
+
+
+### open{#open}
+
+| 이름 | 설명 |
+| --- | --- |
+| open(fileName, options) | 지정된 파일 형식을 사용하여 주어진 경로에서 씬을 엽니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| fileName | String | 파일 이름. |
+| 옵션 | LoadOptions | 스트림을 열기 위한 보다 자세한 구성. |
+
+ **Result:**
+AnimationClip
+
+
+---
+
+
+### open{#open}
+
+| 이름 | 설명 |
+| --- | --- |
+| open(fileName) | 주어진 경로에서 씬을 엽니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| fileName | String | 파일 이름. |
+
+ **Result:**
+AnimationClip
+
+
+---
+
+
+### fromFile{#fromFile}
+
+| 이름 | 설명 |
+| --- | --- |
+| fromFile(fileName) | 주어진 경로에서 씬을 엽니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| fileName | String | 파일 이름. |
+
+ **Result:**
+AnimationClip
+
+
+---
+
+
+### save{#save}
+
+| 이름 | 설명 |
+| --- | --- |
+| save(fileName) | 지정된 파일 형식을 사용하여 지정된 경로에 씬을 저장합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| fileName | String | 파일 이름. |
+
+ **Result:**
+AnimationClip
+
+
+---
+
+
+### save{#save}
+
+| 이름 | 설명 |
+| --- | --- |
+| save(fileName, format) | 지정된 파일 형식을 사용하여 지정된 경로에 씬을 저장합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| fileName | String | 파일 이름. |
+| format | 파일 형식 | 형식. |
+
+ **Result:**
+AnimationClip
+
+
+---
+
+
+### save{#save}
+
+| 이름 | 설명 |
+| --- | --- |
+| save(fileName, options) | 지정된 파일 형식을 사용하여 지정된 경로에 씬을 저장합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| fileName | String | 파일 이름. |
+| 옵션 | SaveOptions | 스트림을 저장하기 위한 보다 자세한 구성. |
+
+ **Result:**
+AnimationClip
+
+
+---
+
+
+### render{#render}
+
+| 이름 | 설명 |
+| --- | --- |
+| render(camera, fileName) | 주어진 카메라 시점에서 씬을 외부 파일로 렌더링합니다. 기본 출력 크기는 1024x768이며 출력 형식은 png입니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 카메라 | 카메라 | 어떤 카메라 시점에서 씬을 렌더링할지 |
+| fileName | String | 출력 파일의 파일 이름 |
+
+ **Result:**
+AnimationClip
+
+
+---
+
+
+### render{#render}
+
+| 이름 | 설명 |
+| --- | --- |
+| render(camera, fileName, size, format) | 주어진 카메라 시점에서 씬을 외부 파일로 렌더링합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 카메라 | 카메라 | 어떤 카메라 시점에서 씬을 렌더링할지 |
+| fileName | String | 출력 파일의 파일 이름 |
+| 크기 | Vector2 | 최종 렌더링 이미지의 크기 |
+| format | String | 출력 파일의 이미지 형식 |
+
+ **Result:**
+AnimationClip
+
+
+---
+
+
+### render{#render}
+
+| 이름 | 설명 |
+| --- | --- |
+| render(camera, fileName, size, format, options) | 주어진 카메라 시점에서 씬을 외부 파일로 렌더링합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 카메라 | 카메라 | 어떤 카메라 시점에서 씬을 렌더링할지 |
+| fileName | String | 출력 파일의 파일 이름 |
+| 크기 | Vector2 | 최종 렌더링 이미지의 크기 |
+| format | String | 출력 파일의 이미지 형식 |
+| 옵션 | ImageRenderOptions | 일부 내부 설정을 사용자 정의하는 옵션. |
+
+ **Result:**
+AnimationClip
+
+
+---
+
+
+### render{#render}
+
+| 이름 | 설명 |
+| --- | --- |
+| render(camera, bitmap) | 주어진 카메라 시점에서 씬을 비트맵으로 렌더링합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 카메라 | 카메라 | 어떤 카메라 시점에서 씬을 렌더링할지 |
+| 비트맵 | TextureData | 렌더링 결과의 대상 |
+
+ **Result:**
+AnimationClip
+
+
+---
+
+
+### render{#render}
+
+| 이름 | 설명 |
+| --- | --- |
+| render(camera, bitmap, options) | 주어진 카메라 시점에서 씬을 비트맵으로 렌더링합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 카메라 | 카메라 | 어떤 카메라 시점에서 씬을 렌더링할지 |
+| 비트맵 | TextureData | 렌더링 결과의 대상 |
+| 옵션 | ImageRenderOptions | 일부 내부 설정을 사용자 정의하는 옵션. |
+
+ **Result:**
+AnimationClip
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/sceneobject/_index.md
+++ b/korean/nodejs-java/aspose.threed/sceneobject/_index.md
@@ -1,0 +1,196 @@
+---
+title: "SceneObject"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/sceneobject/
+---
+## SceneObject class
+
+Scene 내부에 저장될 객체들의 루트 클래스.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor(name) | 기본 이름으로 SceneObject를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| name | String | 이 인스턴스의 이름 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload() | SceneObject를 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 이름 | 설명 |
+| --- | --- |
+| getScene() | 이 객체가 속한 씬을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/shaderexception/_index.md
+++ b/korean/nodejs-java/aspose.threed/shaderexception/_index.md
@@ -1,0 +1,35 @@
+---
+title: "ShaderException"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/shaderexception/
+---
+## ShaderException class
+
+셰이더 관련 예외
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor(message) | ShaderException의 생성자 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 메시지 | String | null |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/shadermaterial/_index.md
+++ b/korean/nodejs-java/aspose.threed/shadermaterial/_index.md
@@ -1,0 +1,261 @@
+---
+title: "ShaderMaterial"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/shadermaterial/
+---
+## ShaderMaterial class
+
+셰이더 머티리얼은 외부 렌더링 엔진이나 셰이더 언어를 사용하여 머티리얼을 설명할 수 있게 합니다.  ShaderMaterial은 구체적인 렌더링 세부 사항을 설명하기 위해 ShaderTechnique을 사용하며, 최종 렌더링 플랫폼에 따라 가장 적합한 것이 사용됩니다.  예를 들어, ShaderMaterial 인스턴스는 두 개의 technique을 가질 수 있는데, 하나는 HLSL로 정의되고 다른 하나는 GLSL로 정의됩니다.  비윈도우 플랫폼에서는 HLSL 대신 GLSL을 사용해야 합니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | ShaderMaterial 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload(name) | ShaderMaterial 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| name | String | 이름 |
+
+ **Result:**
+
+
+
+---
+
+
+### getTechniques{#getTechniques}
+
+| 이름 | 설명 |
+| --- | --- |
+| getTechniques() | 이 자료에 정의된 모든 사용 가능한 기술을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTexture{#getTexture}
+
+| 이름 | 설명 |
+| --- | --- |
+| getTexture(slotName) | 지정된 슬롯에서 텍스처를 가져옵니다. 이는 재질의 속성 이름이거나 셰이더의 매개변수 이름일 수 있습니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| slotName | String | 슬롯 이름. |
+
+ **Result:**
+TextureBase
+
+
+---
+
+
+### setTexture{#setTexture}
+
+| 이름 | 설명 |
+| --- | --- |
+| setTexture(slotName, texture) | 지정된 슬롯에 텍스처를 설정합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| slotName | String | 슬롯 이름. |
+| texture | TextureBase | 텍스처. |
+
+ **Result:**
+TextureBase
+
+
+---
+
+
+### toString{#toString}
+
+| 이름 | 설명 |
+| --- | --- |
+| toString() | 객체를 문자열로 포맷합니다. |
+
+ **Result:**
+String
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+### iterator{#iterator}
+
+| 이름 | 설명 |
+| --- | --- |
+| iterator() | 내부 사용을 위해 예약되었습니다. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/shaderprogram/_index.md
+++ b/korean/nodejs-java/aspose.threed/shaderprogram/_index.md
@@ -1,0 +1,13 @@
+---
+title: "ShaderProgram"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/shaderprogram/
+---
+## ShaderProgram class
+
+셰이더 프로그램  @hideconstructor
+
+

--- a/korean/nodejs-java/aspose.threed/shaderset/_index.md
+++ b/korean/nodejs-java/aspose.threed/shaderset/_index.md
@@ -1,0 +1,133 @@
+---
+title: "ShaderSet"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/shaderset/
+---
+## ShaderSet class
+
+각 종류의 머티리얼에 대한 셰이더 프로그램
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | ShaderSet 인스턴스를 생성합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLambert{#getLambert}
+
+| 이름 | 설명 |
+| --- | --- |
+| getLambert() | lambert 재질을 렌더링하는 데 사용되는 셰이더를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setLambert{#setLambert}
+
+| 이름 | 설명 |
+| --- | --- |
+| setLambert(value) | lambert 재질을 렌더링하는 데 사용되는 셰이더를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getPhong{#getPhong}
+
+| 이름 | 설명 |
+| --- | --- |
+| getPhong() | phong 재질을 렌더링하는 데 사용되는 셰이더를 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### setPhong{#setPhong}
+
+| 이름 | 설명 |
+| --- | --- |
+| setPhong(value) | phong 재질을 렌더링하는 데 사용되는 셰이더를 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getPbr{#getPbr}
+
+| 이름 | 설명 |
+| --- | --- |
+| getPbr() | PBR 재질을 렌더링하는 데 사용되는 셰이더를 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### setPbr{#setPbr}
+
+| 이름 | 설명 |
+| --- | --- |
+| setPbr(value) | PBR 재질을 렌더링하는 데 사용되는 셰이더를 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFallback{#getFallback}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFallback() | 필요한 셰이더를 사용할 수 없을 때 대체 셰이더를 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### setFallback{#setFallback}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFallback(value) | 필요한 셰이더를 사용할 수 없을 때 대체 셰이더를 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/shadersource/_index.md
+++ b/korean/nodejs-java/aspose.threed/shadersource/_index.md
@@ -1,0 +1,13 @@
+---
+title: "ShaderSource"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/shadersource/
+---
+## ShaderSource class
+
+셰이더의 소스 코드  @hideconstructor
+
+

--- a/korean/nodejs-java/aspose.threed/shadertechnique/_index.md
+++ b/korean/nodejs-java/aspose.threed/shadertechnique/_index.md
@@ -1,0 +1,270 @@
+---
+title: "ShaderTechnique"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/shadertechnique/
+---
+## ShaderTechnique class
+
+Shader technique은 구체적인 렌더링 구현을 나타냅니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | ShaderTechnique 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDescription{#getDescription}
+
+| 이름 | 설명 |
+| --- | --- |
+| getDescription() | 이 기술의 설명을 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### setDescription{#setDescription}
+
+| 이름 | 설명 |
+| --- | --- |
+| setDescription(value) | 이 기술의 설명을 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getShaderLanguage{#getShaderLanguage}
+
+| 이름 | 설명 |
+| --- | --- |
+| getShaderLanguage() | 이 기술에서 사용되는 셰이더 언어를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setShaderLanguage{#setShaderLanguage}
+
+| 이름 | 설명 |
+| --- | --- |
+| setShaderLanguage(value) | 이 기술에서 사용되는 셰이더 언어를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getShaderVersion{#getShaderVersion}
+
+| 이름 | 설명 |
+| --- | --- |
+| getShaderVersion() | 이 기술에서 사용되는 셰이더 버전을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setShaderVersion{#setShaderVersion}
+
+| 이름 | 설명 |
+| --- | --- |
+| setShaderVersion(value) | 이 기술에서 사용되는 셰이더 버전을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getShaderFile{#getShaderFile}
+
+| 이름 | 설명 |
+| --- | --- |
+| getShaderFile() | 외부 셰이더 파일의 파일 이름을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setShaderFile{#setShaderFile}
+
+| 이름 | 설명 |
+| --- | --- |
+| setShaderFile(value) | 외부 셰이더 파일의 파일 이름을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getShaderContent{#getShaderContent}
+
+| 이름 | 설명 |
+| --- | --- |
+| getShaderContent() | 임베디드 셰이더 스크립트의 내용을 가져오거나 설정합니다. HLSL/GLSL 셰이더 소스 파일일 수 있습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setShaderContent{#setShaderContent}
+
+| 이름 | 설명 |
+| --- | --- |
+| setShaderContent(value) | 임베디드 셰이더 스크립트의 내용을 가져오거나 설정합니다. HLSL/GLSL 셰이더 소스 파일일 수 있습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getShaderEntry{#getShaderEntry}
+
+| 이름 | 설명 |
+| --- | --- |
+| getShaderEntry() | 셰이더의 진입점을 가져오거나 설정합니다. HLSL과 같은 일부 셰이더는 사용자 정의 진입점을 가질 수 있습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setShaderEntry{#setShaderEntry}
+
+| 이름 | 설명 |
+| --- | --- |
+| setShaderEntry(value) | 셰이더의 진입점을 가져오거나 설정합니다. HLSL과 같은 일부 셰이더는 사용자 정의 진입점을 가질 수 있습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getRenderAPI{#getRenderAPI}
+
+| 이름 | 설명 |
+| --- | --- |
+| getRenderAPI() | 이 기술에서 사용되는 렌더링 API를 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### setRenderAPI{#setRenderAPI}
+
+| 이름 | 설명 |
+| --- | --- |
+| setRenderAPI(value) | 이 기술에서 사용되는 렌더링 API를 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getRenderAPIVersion{#getRenderAPIVersion}
+
+| 이름 | 설명 |
+| --- | --- |
+| getRenderAPIVersion() | 렌더링 API의 버전을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRenderAPIVersion{#setRenderAPIVersion}
+
+| 이름 | 설명 |
+| --- | --- |
+| setRenderAPIVersion(value) | 렌더링 API의 버전을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getShaderParameters{#getShaderParameters}
+
+| 이름 | 설명 |
+| --- | --- |
+| getShaderParameters() | 셰이더 매개변수 정의를 가져옵니다. 키는 동적 속성의 이름이며, 값은 해당 속성이 연결된 셰이더 매개변수 이름입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### addBinding{#addBinding}
+
+| 이름 | 설명 |
+| --- | --- |
+| addBinding(property, shaderParameter) | 동적 속성을 셰이더 매개변수에 바인딩합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 동적 속성의 이름입니다. |
+| shaderParameter | String | 셰이더 매개변수의 이름입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/shadervariable/_index.md
+++ b/korean/nodejs-java/aspose.threed/shadervariable/_index.md
@@ -1,0 +1,68 @@
+---
+title: "ShaderVariable"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/shadervariable/
+---
+## ShaderVariable class
+
+셰이더 변수
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor(name) | ShaderVariable의 생성자 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| nam | String | null |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload(name, shaderStage) | ShaderVariable의 생성자 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| nam | String | null |
+| shaderStage | 숫자 | ShaderStage |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이 변수의 이름을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/shape/_index.md
+++ b/korean/nodejs-java/aspose.threed/shape/_index.md
@@ -1,0 +1,573 @@
+---
+title: "모양"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/shape/
+---
+## Shape class
+
+Shape은 일련의 컨트롤 포인트에 대한 변형을 설명하며, 이는 Maya의 클러스터 디포머와 유사합니다.  예를 들어, 생성된 기하학에 Shape을 추가할 수 있습니다.  Shape과 기하학은 동일한 토폴로지 정보를 가지지만 컨트롤 포인트의 위치는 다릅니다.  영향 정도가 다르게 적용되어 기하학은 변형 효과를 수행합니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | Shape 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload(name) | Shape 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| name | String | 이름 |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| 이름 | 설명 |
+| --- | --- |
+| getIndices() | 인덱스를 가져옵니다. 인덱스. |
+
+ **Result:**
+
+
+
+---
+
+
+### getVisible{#getVisible}
+
+| 이름 | 설명 |
+| --- | --- |
+| getVisible() | 지오메트리가 보이는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setVisible{#setVisible}
+
+| 이름 | 설명 |
+| --- | --- |
+| setVisible(value) | 지오메트리가 보이는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDeformers{#getDeformers}
+
+| 이름 | 설명 |
+| --- | --- |
+| getDeformers() | 이 지오메트리와 연결된 모든 디포머를 가져옵니다. 디포머. |
+
+ **Result:**
+
+
+
+---
+
+
+### getControlPoints{#getControlPoints}
+
+| 이름 | 설명 |
+| --- | --- |
+| getControlPoints() | 모든 제어점을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastShadows{#getCastShadows}
+
+| 이름 | 설명 |
+| --- | --- |
+| getCastShadows() | 이 지오메트리가 그림자를 드리울 수 있는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastShadows{#setCastShadows}
+
+| 이름 | 설명 |
+| --- | --- |
+| setCastShadows(value) | 이 지오메트리가 그림자를 드리울 수 있는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReceiveShadows{#getReceiveShadows}
+
+| 이름 | 설명 |
+| --- | --- |
+| getReceiveShadows() | 이 지오메트리가 그림자를 받을 수 있는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReceiveShadows{#setReceiveShadows}
+
+| 이름 | 설명 |
+| --- | --- |
+| setReceiveShadows(value) | 이 지오메트리가 그림자를 받을 수 있는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElements{#getVertexElements}
+
+| 이름 | 설명 |
+| --- | --- |
+| getVertexElements() | 모든 정점 요소를 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNodes() | 모든 부모 노드를 가져옵니다. 엔터티는 기하학 인스턴싱을 위해 여러 부모 노드에 부착될 수 있습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExcluded() | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExcluded(value) | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNode() | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setParentNode(value) | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 이름 | 설명 |
+| --- | --- |
+| getScene() | 이 객체가 속한 씬을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### fromControlPoints{#fromControlPoints}
+
+| 이름 | 설명 |
+| --- | --- |
+| fromControlPoints(controlPoints) | 지정된 제어점을 사용하고 기본 인덱스로 형태를 생성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| controlPoint | Vector3[] | null |
+
+ **Result:**
+모양
+
+
+---
+
+
+### getElement{#getElement}
+
+| 이름 | 설명 |
+| --- | --- |
+| getElement(type) | 지정된 타입의 정점 요소를 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| type | VertexElementType | VertexElementType |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### getVertexElementOfUV{#getVertexElementOfUV}
+
+| 이름 | 설명 |
+| --- | --- |
+| getVertexElementOfUV(textureMapping) | 주어진 텍스처 매핑 타입으로 VertexElementUV 인스턴스를 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| textureMapping | TextureMapping | TextureMapping |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### createElement{#createElement}
+
+| 이름 | 설명 |
+| --- | --- |
+| createElement(type) | 지정된 타입의 정점 요소를 생성하고 이를 지오메트리에 추가합니다. 타입이 VertexElementType.UV인 경우, TextureMapping.DIFFUSE 타입의 텍스처 매핑을 가진 VertexElementUV가 생성됩니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| type | VertexElementType | VertexElementType |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### addElement{#addElement}
+
+| 이름 | 설명 |
+| --- | --- |
+| addElement(element) | 기존 정점 요소를 현재 지오메트리에 추가합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| element | VertexElement | 추가할 정점 요소 |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### createElement{#createElement}
+
+| 이름 | 설명 |
+| --- | --- |
+| createElement(type, mappingMode, referenceMode) | 지정된 타입의 정점 요소를 생성하고 이를 지오메트리에 추가합니다. 타입이 VertexElementType.UV인 경우, TextureMapping.DIFFUSE 타입의 텍스처 매핑을 가진 VertexElementUV가 생성됩니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| type | VertexElementType | VertexElementType |
+| mappingMode | MappingMode | MappingMode |
+| referenceMode | ReferenceMode | ReferenceMode |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### createElementUV{#createElementUV}
+
+| 이름 | 설명 |
+| --- | --- |
+| createElementUV(uvMapping) | 주어진 텍스처 매핑 유형으로 VertexElementUV를 생성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| uvMapping | TextureMapping | TextureMapping |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### createElementUV{#createElementUV}
+
+| 이름 | 설명 |
+| --- | --- |
+| createElementUV(uvMapping, mappingMode, referenceMode) | 주어진 텍스처 매핑 유형으로 VertexElementUV를 생성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| uvMapping | TextureMapping | TextureMapping |
+| mappingMode | MappingMode | MappingMode |
+| referenceMode | ReferenceMode | ReferenceMode |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBoundingBox() | 현재 엔터티의 객체 공간 좌표계에서 경계 상자를 가져옵니다. |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEntityRendererKey() | 렌더러에 등록된 엔터티 렌더러의 키를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/skeleton/_index.md
+++ b/korean/nodejs-java/aspose.threed/skeleton/_index.md
@@ -1,0 +1,339 @@
+---
+title: "스켈레톤"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/skeleton/
+---
+## Skeleton class
+
+Skeleton은 주로 CAD 소프트웨어에서 디자이너가 골격 구조의 변환을 조작하도록 돕기 위해 사용되며, CAD 소프트웨어 외부에서는 보통 쓸모가 없습니다. Skeleton 계층을 CAD 소프트웨어에서 하나의 객체처럼 동작하게 하려면, 최상위 Skeleton 노드를 Type을 SkeletonType.SKELETON으로 설정하여 루트로 표시하고, 모든 자식은 SkeletonType.BONE으로 설정해야 합니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | Skeleton 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload(name) | Skeleton 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| name | String | 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getSize{#getSize}
+
+| 이름 | 설명 |
+| --- | --- |
+| getSize() | CAD 소프트웨어에서 뼈의 크기를 나타내는 데 사용되는 사지 노드 크기를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setSize{#setSize}
+
+| 이름 | 설명 |
+| --- | --- |
+| setSize(value) | CAD 소프트웨어에서 뼈의 크기를 나타내는 데 사용되는 사지 노드 크기를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getType{#getType}
+
+| 이름 | 설명 |
+| --- | --- |
+| getType() | 스켈레톤의 유형을 가져오거나 설정합니다. 속성 값은 SkeletonType 정수 상수입니다. 스켈레톤의 유형. |
+
+ **Result:**
+
+
+
+---
+
+
+### setType{#setType}
+
+| 이름 | 설명 |
+| --- | --- |
+| setType(value) | 스켈레톤의 유형을 가져오거나 설정합니다. 속성 값은 SkeletonType 정수 상수입니다. 스켈레톤의 유형. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNodes() | 모든 부모 노드를 가져옵니다. 엔터티는 기하학 인스턴싱을 위해 여러 부모 노드에 부착될 수 있습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExcluded() | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExcluded(value) | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNode() | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setParentNode(value) | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 이름 | 설명 |
+| --- | --- |
+| getScene() | 이 객체가 속한 씬을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBoundingBox() | 현재 엔터티의 객체 공간 좌표계에서 경계 상자를 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEntityRendererKey() | 렌더러에 등록된 엔터티 렌더러의 키를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/skindeformer/_index.md
+++ b/korean/nodejs-java/aspose.threed/skindeformer/_index.md
@@ -1,0 +1,209 @@
+---
+title: "SkinDeformer"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/skindeformer/
+---
+## SkinDeformer class
+
+스킨 디포머는 여러 개의 본을 포함하며, 각 본은 컨트롤 포인트 가중치를 통해 기하학의 일부를 블렌딩합니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor(name) | SkinDeformer 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| name | String | 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload() | SkinDeformer 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getBones{#getBones}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBones() | 스킨 디포머가 포함하는 모든 본을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getOwner{#getOwner}
+
+| 이름 | 설명 |
+| --- | --- |
+| getOwner() | 이 디포머를 소유하는 지오메트리를 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/sphere/_index.md
+++ b/korean/nodejs-java/aspose.threed/sphere/_index.md
@@ -1,0 +1,581 @@
+---
+title: "Sphere"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/sphere/
+---
+## Sphere class
+
+파라미터화된 구.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | Sphere의 새 인스턴스를 기본 반경 1로 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload(radius) | 지정된 반경으로 Sphere 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 반경 | 숫자 | 반경. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload2(radius, widthSegments, heightSegments) | 지정된 반경, 가로 세그먼트 및 세로 세그먼트로 Sphere 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 반경 | 숫자 | 구체의 반경. |
+| widthSegments | 숫자 | 너비 세그먼트. |
+| heightSegments | 숫자 | 세로 세그먼트. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload3{#constructor_overload3}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload3(name, radius, widthSegments, heightSegments, phiStart, phiLength, thetaStart, thetaLength) | Sphere 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| name | String | 이름. |
+| 반경 | 숫자 | 구체의 반경. |
+| widthSegments | 숫자 | 너비 세그먼트. |
+| heightSegments | 숫자 | 세로 세그먼트. |
+| phiStart | 숫자 | Phi 시작. |
+| phiLength | 숫자 | Phi 길이. |
+| thetaStart | 숫자 | Theta 시작. |
+| thetaLength | 숫자 | Theta 길이. |
+
+ **Result:**
+
+
+
+---
+
+
+### getWidthSegments{#getWidthSegments}
+
+| 이름 | 설명 |
+| --- | --- |
+| getWidthSegments() | 너비 세그먼트를 가져오거나 설정합니다. 너비 세그먼트. |
+
+ **Result:**
+
+
+
+---
+
+
+### setWidthSegments{#setWidthSegments}
+
+| 이름 | 설명 |
+| --- | --- |
+| setWidthSegments(value) | 너비 세그먼트를 가져오거나 설정합니다. 너비 세그먼트. |
+
+ **Result:**
+
+
+
+---
+
+
+### getHeightSegments{#getHeightSegments}
+
+| 이름 | 설명 |
+| --- | --- |
+| getHeightSegments() | 세로 세그먼트를 가져오거나 설정합니다. 세로 세그먼트. |
+
+ **Result:**
+
+
+
+---
+
+
+### setHeightSegments{#setHeightSegments}
+
+| 이름 | 설명 |
+| --- | --- |
+| setHeightSegments(value) | 세로 세그먼트를 가져오거나 설정합니다. 세로 세그먼트. |
+
+ **Result:**
+
+
+
+---
+
+
+### getPhiStart{#getPhiStart}
+
+| 이름 | 설명 |
+| --- | --- |
+| getPhiStart() | phi 시작을 가져오거나 설정합니다. phi 시작. |
+
+ **Result:**
+
+
+
+---
+
+
+### setPhiStart{#setPhiStart}
+
+| 이름 | 설명 |
+| --- | --- |
+| setPhiStart(value) | phi 시작을 가져오거나 설정합니다. phi 시작. |
+
+ **Result:**
+
+
+
+---
+
+
+### getPhiLength{#getPhiLength}
+
+| 이름 | 설명 |
+| --- | --- |
+| getPhiLength() | phi의 길이를 가져오거나 설정합니다. phi의 길이. |
+
+ **Result:**
+
+
+
+---
+
+
+### setPhiLength{#setPhiLength}
+
+| 이름 | 설명 |
+| --- | --- |
+| setPhiLength(value) | phi의 길이를 가져오거나 설정합니다. phi의 길이. |
+
+ **Result:**
+
+
+
+---
+
+
+### getThetaStart{#getThetaStart}
+
+| 이름 | 설명 |
+| --- | --- |
+| getThetaStart() | theta 시작을 가져오거나 설정합니다. theta 시작. |
+
+ **Result:**
+
+
+
+---
+
+
+### setThetaStart{#setThetaStart}
+
+| 이름 | 설명 |
+| --- | --- |
+| setThetaStart(value) | theta 시작을 가져오거나 설정합니다. theta 시작. |
+
+ **Result:**
+
+
+
+---
+
+
+### getThetaLength{#getThetaLength}
+
+| 이름 | 설명 |
+| --- | --- |
+| getThetaLength() | theta의 길이를 가져오거나 설정합니다. theta의 길이. |
+
+ **Result:**
+
+
+
+---
+
+
+### setThetaLength{#setThetaLength}
+
+| 이름 | 설명 |
+| --- | --- |
+| setThetaLength(value) | theta의 길이를 가져오거나 설정합니다. theta의 길이. |
+
+ **Result:**
+
+
+
+---
+
+
+### getRadius{#getRadius}
+
+| 이름 | 설명 |
+| --- | --- |
+| getRadius() | 구의 반경을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRadius{#setRadius}
+
+| 이름 | 설명 |
+| --- | --- |
+| setRadius(value) | 구의 반경을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastShadows{#getCastShadows}
+
+| 이름 | 설명 |
+| --- | --- |
+| getCastShadows() | 이 지오메트리가 그림자를 드리울 수 있는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastShadows{#setCastShadows}
+
+| 이름 | 설명 |
+| --- | --- |
+| setCastShadows(value) | 이 지오메트리가 그림자를 드리울 수 있는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReceiveShadows{#getReceiveShadows}
+
+| 이름 | 설명 |
+| --- | --- |
+| getReceiveShadows() | 이 지오메트리가 그림자를 받을 수 있는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReceiveShadows{#setReceiveShadows}
+
+| 이름 | 설명 |
+| --- | --- |
+| setReceiveShadows(value) | 이 지오메트리가 그림자를 받을 수 있는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNodes() | 모든 부모 노드를 가져옵니다. 엔터티는 기하학 인스턴싱을 위해 여러 부모 노드에 부착될 수 있습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExcluded() | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExcluded(value) | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNode() | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setParentNode(value) | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 이름 | 설명 |
+| --- | --- |
+| getScene() | 이 객체가 속한 씬을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### toMesh{#toMesh}
+
+| 이름 | 설명 |
+| --- | --- |
+| toMesh() | 현재 객체를 메시로 변환합니다 |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBoundingBox() | 현재 엔터티의 객체 공간 좌표계에서 경계 상자를 가져옵니다. |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEntityRendererKey() | 렌더러에 등록된 엔터티 렌더러의 키를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/spirvsource/_index.md
+++ b/korean/nodejs-java/aspose.threed/spirvsource/_index.md
@@ -1,0 +1,159 @@
+---
+title: "SPIRVSource"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/spirvsource/
+---
+## SPIRVSource class
+
+SPIR-V 형식의 컴파일된 셰이더.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | SPIR-V 기반 셰이더 소스의 생성자입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMaximumDescriptorSets{#getMaximumDescriptorSets}
+
+| 이름 | 설명 |
+| --- | --- |
+| getMaximumDescriptorSets() | 최대 디스크립터 세트, 기본값은 10입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMaximumDescriptorSets{#setMaximumDescriptorSets}
+
+| 이름 | 설명 |
+| --- | --- |
+| setMaximumDescriptorSets(value) | 최대 디스크립터 세트, 기본값은 10입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getComputeShader{#getComputeShader}
+
+| 이름 | 설명 |
+| --- | --- |
+| getComputeShader() | 컴퓨트 셰이더의 소스 코드를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setComputeShader{#setComputeShader}
+
+| 이름 | 설명 |
+| --- | --- |
+| setComputeShader(value) | 컴퓨트 셰이더의 소스 코드를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getGeometryShader{#getGeometryShader}
+
+| 이름 | 설명 |
+| --- | --- |
+| getGeometryShader() | 지오메트리 셰이더의 소스 코드를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setGeometryShader{#setGeometryShader}
+
+| 이름 | 설명 |
+| --- | --- |
+| setGeometryShader(value) | 지오메트리 셰이더의 소스 코드를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexShader{#getVertexShader}
+
+| 이름 | 설명 |
+| --- | --- |
+| getVertexShader() | 버텍스 셰이더의 소스 코드를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setVertexShader{#setVertexShader}
+
+| 이름 | 설명 |
+| --- | --- |
+| setVertexShader(value) | 버텍스 셰이더의 소스 코드를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFragmentShader{#getFragmentShader}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFragmentShader() | 프래그먼트 셰이더의 소스 코드를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFragmentShader{#setFragmentShader}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFragmentShader(value) | 프래그먼트 셰이더의 소스 코드를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/stencilstate/_index.md
+++ b/korean/nodejs-java/aspose.threed/stencilstate/_index.md
@@ -1,0 +1,152 @@
+---
+title: "StencilState"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/stencilstate/
+---
+## StencilState class
+
+각 면에 대한 스텐실 상태.  @hideconstructor
+
+
+## 메서드
+
+### getCompare{#getCompare}
+
+| 이름 | 설명 |
+| --- | --- |
+| getCompare() | 스텐실 테스트에 사용되는 비교 함수를 가져오거나 설정합니다. 속성값은 CompareFunction 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setCompare{#setCompare}
+
+| 이름 | 설명 |
+| --- | --- |
+| setCompare(value) | 스텐실 테스트에 사용되는 비교 함수를 가져오거나 설정합니다. 속성값은 CompareFunction 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFailAction{#getFailAction}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFailAction() | 스텐실 테스트가 실패할 때 스텐실 동작을 가져오거나 설정합니다. 속성값은 StencilAction 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFailAction{#setFailAction}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFailAction(value) | 스텐실 테스트가 실패할 때 스텐실 동작을 가져오거나 설정합니다. 속성값은 StencilAction 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDepthFailAction{#getDepthFailAction}
+
+| 이름 | 설명 |
+| --- | --- |
+| getDepthFailAction() | 스텐실 테스트는 통과하고 깊이 테스트가 실패할 때 스텐실 동작을 가져오거나 설정합니다. 속성값은 StencilAction 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDepthFailAction{#setDepthFailAction}
+
+| 이름 | 설명 |
+| --- | --- |
+| setDepthFailAction(value) | 스텐실 테스트는 통과하고 깊이 테스트가 실패할 때 스텐실 동작을 가져오거나 설정합니다. 속성값은 StencilAction 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getPassAction{#getPassAction}
+
+| 이름 | 설명 |
+| --- | --- |
+| getPassAction() | 스텐실 테스트와 깊이 테스트가 모두 통과할 때 스텐실 동작을 가져오거나 설정합니다. 속성값은 StencilAction 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setPassAction{#setPassAction}
+
+| 이름 | 설명 |
+| --- | --- |
+| setPassAction(value) | 스텐실 테스트와 깊이 테스트가 모두 통과할 때 스텐실 동작을 가져오거나 설정합니다. 속성값은 StencilAction 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### equals{#equals}
+
+| 이름 | 설명 |
+| --- | --- |
+| equals(obj) | 이 인스턴스가 지정된 객체와 같은지 여부를 나타내는 값을 반환합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| ob | Object | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### hashCode{#hashCode}
+
+| 이름 | 설명 |
+| --- | --- |
+| hashCode() | 이 인스턴스의 해시 코드를 반환합니다. |
+
+ **Result:**
+boolean
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/stlloadoptions/_index.md
+++ b/korean/nodejs-java/aspose.threed/stlloadoptions/_index.md
@@ -1,0 +1,191 @@
+---
+title: "StlLoadOptions"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/stlloadoptions/
+---
+## StlLoadOptions class
+
+STL 로드 옵션
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | 새 StlLoadOptions 인스턴스를 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload(contentType) | 새 StlLoadOptions 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| contentType | FileContentType | FileContentType |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlipCoordinateSystem{#getFlipCoordinateSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFlipCoordinateSystem() | 가져오기 중에 제어점/노멀의 좌표계를 뒤집을지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlipCoordinateSystem{#setFlipCoordinateSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFlipCoordinateSystem(value) | 가져오기 중에 제어점/노멀의 좌표계를 뒤집을지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getRecalculateNormal{#getRecalculateNormal}
+
+| 이름 | 설명 |
+| --- | --- |
+| getRecalculateNormal() | STL 파일에 저장된 노멀 데이터를 무시하고 정점 위치를 기반으로 노멀 데이터를 다시 계산합니다. 기본값은 false입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRecalculateNormal{#setRecalculateNormal}
+
+| 이름 | 설명 |
+| --- | --- |
+| setRecalculateNormal(value) | STL 파일에 저장된 노멀 데이터를 무시하고 정점 위치를 기반으로 노멀 데이터를 다시 계산합니다. 기본값은 false입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileFormat() | 현재 저장/로드 옵션에 지정된 파일 형식을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEncoding() | 텍스트 기반 파일에 대한 기본 인코딩을 가져오거나 설정합니다. 기본값은 null이며, 이는 가져오기/내보내기 프로그램이 사용할 인코딩을 결정함을 의미합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileSystem() | 로드/저장 중 외부 종속성을 관리하는 방법을 사용자가 처리하도록 허용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFileSystem(value) | 로드/저장 중 외부 종속성을 관리하는 방법을 사용자가 처리하도록 허용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| 이름 | 설명 |
+| --- | --- |
+| getLookupPaths() | OBJ와 같은 일부 파일은 외부 파일에 의존하며, 조회 경로를 통해 Aspose.3D가 외부 파일을 찾아 로드할 수 있도록 합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileName() | 내보내기/가져오기 씬의 파일 이름입니다. 선택 사항이지만 OBJ의 재질과 같은 외부 자산을 직렬화할 때 유용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFileName(value) | 내보내기/가져오기 씬의 파일 이름입니다. 선택 사항이지만 OBJ의 재질과 같은 외부 자산을 직렬화할 때 유용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/stlsaveoptions/_index.md
+++ b/korean/nodejs-java/aspose.threed/stlsaveoptions/_index.md
@@ -1,0 +1,191 @@
+---
+title: "StlSaveOptions"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/stlsaveoptions/
+---
+## StlSaveOptions class
+
+STL 저장 옵션
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | 새 StlSaveOptions 인스턴스를 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload(contentType) | 새 StlSaveOptions 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| contentType | FileContentType | FileContentType |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlipCoordinateSystem{#getFlipCoordinateSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFlipCoordinateSystem() | 내보내기 중 제어점/노멀의 좌표계 반전 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlipCoordinateSystem{#setFlipCoordinateSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFlipCoordinateSystem(value) | 내보내기 중 제어점/노멀의 좌표계 반전 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportTextures{#getExportTextures}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExportTextures() | 씬에서 사용된 텍스처를 출력 디렉터리로 복사합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextures{#setExportTextures}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExportTextures(value) | 씬에서 사용된 텍스처를 출력 디렉터리로 복사합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileFormat() | 현재 저장/로드 옵션에 지정된 파일 형식을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEncoding() | 텍스트 기반 파일에 대한 기본 인코딩을 가져오거나 설정합니다. 기본값은 null이며, 이는 가져오기/내보내기 프로그램이 사용할 인코딩을 결정함을 의미합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileSystem() | 로드/저장 중 외부 종속성을 관리하는 방법을 사용자가 처리하도록 허용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFileSystem(value) | 로드/저장 중 외부 종속성을 관리하는 방법을 사용자가 처리하도록 허용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| 이름 | 설명 |
+| --- | --- |
+| getLookupPaths() | OBJ와 같은 일부 파일은 외부 파일에 의존하며, 조회 경로를 통해 Aspose.3D가 외부 파일을 찾아 로드할 수 있도록 합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileName() | 내보내기/가져오기 씬의 파일 이름입니다. 선택 사항이지만 OBJ의 재질과 같은 외부 자산을 직렬화할 때 유용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFileName(value) | 내보내기/가져오기 씬의 파일 이름입니다. 선택 사항이지만 OBJ의 재질과 같은 외부 자산을 직렬화할 때 유용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/sweptareasolid/_index.md
+++ b/korean/nodejs-java/aspose.threed/sweptareasolid/_index.md
@@ -1,0 +1,385 @@
+---
+title: "SweptAreaSolid"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/sweptareasolid/
+---
+## SweptAreaSolid class
+
+SweptAreaSolid은 프로파일을 직접선(directrix)을 따라 스윕하여 기하학을 구성합니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getShape{#getShape}
+
+| 이름 | 설명 |
+| --- | --- |
+| getShape() | 기하학을 구성하기 위한 기본 프로파일입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setShape{#setShape}
+
+| 이름 | 설명 |
+| --- | --- |
+| setShape(value) | 기하학을 구성하기 위한 기본 프로파일입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDirectrix{#getDirectrix}
+
+| 이름 | 설명 |
+| --- | --- |
+| getDirectrix() | 스윕 영역이 따라 움직이는 직접선입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDirectrix{#setDirectrix}
+
+| 이름 | 설명 |
+| --- | --- |
+| setDirectrix(value) | 스윕 영역이 따라 움직이는 직접선입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getStartPoint{#getStartPoint}
+
+| 이름 | 설명 |
+| --- | --- |
+| getStartPoint() | 직접선의 시작점. |
+
+ **Result:**
+
+
+
+---
+
+
+### setStartPoint{#setStartPoint}
+
+| 이름 | 설명 |
+| --- | --- |
+| setStartPoint(value) | 직접선의 시작점. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEndPoint{#getEndPoint}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEndPoint() | 직접선의 끝점. |
+
+ **Result:**
+
+
+
+---
+
+
+### setEndPoint{#setEndPoint}
+
+| 이름 | 설명 |
+| --- | --- |
+| setEndPoint(value) | 직접선의 끝점. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNodes() | 모든 부모 노드를 가져옵니다. 엔터티는 기하학 인스턴싱을 위해 여러 부모 노드에 부착될 수 있습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExcluded() | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExcluded(value) | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNode() | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setParentNode(value) | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 이름 | 설명 |
+| --- | --- |
+| getScene() | 이 객체가 속한 씬을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### toMesh{#toMesh}
+
+| 이름 | 설명 |
+| --- | --- |
+| toMesh() | 현재 객체를 메시로 변환합니다 |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBoundingBox() | 현재 엔터티의 객체 공간 좌표계에서 경계 상자를 가져옵니다. |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEntityRendererKey() | 렌더러에 등록된 엔터티 렌더러의 키를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/text/_index.md
+++ b/korean/nodejs-java/aspose.threed/text/_index.md
@@ -1,0 +1,346 @@
+---
+title: "텍스트"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/text/
+---
+## Text class
+
+텍스트 프로파일은 폰트와 텍스트를 사용하여 윤곽을 설명합니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getContent{#getContent}
+
+| 이름 | 설명 |
+| --- | --- |
+| getContent() | 텍스트의 내용 |
+
+ **Result:**
+
+
+
+---
+
+
+### setContent{#setContent}
+
+| 이름 | 설명 |
+| --- | --- |
+| setContent(value) | 텍스트의 내용 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFont{#getFont}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFont() | 텍스트의 글꼴. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFont{#setFont}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFont(value) | 텍스트의 글꼴. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFontSize{#getFontSize}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFontSize() | 글꼴 크기 배율. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFontSize{#setFontSize}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFontSize(value) | 글꼴 크기 배율. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNodes() | 모든 부모 노드를 가져옵니다. 엔터티는 기하학 인스턴싱을 위해 여러 부모 노드에 부착될 수 있습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExcluded() | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExcluded(value) | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNode() | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setParentNode(value) | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 이름 | 설명 |
+| --- | --- |
+| getScene() | 이 객체가 속한 씬을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEntityRendererKey() | 렌더러에 등록된 엔터티 렌더러의 키를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBoundingBox() | 현재 엔터티의 객체 공간 좌표계에서 경계 상자를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/texture/_index.md
+++ b/korean/nodejs-java/aspose.threed/texture/_index.md
@@ -1,0 +1,607 @@
+---
+title: "Texture"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/texture/
+---
+## Texture class
+
+이 클래스는 외부 파일에서 텍스처를 정의합니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | Texture 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload(name) | Texture 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| name | String | 이름 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEnableMipMap{#getEnableMipMap}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEnableMipMap() | 이 텍스처에 대해 mipmap이 활성화되어 있는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setEnableMipMap{#setEnableMipMap}
+
+| 이름 | 설명 |
+| --- | --- |
+| setEnableMipMap(value) | 이 텍스처에 대해 mipmap이 활성화되어 있는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getContent{#getContent}
+
+| 이름 | 설명 |
+| --- | --- |
+| getContent() | 텍스처의 이진 콘텐츠를 가져오거나 설정합니다. 포함된 텍스처 콘텐츠는 선택 사항이며, 누락된 경우 사용자는 외부 파일에서 텍스처를 로드해야 합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setContent{#setContent}
+
+| 이름 | 설명 |
+| --- | --- |
+| setContent(value) | 텍스처의 이진 콘텐츠를 가져오거나 설정합니다. 포함된 텍스처 콘텐츠는 선택 사항이며, 누락된 경우 사용자는 외부 파일에서 텍스처를 로드해야 합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileName() | 연관된 텍스처 파일을 가져오거나 설정합니다. 파일 이름입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFileName(value) | 연관된 텍스처 파일을 가져오거나 설정합니다. 파일 이름입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAlpha{#getAlpha}
+
+| 이름 | 설명 |
+| --- | --- |
+| getAlpha() | 텍스처의 기본 알파 값을 가져오거나 설정합니다. 이는 AlphaSource가 AlphaSource.PIXEL_ALPHA일 때 유효합니다. 기본값은 1.0이며, 유효 범위는 0에서 1 사이입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setAlpha{#setAlpha}
+
+| 이름 | 설명 |
+| --- | --- |
+| setAlpha(value) | 텍스처의 기본 알파 값을 가져오거나 설정합니다. 이는 AlphaSource가 AlphaSource.PIXEL_ALPHA일 때 유효합니다. 기본값은 1.0이며, 유효 범위는 0에서 1 사이입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAlphaSource{#getAlphaSource}
+
+| 이름 | 설명 |
+| --- | --- |
+| getAlphaSource() | 텍스처가 알파 채널을 정의하는지 여부를 가져오거나 설정합니다. 기본값은 AlphaSource.NONE입니다. 속성 값은 AlphaSource 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setAlphaSource{#setAlphaSource}
+
+| 이름 | 설명 |
+| --- | --- |
+| setAlphaSource(value) | 텍스처가 알파 채널을 정의하는지 여부를 가져오거나 설정합니다. 기본값은 AlphaSource.NONE입니다. 속성 값은 AlphaSource 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getWrapModeU{#getWrapModeU}
+
+| 이름 | 설명 |
+| --- | --- |
+| getWrapModeU() | U 방향의 텍스처 랩 모드를 가져오거나 설정합니다. 속성 값은 WrapMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setWrapModeU{#setWrapModeU}
+
+| 이름 | 설명 |
+| --- | --- |
+| setWrapModeU(value) | U 방향의 텍스처 랩 모드를 가져오거나 설정합니다. 속성 값은 WrapMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getWrapModeV{#getWrapModeV}
+
+| 이름 | 설명 |
+| --- | --- |
+| getWrapModeV() | V 방향의 텍스처 랩 모드를 가져오거나 설정합니다. 속성 값은 WrapMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setWrapModeV{#setWrapModeV}
+
+| 이름 | 설명 |
+| --- | --- |
+| setWrapModeV(value) | V 방향의 텍스처 랩 모드를 가져오거나 설정합니다. 속성 값은 WrapMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getWrapModeW{#getWrapModeW}
+
+| 이름 | 설명 |
+| --- | --- |
+| getWrapModeW() | W 방향의 �스처 랩 모드를 가져오거나 설정합니다. 속성 값은 WrapMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setWrapModeW{#setWrapModeW}
+
+| 이름 | 설명 |
+| --- | --- |
+| setWrapModeW(value) | W 방향의 �스처 랩 모드를 가져오거나 설정합니다. 속성 값은 WrapMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMinFilter{#getMinFilter}
+
+| 이름 | 설명 |
+| --- | --- |
+| getMinFilter() | 축소에 대한 필터를 가져오거나 설정합니다. 속성 값은 TextureFilter 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMinFilter{#setMinFilter}
+
+| 이름 | 설명 |
+| --- | --- |
+| setMinFilter(value) | 축소에 대한 필터를 가져오거나 설정합니다. 속성 값은 TextureFilter 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMagFilter{#getMagFilter}
+
+| 이름 | 설명 |
+| --- | --- |
+| getMagFilter() | 배율에 대한 필터를 가져오거나 설정합니다. 속성값은 TextureFilter 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMagFilter{#setMagFilter}
+
+| 이름 | 설명 |
+| --- | --- |
+| setMagFilter(value) | 배율에 대한 필터를 가져오거나 설정합니다. 속성값은 TextureFilter 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMipFilter{#getMipFilter}
+
+| 이름 | 설명 |
+| --- | --- |
+| getMipFilter() | Mip 레벨 샘플링에 대한 필터를 가져오거나 설정합니다. 속성값은 TextureFilter 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMipFilter{#setMipFilter}
+
+| 이름 | 설명 |
+| --- | --- |
+| setMipFilter(value) | Mip 레벨 샘플링에 대한 필터를 가져오거나 설정합니다. 속성값은 TextureFilter 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getUVRotation{#getUVRotation}
+
+| 이름 | 설명 |
+| --- | --- |
+| getUVRotation() | 텍스처의 회전을 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### setUVRotation{#setUVRotation}
+
+| 이름 | 설명 |
+| --- | --- |
+| setUVRotation(value) | 텍스처의 회전을 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getUVScale{#getUVScale}
+
+| 이름 | 설명 |
+| --- | --- |
+| getUVScale() | UV 스케일을 가져오거나 설정합니다. UV 스케일. |
+
+ **Result:**
+
+
+
+---
+
+
+### setUVScale{#setUVScale}
+
+| 이름 | 설명 |
+| --- | --- |
+| setUVScale(value) | UV 스케일을 가져오거나 설정합니다. UV 스케일. |
+
+ **Result:**
+
+
+
+---
+
+
+### getUVTranslation{#getUVTranslation}
+
+| 이름 | 설명 |
+| --- | --- |
+| getUVTranslation() | UV 변환을 가져오거나 설정합니다. UV 변환. |
+
+ **Result:**
+
+
+
+---
+
+
+### setUVTranslation{#setUVTranslation}
+
+| 이름 | 설명 |
+| --- | --- |
+| setUVTranslation(value) | UV 변환을 가져오거나 설정합니다. UV 변환. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTranslation{#setTranslation}
+
+| 이름 | 설명 |
+| --- | --- |
+| setTranslation(u, v) | UV 변환을 설정합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| u | 숫자 | U. |
+| v | 숫자 | V. |
+
+ **Result:**
+
+
+
+---
+
+
+### setScale{#setScale}
+
+| 이름 | 설명 |
+| --- | --- |
+| setScale(u, v) | UV 스케일을 설정합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| u | 숫자 | U. |
+| v | 숫자 | V. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRotation{#setRotation}
+
+| 이름 | 설명 |
+| --- | --- |
+| setRotation(u, v) | UV 회전을 설정합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| u | 숫자 | U. |
+| v | 숫자 | V. |
+
+ **Result:**
+
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/texturebase/_index.md
+++ b/korean/nodejs-java/aspose.threed/texturebase/_index.md
@@ -1,0 +1,516 @@
+---
+title: "TextureBase"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/texturebase/
+---
+## TextureBase class
+
+구체적인 모든 텍스처의 기본 클래스입니다.  Texture는 기하학 표면의 외관과 느낌을 정의합니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor(name) | TextureBase 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| name | String | 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAlpha{#getAlpha}
+
+| 이름 | 설명 |
+| --- | --- |
+| getAlpha() | 텍스처의 기본 알파 값을 가져오거나 설정합니다. 이는 AlphaSource가 AlphaSource.PIXEL_ALPHA일 때 유효합니다. 기본값은 1.0이며, 유효 범위는 0에서 1 사이입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setAlpha{#setAlpha}
+
+| 이름 | 설명 |
+| --- | --- |
+| setAlpha(value) | 텍스처의 기본 알파 값을 가져오거나 설정합니다. 이는 AlphaSource가 AlphaSource.PIXEL_ALPHA일 때 유효합니다. 기본값은 1.0이며, 유효 범위는 0에서 1 사이입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAlphaSource{#getAlphaSource}
+
+| 이름 | 설명 |
+| --- | --- |
+| getAlphaSource() | 텍스처가 알파 채널을 정의하는지 여부를 가져오거나 설정합니다. 기본값은 AlphaSource.NONE입니다. 속성 값은 AlphaSource 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setAlphaSource{#setAlphaSource}
+
+| 이름 | 설명 |
+| --- | --- |
+| setAlphaSource(value) | 텍스처가 알파 채널을 정의하는지 여부를 가져오거나 설정합니다. 기본값은 AlphaSource.NONE입니다. 속성 값은 AlphaSource 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getWrapModeU{#getWrapModeU}
+
+| 이름 | 설명 |
+| --- | --- |
+| getWrapModeU() | U 방향의 텍스처 랩 모드를 가져오거나 설정합니다. 속성 값은 WrapMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setWrapModeU{#setWrapModeU}
+
+| 이름 | 설명 |
+| --- | --- |
+| setWrapModeU(value) | U 방향의 텍스처 랩 모드를 가져오거나 설정합니다. 속성 값은 WrapMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getWrapModeV{#getWrapModeV}
+
+| 이름 | 설명 |
+| --- | --- |
+| getWrapModeV() | V 방향의 텍스처 랩 모드를 가져오거나 설정합니다. 속성 값은 WrapMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setWrapModeV{#setWrapModeV}
+
+| 이름 | 설명 |
+| --- | --- |
+| setWrapModeV(value) | V 방향의 텍스처 랩 모드를 가져오거나 설정합니다. 속성 값은 WrapMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getWrapModeW{#getWrapModeW}
+
+| 이름 | 설명 |
+| --- | --- |
+| getWrapModeW() | W 방향의 �스처 랩 모드를 가져오거나 설정합니다. 속성 값은 WrapMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setWrapModeW{#setWrapModeW}
+
+| 이름 | 설명 |
+| --- | --- |
+| setWrapModeW(value) | W 방향의 �스처 랩 모드를 가져오거나 설정합니다. 속성 값은 WrapMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMinFilter{#getMinFilter}
+
+| 이름 | 설명 |
+| --- | --- |
+| getMinFilter() | 축소에 대한 필터를 가져오거나 설정합니다. 속성 값은 TextureFilter 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMinFilter{#setMinFilter}
+
+| 이름 | 설명 |
+| --- | --- |
+| setMinFilter(value) | 축소에 대한 필터를 가져오거나 설정합니다. 속성 값은 TextureFilter 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMagFilter{#getMagFilter}
+
+| 이름 | 설명 |
+| --- | --- |
+| getMagFilter() | 배율에 대한 필터를 가져오거나 설정합니다. 속성값은 TextureFilter 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMagFilter{#setMagFilter}
+
+| 이름 | 설명 |
+| --- | --- |
+| setMagFilter(value) | 배율에 대한 필터를 가져오거나 설정합니다. 속성값은 TextureFilter 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMipFilter{#getMipFilter}
+
+| 이름 | 설명 |
+| --- | --- |
+| getMipFilter() | Mip 레벨 샘플링에 대한 필터를 가져오거나 설정합니다. 속성값은 TextureFilter 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMipFilter{#setMipFilter}
+
+| 이름 | 설명 |
+| --- | --- |
+| setMipFilter(value) | Mip 레벨 샘플링에 대한 필터를 가져오거나 설정합니다. 속성값은 TextureFilter 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getUVRotation{#getUVRotation}
+
+| 이름 | 설명 |
+| --- | --- |
+| getUVRotation() | 텍스처의 회전을 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### setUVRotation{#setUVRotation}
+
+| 이름 | 설명 |
+| --- | --- |
+| setUVRotation(value) | 텍스처의 회전을 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getUVScale{#getUVScale}
+
+| 이름 | 설명 |
+| --- | --- |
+| getUVScale() | UV 스케일을 가져오거나 설정합니다. UV 스케일. |
+
+ **Result:**
+
+
+
+---
+
+
+### setUVScale{#setUVScale}
+
+| 이름 | 설명 |
+| --- | --- |
+| setUVScale(value) | UV 스케일을 가져오거나 설정합니다. UV 스케일. |
+
+ **Result:**
+
+
+
+---
+
+
+### getUVTranslation{#getUVTranslation}
+
+| 이름 | 설명 |
+| --- | --- |
+| getUVTranslation() | UV 변환을 가져오거나 설정합니다. UV 변환. |
+
+ **Result:**
+
+
+
+---
+
+
+### setUVTranslation{#setUVTranslation}
+
+| 이름 | 설명 |
+| --- | --- |
+| setUVTranslation(value) | UV 변환을 가져오거나 설정합니다. UV 변환. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTranslation{#setTranslation}
+
+| 이름 | 설명 |
+| --- | --- |
+| setTranslation(u, v) | UV 변환을 설정합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| u | 숫자 | U. |
+| v | 숫자 | V. |
+
+ **Result:**
+
+
+
+---
+
+
+### setScale{#setScale}
+
+| 이름 | 설명 |
+| --- | --- |
+| setScale(u, v) | UV 스케일을 설정합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| u | 숫자 | U. |
+| v | 숫자 | V. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRotation{#setRotation}
+
+| 이름 | 설명 |
+| --- | --- |
+| setRotation(u, v) | UV 회전을 설정합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| u | 숫자 | U. |
+| v | 숫자 | V. |
+
+ **Result:**
+
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/texturecodec/_index.md
+++ b/korean/nodejs-java/aspose.threed/texturecodec/_index.md
@@ -1,0 +1,61 @@
+---
+title: "TextureCodec"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/texturecodec/
+---
+## TextureCodec class
+
+텍스처용 인코더와 디코더를 관리하는 클래스입니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getSupportedEncoderFormats{#getSupportedEncoderFormats}
+
+| 이름 | 설명 |
+| --- | --- |
+| getSupportedEncoderFormats() | 지원되는 모든 인코더 형식을 가져옵니다 |
+
+ **Result:**
+String[]
+
+
+---
+
+
+### registerCodec{#registerCodec}
+
+| 이름 | 설명 |
+| --- | --- |
+| registerCodec(codec) | 텍스처 인코더 및 디코더 집합을 등록합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 코드 | ITextureCodec | null |
+
+ **Result:**
+String[]
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/texturedata/_index.md
+++ b/korean/nodejs-java/aspose.threed/texturedata/_index.md
@@ -1,0 +1,289 @@
+---
+title: "TextureData"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/texturedata/
+---
+## TextureData class
+
+이 클래스는 텍스처의 원시 데이터와 포맷 정의를 포함합니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor(width, height, stride, bytesPerPixel, pixelFormat, data) | TextureData의 생성자 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 너비 | 숫자 | null |
+| 높이 | 숫자 | null |
+| strid | 숫자 | null |
+| bytesPerPixe | 숫자 | null |
+| pixelFormat | PixelFormat | PixelFormat |
+| 데이터 | byte[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload(width, height, pixelFormat) | 새로운 TextureData를 생성하고 픽셀 데이터를 할당합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 너비 | 숫자 | null |
+| 높이 | 숫자 | null |
+| pixelFormat | PixelFormat | PixelFormat |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload2() | TextureData의 생성자 |
+
+ **Result:**
+
+
+
+---
+
+
+### getData{#getData}
+
+| 이름 | 설명 |
+| --- | --- |
+| getData() | 픽셀 데이터의 원시 바이트 |
+
+ **Result:**
+
+
+
+---
+
+
+### getWidth{#getWidth}
+
+| 이름 | 설명 |
+| --- | --- |
+| getWidth() | 수평 픽셀 수 |
+
+ **Result:**
+
+
+
+---
+
+
+### getHeight{#getHeight}
+
+| 이름 | 설명 |
+| --- | --- |
+| getHeight() | 수직 픽셀 수 |
+
+ **Result:**
+
+
+
+---
+
+
+### getStride{#getStride}
+
+| 이름 | 설명 |
+| --- | --- |
+| getStride() | 스캔라인의 바이트 수. |
+
+ **Result:**
+
+
+
+---
+
+
+### getBytesPerPixel{#getBytesPerPixel}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBytesPerPixel() | 픽셀당 바이트 수 |
+
+ **Result:**
+
+
+
+---
+
+
+### getPixelFormat{#getPixelFormat}
+
+| 이름 | 설명 |
+| --- | --- |
+| getPixelFormat() | 픽셀 형식입니다. 이 속성의 값은 PixelFormat 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### fromFile{#fromFile}
+
+| 이름 | 설명 |
+| --- | --- |
+| fromFile(fileName) | 파일에서 텍스처를 로드합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| fileNam | String | null |
+
+ **Result:**
+TextureData
+
+
+---
+
+
+### save{#save}
+
+| 이름 | 설명 |
+| --- | --- |
+| save(fileName) | 텍스처 데이터를 이미지 파일에 저장합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| fileName | String | 이미지가 저장될 파일 이름입니다. |
+
+ **Result:**
+TextureData
+
+
+---
+
+
+### save{#save}
+
+| 이름 | 설명 |
+| --- | --- |
+| save(fileName, format) | 텍스처 데이터를 이미지 파일에 저장합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| fileName | String | 이미지가 저장될 파일 이름입니다. |
+| format | String | 출력 파일의 이미지 포맷입니다. |
+
+ **Result:**
+TextureData
+
+
+---
+
+
+### mapPixels{#mapPixels}
+
+| 이름 | 설명 |
+| --- | --- |
+| mapPixels(mapMode) | 읽기/쓰기를 위해 모든 픽셀을 매핑합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| mapMode | PixelMapMode | PixelMapMode |
+
+ **Result:**
+PixelMapping
+
+
+---
+
+
+### mapPixels{#mapPixels}
+
+| 이름 | 설명 |
+| --- | --- |
+| mapPixels(mapMode, format) | 주어진 픽셀 포맷으로 읽기/쓰기를 위해 모든 픽셀을 매핑합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| mapMode | PixelMapMode | PixelMapMode |
+| format | PixelFormat | PixelFormat |
+
+ **Result:**
+PixelMapping
+
+
+---
+
+
+### mapPixels{#mapPixels}
+
+| 이름 | 설명 |
+| --- | --- |
+| mapPixels(rect, mapMode, format) | rect 로 지정된 픽셀을 주어진 픽셀 포맷으로 읽기/쓰기를 위해 매핑합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| rect | Rect | 액세스할 픽셀 영역 |
+| mapMode | PixelMapMode | PixelMapMode |
+| format | PixelFormat | PixelFormat |
+
+ **Result:**
+PixelMapping
+
+
+---
+
+
+### transformPixelFormat{#transformPixelFormat}
+
+| 이름 | 설명 |
+| --- | --- |
+| transformPixelFormat(pixelFormat) | 픽셀의 레이아웃을 새로운 픽셀 포맷으로 변환합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| pixelFormat | PixelFormat | PixelFormat |
+
+ **Result:**
+PixelMapping
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/textureslot/_index.md
+++ b/korean/nodejs-java/aspose.threed/textureslot/_index.md
@@ -1,0 +1,42 @@
+---
+title: "TextureSlot"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/textureslot/
+---
+## TextureSlot class
+
+Material의 텍스처 슬롯으로, material 인스턴스를 통해 열거할 수 있습니다.  @hideconstructor
+
+
+## 메서드
+
+### getSlotName{#getSlotName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getSlotName() | 이 텍스처가 바인딩될 슬롯 이름을 나타냅니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTexture{#getTexture}
+
+| 이름 | 설명 |
+| --- | --- |
+| getTexture() | 재료에 바인딩될 텍스처. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/torus/_index.md
+++ b/korean/nodejs-java/aspose.threed/torus/_index.md
@@ -1,0 +1,528 @@
+---
+title: "토러스"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/torus/
+---
+## Torus class
+
+파라미터화된 토러스.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | Torus 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload(radius, tube) | Torus 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 반경 | 숫자 | 토러스의 반지름입니다. |
+| tube | 숫자 | 토러스 튜브의 반지름입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload2(radius, tube, arc) | Torus 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 반경 | 숫자 | 토러스의 반지름입니다. |
+| tube | 숫자 | 토러스 튜브의 반지름입니다. |
+| arc | 숫자 | 아크. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload3{#constructor_overload3}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload3(name, radius, tube, radialSegments, tubularSegments, arc) | Torus 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| name | String | 이름. |
+| 반경 | 숫자 | 토러스의 반지름입니다. |
+| tube | 숫자 | 토러스 튜브의 반지름입니다. |
+| radialSegments | 숫자 | 방사형 세그먼트. |
+| tubularSegments | 숫자 | 튜브형 세그먼트. |
+| arc | 숫자 | 아크. |
+
+ **Result:**
+
+
+
+---
+
+
+### getRadius{#getRadius}
+
+| 이름 | 설명 |
+| --- | --- |
+| getRadius() | 토러스의 반경을 가져오거나 설정합니다. 반경. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRadius{#setRadius}
+
+| 이름 | 설명 |
+| --- | --- |
+| setRadius(value) | 토러스의 반경을 가져오거나 설정합니다. 반경. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTube{#getTube}
+
+| 이름 | 설명 |
+| --- | --- |
+| getTube() | 튜브의 반경을 가져오거나 설정합니다. 튜브. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTube{#setTube}
+
+| 이름 | 설명 |
+| --- | --- |
+| setTube(value) | 튜브의 반경을 가져오거나 설정합니다. 튜브. |
+
+ **Result:**
+
+
+
+---
+
+
+### getRadialSegments{#getRadialSegments}
+
+| 이름 | 설명 |
+| --- | --- |
+| getRadialSegments() | 방사형 세그먼트를 가져오거나 설정합니다. 방사형 세그먼트입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRadialSegments{#setRadialSegments}
+
+| 이름 | 설명 |
+| --- | --- |
+| setRadialSegments(value) | 방사형 세그먼트를 가져오거나 설정합니다. 방사형 세그먼트입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTubularSegments{#getTubularSegments}
+
+| 이름 | 설명 |
+| --- | --- |
+| getTubularSegments() | 튜브형 세그먼트를 가져오거나 설정합니다. 튜브형 세그먼트. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTubularSegments{#setTubularSegments}
+
+| 이름 | 설명 |
+| --- | --- |
+| setTubularSegments(value) | 튜브형 세그먼트를 가져오거나 설정합니다. 튜브형 세그먼트. |
+
+ **Result:**
+
+
+
+---
+
+
+### getArc{#getArc}
+
+| 이름 | 설명 |
+| --- | --- |
+| getArc() | 호를 가져오거나 설정합니다. 호. |
+
+ **Result:**
+
+
+
+---
+
+
+### setArc{#setArc}
+
+| 이름 | 설명 |
+| --- | --- |
+| setArc(value) | 호를 가져오거나 설정합니다. 호. |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastShadows{#getCastShadows}
+
+| 이름 | 설명 |
+| --- | --- |
+| getCastShadows() | 이 지오메트리가 그림자를 드리울 수 있는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastShadows{#setCastShadows}
+
+| 이름 | 설명 |
+| --- | --- |
+| setCastShadows(value) | 이 지오메트리가 그림자를 드리울 수 있는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReceiveShadows{#getReceiveShadows}
+
+| 이름 | 설명 |
+| --- | --- |
+| getReceiveShadows() | 이 지오메트리가 그림자를 받을 수 있는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReceiveShadows{#setReceiveShadows}
+
+| 이름 | 설명 |
+| --- | --- |
+| setReceiveShadows(value) | 이 지오메트리가 그림자를 받을 수 있는지 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNodes() | 모든 부모 노드를 가져옵니다. 엔터티는 기하학 인스턴싱을 위해 여러 부모 노드에 부착될 수 있습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExcluded() | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExcluded(value) | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNode() | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setParentNode(value) | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 이름 | 설명 |
+| --- | --- |
+| getScene() | 이 객체가 속한 씬을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### toMesh{#toMesh}
+
+| 이름 | 설명 |
+| --- | --- |
+| toMesh() | 현재 객체를 메시로 변환합니다 |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBoundingBox() | 현재 엔터티의 객체 공간 좌표계에서 경계 상자를 가져옵니다. |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEntityRendererKey() | 렌더러에 등록된 엔터티 렌더러의 키를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/transform/_index.md
+++ b/korean/nodejs-java/aspose.threed/transform/_index.md
@@ -1,0 +1,561 @@
+---
+title: "변환"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/transform/
+---
+## Transform class
+
+Transform은 객체의 이동/스케일/회전 또는 변환 행렬에 최소 비용으로 접근할 수 있는 정보를 포함합니다. 이는 로컬 변환에 사용됩니다.  @hideconstructor
+
+
+## 메서드
+
+### getGeometricTranslation{#getGeometricTranslation}
+
+| 이름 | 설명 |
+| --- | --- |
+| getGeometricTranslation() | 기하학적 변환을 가져오거나 설정합니다. 기하학적 변환은 연결된 엔터티에만 영향을 미치며 자식 노드는 영향을 받지 않습니다. 지원하지 않는 파일 형식으로 기하학적 변환을 내보낼 때 로컬 변환으로 병합됩니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setGeometricTranslation{#setGeometricTranslation}
+
+| 이름 | 설명 |
+| --- | --- |
+| setGeometricTranslation(value) | 기하학적 변환을 가져오거나 설정합니다. 기하학적 변환은 연결된 엔터티에만 영향을 미치며 자식 노드는 영향을 받지 않습니다. 지원하지 않는 파일 형식으로 기하학적 변환을 내보낼 때 로컬 변환으로 병합됩니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getGeometricScaling{#getGeometricScaling}
+
+| 이름 | 설명 |
+| --- | --- |
+| getGeometricScaling() | 기하학적 스케일링을 가져오거나 설정합니다. 기하학적 변환은 연결된 엔터티에만 영향을 미치며 자식 노드는 영향을 받지 않습니다. 지원하지 않는 파일 형식으로 기하학적 변환을 내보낼 때 로컬 변환으로 병합됩니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setGeometricScaling{#setGeometricScaling}
+
+| 이름 | 설명 |
+| --- | --- |
+| setGeometricScaling(value) | 기하학적 스케일링을 가져오거나 설정합니다. 기하학적 변환은 연결된 엔터티에만 영향을 미치며 자식 노드는 영향을 받지 않습니다. 지원하지 않는 파일 형식으로 기하학적 변환을 내보낼 때 로컬 변환으로 병합됩니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getGeometricRotation{#getGeometricRotation}
+
+| 이름 | 설명 |
+| --- | --- |
+| getGeometricRotation() | 기하학적 오일러 회전을 가져오거나 설정합니다(도 단위). 기하학적 변환은 연결된 엔터티에만 영향을 미치며 자식 노드는 영향을 받지 않습니다. 지원하지 않는 파일 형식으로 기하학적 변환을 내보낼 때 로컬 변환으로 병합됩니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setGeometricRotation{#setGeometricRotation}
+
+| 이름 | 설명 |
+| --- | --- |
+| setGeometricRotation(value) | 기하학적 오일러 회전을 가져오거나 설정합니다(도 단위). 기하학적 변환은 연결된 엔터티에만 영향을 미치며 자식 노드는 영향을 받지 않습니다. 지원하지 않는 파일 형식으로 기하학적 변환을 내보낼 때 로컬 변환으로 병합됩니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTranslation{#getTranslation}
+
+| 이름 | 설명 |
+| --- | --- |
+| getTranslation() | 이동을 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### setTranslation{#setTranslation}
+
+| 이름 | 설명 |
+| --- | --- |
+| setTranslation(value) | 이동을 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getScale{#getScale}
+
+| 이름 | 설명 |
+| --- | --- |
+| getScale() | 스케일을 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### setScale{#setScale}
+
+| 이름 | 설명 |
+| --- | --- |
+| setScale(value) | 스케일을 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getPreRotation{#getPreRotation}
+
+| 이름 | 설명 |
+| --- | --- |
+| getPreRotation() | 각도로 표시된 사전 회전을 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### setPreRotation{#setPreRotation}
+
+| 이름 | 설명 |
+| --- | --- |
+| setPreRotation(value) | 각도로 표시된 사전 회전을 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getPostRotation{#getPostRotation}
+
+| 이름 | 설명 |
+| --- | --- |
+| getPostRotation() | 각도로 표시된 사후 회전을 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### setPostRotation{#setPostRotation}
+
+| 이름 | 설명 |
+| --- | --- |
+| setPostRotation(value) | 각도로 표시된 사후 회전을 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getEulerAngles{#getEulerAngles}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEulerAngles() | 각도로 측정된 오일러 각으로 표시된 회전을 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### setEulerAngles{#setEulerAngles}
+
+| 이름 | 설명 |
+| --- | --- |
+| setEulerAngles(value) | 각도로 측정된 오일러 각으로 표시된 회전을 가져오거나 설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getRotation{#getRotation}
+
+| 이름 | 설명 |
+| --- | --- |
+| getRotation() | 쿼터니언으로 표시된 회전을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRotation{#setRotation}
+
+| 이름 | 설명 |
+| --- | --- |
+| setRotation(value) | 쿼터니언으로 표시된 회전을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTransformMatrix{#getTransformMatrix}
+
+| 이름 | 설명 |
+| --- | --- |
+| getTransformMatrix() | 변환 행렬을 가져오거나 설정합니다. 이 값에 할당하면 Translation, Scale 및 Rotation이 초기화되며, GeometricRotation, GeometricScaling 및 GeometricTranslation은 영향을 받지 않습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTransformMatrix{#setTransformMatrix}
+
+| 이름 | 설명 |
+| --- | --- |
+| setTransformMatrix(value) | 변환 행렬을 가져오거나 설정합니다. 이 값에 할당하면 Translation, Scale 및 Rotation이 초기화되며, GeometricRotation, GeometricScaling 및 GeometricTranslation은 영향을 받지 않습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setGeometricTranslation{#setGeometricTranslation}
+
+| 이름 | 설명 |
+| --- | --- |
+| setGeometricTranslation(x, y, z) | 기하학적 이동을 설정합니다. 기하학적 변환은 연결된 엔터티에만 영향을 미치고 자식 노드는 영향을 받지 않습니다. 지원하지 않는 파일 형식으로 기하학적 변환을 내보낼 때 로컬 변환으로 병합됩니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setGeometricScaling{#setGeometricScaling}
+
+| 이름 | 설명 |
+| --- | --- |
+| setGeometricScaling(sx, sy, sz) | 기하학적 스케일을 설정합니다. 기하학적 변환은 연결된 엔터티에만 영향을 미치고 자식 노드는 영향을 받지 않습니다. 지원하지 않는 파일 형식으로 기하학적 변환을 내보낼 때 로컬 변환으로 병합됩니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setGeometricRotation{#setGeometricRotation}
+
+| 이름 | 설명 |
+| --- | --- |
+| setGeometricRotation(rx, ry, rz) | 기하학적 오일러 회전을 설정합니다(각도로 측정). 기하학적 변환은 연결된 엔터티에만 영향을 미치고 자식 노드는 영향을 받지 않습니다. 지원하지 않는 파일 형식으로 기하학적 변환을 내보낼 때 로컬 변환으로 병합됩니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTranslation{#setTranslation}
+
+| 이름 | 설명 |
+| --- | --- |
+| setTranslation(tx, ty, tz) | 현재 변환의 이동을 설정합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| t | 숫자 | null |
+| t | 숫자 | null |
+| t | 숫자 | null |
+
+ **Result:**
+변환
+
+
+---
+
+
+### setScale{#setScale}
+
+| 이름 | 설명 |
+| --- | --- |
+| setScale(sx, sy, sz) | 현재 변환의 스케일을 설정합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| s | 숫자 | null |
+| s | 숫자 | null |
+| s | 숫자 | null |
+
+ **Result:**
+변환
+
+
+---
+
+
+### setEulerAngles{#setEulerAngles}
+
+| 이름 | 설명 |
+| --- | --- |
+| setEulerAngles(rx, ry, rz) | 현재 변환의 Euler 각도를 도 단위로 설정합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| r | 숫자 | null |
+| r | 숫자 | null |
+| r | 숫자 | null |
+
+ **Result:**
+변환
+
+
+---
+
+
+### setRotation{#setRotation}
+
+| 이름 | 설명 |
+| --- | --- |
+| setRotation(rw, rx, ry, rz) | 현재 변환의 회전을 (쿼터니언 구성 요소로) 설정합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| r | 숫자 | null |
+| r | 숫자 | null |
+| r | 숫자 | null |
+| r | 숫자 | null |
+
+ **Result:**
+변환
+
+
+---
+
+
+### setPreRotation{#setPreRotation}
+
+| 이름 | 설명 |
+| --- | --- |
+| setPreRotation(rx, ry, rz) | 프리-회전을 도 단위로 설정합니다. |
+
+ **Result:**
+변환
+
+
+---
+
+
+### setPostRotation{#setPostRotation}
+
+| 이름 | 설명 |
+| --- | --- |
+| setPostRotation(rx, ry, rz) | 포스트-회전을 도 단위로 설정합니다. |
+
+ **Result:**
+변환
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/transformbuilder/_index.md
+++ b/korean/nodejs-java/aspose.threed/transformbuilder/_index.md
@@ -1,0 +1,457 @@
+---
+title: "TransformBuilder"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/transformbuilder/
+---
+## TransformBuilder class
+
+TransformBuilder는 일련의 변환을 통해 변환 행렬을 구축하는 데 사용됩니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor(initial, order) | 초기 변환 행렬과 지정된 합성 순서를 사용하여 TransformBuilder를 생성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| initia | Matrix4 | null |
+| order | ComposeOrder | ComposeOrder |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload(order) | 초기 단위 변환 행렬과 지정된 합성 순서를 사용하여 TransformBuilder를 생성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| order | ComposeOrder | ComposeOrder |
+
+ **Result:**
+
+
+
+---
+
+
+### getMatrix{#getMatrix}
+
+| 이름 | 설명 |
+| --- | --- |
+| getMatrix() | 현재 행렬 값을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMatrix{#setMatrix}
+
+| 이름 | 설명 |
+| --- | --- |
+| setMatrix(value) | 현재 행렬 값을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getComposeOrder{#getComposeOrder}
+
+| 이름 | 설명 |
+| --- | --- |
+| getComposeOrder() | 체인 합성 순서를 가져오거나 설정합니다. 이 속성의 값은 ComposeOrder 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setComposeOrder{#setComposeOrder}
+
+| 이름 | 설명 |
+| --- | --- |
+| setComposeOrder(value) | 체인 합성 순서를 가져오거나 설정합니다. 이 속성의 값은 ComposeOrder 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### compose{#compose}
+
+| 이름 | 설명 |
+| --- | --- |
+| compose(m) | 인수(argument)를 내부 행렬에 추가하거나 앞에 삽입합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+|  | Matrix4 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### append{#append}
+
+| 이름 | 설명 |
+| --- | --- |
+| append(m) | 새 변환 행렬을 변환 체인에 추가합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+|  | Matrix4 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### prepend{#prepend}
+
+| 이름 | 설명 |
+| --- | --- |
+| prepend(m) | 새 변환 행렬을 변환 체인 앞에 추가합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+|  | Matrix4 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### rearrange{#rearrange}
+
+| 이름 | 설명 |
+| --- | --- |
+| rearrange(newX, newY, newZ) | 축의 레이아웃을 재배열합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| newX | 축 | 축 |
+| newY | 축 | 축 |
+| newZ | 축 | 축 |
+
+ **Result:**
+
+
+
+---
+
+
+### scale{#scale}
+
+| 이름 | 설명 |
+| --- | --- |
+| scale(s) | 구성 요소가 s로 스케일된 스케일 변환 행렬을 연결합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+|  | 숫자 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### scale{#scale}
+
+| 이름 | 설명 |
+| --- | --- |
+| scale(x, y, z) | 스케일 변환 행렬을 연결합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+|  | 숫자 | null |
+|  | 숫자 | null |
+|  | 숫자 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### scale{#scale}
+
+| 이름 | 설명 |
+| --- | --- |
+| scale(s) | 스케일 변환을 연결합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+|  | Vector3 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### rotateDegree{#rotateDegree}
+
+| 이름 | 설명 |
+| --- | --- |
+| rotateDegree(angle, axis) | 각도 단위 회전 변환을 연결합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| angle | 숫자 | 도 단위 회전 각도 |
+| axis | Vector3 | 회전할 축 |
+
+ **Result:**
+
+
+
+---
+
+
+### rotateRadian{#rotateRadian}
+
+| 이름 | 설명 |
+| --- | --- |
+| rotateRadian(angle, axis) | 라디안 단위 회전 변환을 연결합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| angle | 숫자 | 라디안 단위 회전 각도 |
+| axis | Vector3 | 회전할 축 |
+
+ **Result:**
+
+
+
+---
+
+
+### rotate{#rotate}
+
+| 이름 | 설명 |
+| --- | --- |
+| rotate(q) | 쿼터니언으로 회전을 연결합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+|  | Quaternion | null |
+
+ **Result:**
+
+
+
+---
+
+
+### rotateEulerDegree{#rotateEulerDegree}
+
+| 이름 | 설명 |
+| --- | --- |
+| rotateEulerDegree(degX, degY, degZ) | 도 단위 오일러 각도로 회전을 연결합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| deg | 숫자 | null |
+| deg | 숫자 | null |
+| deg | 숫자 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### rotateEulerRadian{#rotateEulerRadian}
+
+| 이름 | 설명 |
+| --- | --- |
+| rotateEulerRadian(x, y, z) | 라디안 단위 오일러 각도로 회전을 연결합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+|  | 숫자 | null |
+|  | 숫자 | null |
+|  | 숫자 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### rotateEulerRadian{#rotateEulerRadian}
+
+| 이름 | 설명 |
+| --- | --- |
+| rotateEulerRadian(r) | 라디안 단위 오일러 각도로 회전을 연결합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+|  | Vector3 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### translate{#translate}
+
+| 이름 | 설명 |
+| --- | --- |
+| translate(tx, ty, tz) | 이동 변환을 연결합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| t | 숫자 | null |
+| t | 숫자 | null |
+| t | 숫자 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### translate{#translate}
+
+| 이름 | 설명 |
+| --- | --- |
+| translate(v) | 이동 변환을 연결합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+|  | Vector3 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### reset{#reset}
+
+| 이름 | 설명 |
+| --- | --- |
+| reset() | 변환을 단위 행렬로 재설정합니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### rotateDegree{#rotateDegree}
+
+| 이름 | 설명 |
+| --- | --- |
+| rotateDegree(rot, order) | 지정된 순서로 회전을 추가합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| rot | Vector3 | 도 단위 회전 |
+| order | RotationOrder | RotationOrder |
+
+ **Result:**
+
+
+
+---
+
+
+### rotateRadian{#rotateRadian}
+
+| 이름 | 설명 |
+| --- | --- |
+| rotateRadian(rot, order) | 지정된 순서로 회전을 추가합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| rot | Vector3 | 라디안 단위 회전 |
+| order | RotationOrder | RotationOrder |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/transformedcurve/_index.md
+++ b/korean/nodejs-java/aspose.threed/transformedcurve/_index.md
@@ -1,0 +1,359 @@
+---
+title: "TransformedCurve"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/transformedcurve/
+---
+## TransformedCurve class
+
+TransformedCurve는 변환 행렬을 사용하여 곡선에 위치를 부여합니다. 이를 통해 TrimmedCurve 또는 CompositeCurve 내부에서 변환을 수행할 수 있습니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | TransformedCurve의 생성자 |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload(basisCurve, transformation) | TransformedCurve의 생성자 |
+
+ **Result:**
+
+
+
+---
+
+
+### getTransformMatrix{#getTransformMatrix}
+
+| 이름 | 설명 |
+| --- | --- |
+| getTransformMatrix() | 변환 행렬. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTransformMatrix{#setTransformMatrix}
+
+| 이름 | 설명 |
+| --- | --- |
+| setTransformMatrix(value) | 변환 행렬. |
+
+ **Result:**
+
+
+
+---
+
+
+### getBasisCurve{#getBasisCurve}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBasisCurve() | 기본 곡선. |
+
+ **Result:**
+
+
+
+---
+
+
+### setBasisCurve{#setBasisCurve}
+
+| 이름 | 설명 |
+| --- | --- |
+| setBasisCurve(value) | 기본 곡선. |
+
+ **Result:**
+
+
+
+---
+
+
+### getColor{#getColor}
+
+| 이름 | 설명 |
+| --- | --- |
+| getColor() | 선의 색상을 가져오거나 설정합니다. 기본값은 흰색(1, 1, 1)입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setColor{#setColor}
+
+| 이름 | 설명 |
+| --- | --- |
+| setColor(value) | 선의 색상을 가져오거나 설정합니다. 기본값은 흰색(1, 1, 1)입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNodes() | 모든 부모 노드를 가져옵니다. 엔터티는 기하학 인스턴싱을 위해 여러 부모 노드에 부착될 수 있습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExcluded() | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExcluded(value) | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNode() | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setParentNode(value) | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 이름 | 설명 |
+| --- | --- |
+| getScene() | 이 객체가 속한 씬을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEntityRendererKey() | 렌더러에 등록된 엔터티 렌더러의 키를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBoundingBox() | 현재 엔터티의 객체 공간 좌표계에서 경계 상자를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/trapeziumshape/_index.md
+++ b/korean/nodejs-java/aspose.threed/trapeziumshape/_index.md
@@ -1,0 +1,385 @@
+---
+title: "TrapeziumShape"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/trapeziumshape/
+---
+## TrapeziumShape class
+
+파라미터로 정의된 IFC 호환 트라페지움 형태.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | TrapeziumShape의 생성자 |
+
+ **Result:**
+
+
+
+---
+
+
+### getBottomXDim{#getBottomXDim}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBottomXDim() | x축을 따라 측정된 하단 선의 길이를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setBottomXDim{#setBottomXDim}
+
+| 이름 | 설명 |
+| --- | --- |
+| setBottomXDim(value) | x축을 따라 측정된 하단 선의 길이를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTopXDim{#getTopXDim}
+
+| 이름 | 설명 |
+| --- | --- |
+| getTopXDim() | x축을 따라 측정된 상단 라인의 범위를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTopXDim{#setTopXDim}
+
+| 이름 | 설명 |
+| --- | --- |
+| setTopXDim(value) | x축을 따라 측정된 상단 라인의 범위를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getYDim{#getYDim}
+
+| 이름 | 설명 |
+| --- | --- |
+| getYDim() | y축을 따라 측정된 상단 라인과 하단 라인 사이의 거리를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setYDim{#setYDim}
+
+| 이름 | 설명 |
+| --- | --- |
+| setYDim(value) | y축을 따라 측정된 상단 라인과 하단 라인 사이의 거리를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTopXOffset{#getTopXOffset}
+
+| 이름 | 설명 |
+| --- | --- |
+| getTopXOffset() | 상단 라인의 시작점부터 하단 라인까지의 오프셋을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTopXOffset{#setTopXOffset}
+
+| 이름 | 설명 |
+| --- | --- |
+| setTopXOffset(value) | 상단 라인의 시작점부터 하단 라인까지의 오프셋을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNodes() | 모든 부모 노드를 가져옵니다. 엔터티는 기하학 인스턴싱을 위해 여러 부모 노드에 부착될 수 있습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExcluded() | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExcluded(value) | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNode() | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setParentNode(value) | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 이름 | 설명 |
+| --- | --- |
+| getScene() | 이 객체가 속한 씬을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtent{#getExtent}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExtent() | x 및 y 차원에서의 범위를 가져옵니다. |
+
+ **Result:**
+Vector2
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEntityRendererKey() | 렌더러에 등록된 엔터티 렌더러의 키를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBoundingBox() | 현재 엔터티의 객체 공간 좌표계에서 경계 상자를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/trialexception/_index.md
+++ b/korean/nodejs-java/aspose.threed/trialexception/_index.md
@@ -1,0 +1,61 @@
+---
+title: "TrialException"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/trialexception/
+---
+## TrialException class
+
+라이선스가 적용되지 않은 경우 Scene.Open/Scene.Save에서 이 예외가 발생합니다. SuppressTrialException을 true로 설정하면 이 예외를 끌 수 있습니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor(msg) | TrialException의 생성자 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| ms | String | null |
+
+ **Result:**
+
+
+
+---
+
+
+### getSuppressTrialException{#getSuppressTrialException}
+
+| 이름 | 설명 |
+| --- | --- |
+| getSuppressTrialException() | 이 값을 true로 설정하면 라이선스가 없는 사용에 대한 체험 예외를 억제하지만 제한이 해제되지 않습니다. 제한을 해제하려면 적절한 라이선스를 사용하십시오. 또한 이 값을 true로 설정한다는 것은 비라이선스 제한을 인지하고 있다는 의미입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setSuppressTrialException{#setSuppressTrialException}
+
+| 이름 | 설명 |
+| --- | --- |
+| setSuppressTrialException(value) | 이 값을 true로 설정하면 라이선스가 없는 사용에 대한 체험 예외를 억제하지만 제한이 해제되지 않습니다. 제한을 해제하려면 적절한 라이선스를 사용하십시오. 또한 이 값을 true로 설정한다는 것은 비라이선스 제한을 인지하고 있다는 의미입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/trimesh/_index.md
+++ b/korean/nodejs-java/aspose.threed/trimesh/_index.md
@@ -1,0 +1,679 @@
+---
+title: "TriMesh"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/trimesh/
+---
+## TriMesh class
+
+TriMesh는 GPU에서 직접 사용할 수 있는 원시 데이터를 포함합니다. 이 클래스는 정점당 데이터만 포함하는 메쉬를 구성하는 데 도움이 되는 유틸리티입니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor(name, declaration) | TriMesh 인스턴스를 초기화합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| name | String | 이 TriMesh의 이름 |
+| declaration | VertexDeclaration | 버텍스 선언 |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexDeclaration{#getVertexDeclaration}
+
+| 이름 | 설명 |
+| --- | --- |
+| getVertexDeclaration() | TriMesh의 버텍스 레이아웃. |
+
+ **Result:**
+
+
+
+---
+
+
+### getVerticesCount{#getVerticesCount}
+
+| 이름 | 설명 |
+| --- | --- |
+| getVerticesCount() | 이 TriMesh의 버텍스 개수 |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndicesCount{#getIndicesCount}
+
+| 이름 | 설명 |
+| --- | --- |
+| getIndicesCount() | 이 TriMesh의 인덱스 수 |
+
+ **Result:**
+
+
+
+---
+
+
+### getUnmergedVerticesCount{#getUnmergedVerticesCount}
+
+| 이름 | 설명 |
+| --- | --- |
+| getUnmergedVerticesCount() | beginVertex()와 endVertex()에 의해 전달된 병합되지 않은 정점의 수. |
+
+ **Result:**
+
+
+
+---
+
+
+### getCapacity{#getCapacity}
+
+| 이름 | 설명 |
+| --- | --- |
+| getCapacity() | 미리 할당된 정점의 용량. |
+
+ **Result:**
+
+
+
+---
+
+
+### getVerticesSizeInBytes{#getVerticesSizeInBytes}
+
+| 이름 | 설명 |
+| --- | --- |
+| getVerticesSizeInBytes() | 모든 정점의 총 크기(바이트 단위) |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNodes() | 모든 부모 노드를 가져옵니다. 엔터티는 기하학 인스턴싱을 위해 여러 부모 노드에 부착될 수 있습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExcluded() | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExcluded(value) | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNode() | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setParentNode(value) | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 이름 | 설명 |
+| --- | --- |
+| getScene() | 이 객체가 속한 씬을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### fromMesh{#fromMesh}
+
+| 이름 | 설명 |
+| --- | --- |
+| fromMesh(declaration, mesh) | 주어진 메시 객체와 지정된 정점 레이아웃으로 TriMesh를 생성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| declaratio | VertexDeclaration | null |
+| mes | Mesh | null |
+
+ **Result:**
+TriMesh
+
+
+---
+
+
+### copyFrom{#copyFrom}
+
+| 이름 | 설명 |
+| --- | --- |
+| copyFrom(input, vd) | 새 정점 레이아웃을 사용하여 입력에서 TriMesh를 복사합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| input | TriMesh | 복사를 위한 입력 TriMesh |
+| vd | VertexDeclaration | 출력 TriMesh의 새로운 정점 선언 |
+
+ **Result:**
+TriMesh
+
+
+---
+
+
+### fromMesh{#fromMesh}
+
+| 이름 | 설명 |
+| --- | --- |
+| fromMesh(mesh, useFloat) | 주어진 메시 객체에서 TriMesh를 생성하며, 정점 선언은 입력 메시의 구조를 기반으로 합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| mes | Mesh | null |
+| useFloat | boolean | 각 정점 요소 구성 요소에 대해 double 대신 float 타입을 사용합니다. |
+
+ **Result:**
+TriMesh
+
+
+---
+
+
+### beginVertex{#beginVertex}
+
+| 이름 | 설명 |
+| --- | --- |
+| beginVertex() | 정점 추가 시작 |
+
+ **Result:**
+정점
+
+
+---
+
+
+### endVertex{#endVertex}
+
+| 이름 | 설명 |
+| --- | --- |
+| endVertex() | 정점 추가 종료 |
+
+ **Result:**
+정점
+
+
+---
+
+
+### verticesToArray{#verticesToArray}
+
+| 이름 | 설명 |
+| --- | --- |
+| verticesToArray() | 정점 데이터를 바이트 배열로 변환합니다 |
+
+ **Result:**
+byte[]
+
+
+---
+
+
+### toString{#toString}
+
+| 이름 | 설명 |
+| --- | --- |
+| toString() |  |
+
+ **Result:**
+String
+
+
+---
+
+
+### fromRawData{#fromRawData}
+
+| 이름 | 설명 |
+| --- | --- |
+| fromRawData(vd, vertices, indices, generateVertexMapping) | 원시 데이터에서 TriMesh를 생성합니다. 반환된 TriMesh는 성능을 위해 입력 바이트 배열을 복사하지 않으며, 배열에 대한 외부 변경이 이 인스턴스에 반영됩니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| vd | VertexDeclaration | 정점 선언은 최소 하나의 필드를 포함해야 합니다. |
+| vertices | byte[] | 입력 정점 데이터이며, 정점 배열의 최소 길이는 정점 선언 크기보다 크거나 같아야 합니다. |
+| 인덱스 | Number[] | 삼각형 인덱스 |
+| generateVertexMapping | boolean | 생성 |
+
+ **Result:**
+TriMesh
+
+
+---
+
+
+### loadVerticesFromBytes{#loadVerticesFromBytes}
+
+| 이름 | 설명 |
+| --- | --- |
+| loadVerticesFromBytes(verticesInBytes) | 바이트에서 정점을 로드합니다. 바이트 길이는 정점 크기의 정수 배여야 합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| verticesInByte | byte[] | null |
+
+ **Result:**
+TriMesh
+
+
+---
+
+
+### readVector4{#readVector4}
+
+| 이름 | 설명 |
+| --- | --- |
+| readVector4(idx, field) | vector4 필드를 읽습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| idx | 숫자 | 읽을 정점의 인덱스 |
+| field | VertexField | Vector4/FVector4 데이터 타입을 가진 필드 |
+
+ **Result:**
+Vector4
+
+
+---
+
+
+### readFVector4{#readFVector4}
+
+| 이름 | 설명 |
+| --- | --- |
+| readFVector4(idx, field) | vector4 필드를 읽습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| idx | 숫자 | 읽을 정점의 인덱스 |
+| field | VertexField | Vector4/FVector4 데이터 타입을 가진 필드 |
+
+ **Result:**
+FVector4
+
+
+---
+
+
+### readVector3{#readVector3}
+
+| 이름 | 설명 |
+| --- | --- |
+| readVector3(idx, field) | vector3 필드를 읽습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| idx | 숫자 | 읽을 정점의 인덱스 |
+| field | VertexField | Vector3/FVector3 데이터 유형을 가진 필드 |
+
+ **Result:**
+Vector3
+
+
+---
+
+
+### readFVector3{#readFVector3}
+
+| 이름 | 설명 |
+| --- | --- |
+| readFVector3(idx, field) | vector3 필드를 읽습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| idx | 숫자 | 읽을 정점의 인덱스 |
+| field | VertexField | Vector3/FVector3 데이터 유형을 가진 필드 |
+
+ **Result:**
+FVector3
+
+
+---
+
+
+### readVector2{#readVector2}
+
+| 이름 | 설명 |
+| --- | --- |
+| readVector2(idx, field) | vector2 필드를 읽습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| idx | 숫자 | 읽을 정점의 인덱스 |
+| field | VertexField | Vector2/FVector2 데이터 유형을 가진 필드 |
+
+ **Result:**
+Vector2
+
+
+---
+
+
+### readFVector2{#readFVector2}
+
+| 이름 | 설명 |
+| --- | --- |
+| readFVector2(idx, field) | vector2 필드를 읽습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| idx | 숫자 | 읽을 정점의 인덱스 |
+| field | VertexField | Vector2/FVector2 데이터 유형을 가진 필드 |
+
+ **Result:**
+FVector2
+
+
+---
+
+
+### readDouble{#readDouble}
+
+| 이름 | 설명 |
+| --- | --- |
+| readDouble(idx, field) | double 필드를 읽습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| idx | 숫자 | 읽을 정점의 인덱스 |
+| field | VertexField | float/double 호환 데이터 유형을 가진 필드 |
+
+ **Result:**
+숫자
+
+
+---
+
+
+### readFloat{#readFloat}
+
+| 이름 | 설명 |
+| --- | --- |
+| readFloat(idx, field) | float 필드를 읽습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| idx | 숫자 | 읽을 정점의 인덱스 |
+| field | VertexField | float/double 호환 데이터 유형을 가진 필드 |
+
+ **Result:**
+숫자
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBoundingBox() | 현재 엔터티의 객체 공간 좌표계에서 경계 상자를 가져옵니다. |
+
+ **Result:**
+숫자
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEntityRendererKey() | 렌더러에 등록된 엔터티 렌더러의 키를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+### iterator{#iterator}
+
+| 이름 | 설명 |
+| --- | --- |
+| iterator() | 내부 사용을 위해 예약되었습니다. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/trimmedcurve/_index.md
+++ b/korean/nodejs-java/aspose.threed/trimmedcurve/_index.md
@@ -1,0 +1,398 @@
+---
+title: "TrimmedCurve"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/trimmedcurve/
+---
+## TrimmedCurve class
+
+양쪽 끝에서 기본 곡선을 잘라낸 제한된 곡선.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | TrimmedCurve의 생성자 |
+
+ **Result:**
+
+
+
+---
+
+
+### getBasisCurve{#getBasisCurve}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBasisCurve() | 잘라낼 기준 곡선. |
+
+ **Result:**
+
+
+
+---
+
+
+### setBasisCurve{#setBasisCurve}
+
+| 이름 | 설명 |
+| --- | --- |
+| setBasisCurve(value) | 잘라낼 기준 곡선. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFirst{#getFirst}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFirst() | 잘라낼 첫 번째 끝점으로, 직교점 또는 실수 매개변수가 될 수 있습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFirst{#setFirst}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFirst(value) | 잘라낼 첫 번째 끝점으로, 직교점 또는 실수 매개변수가 될 수 있습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getSecond{#getSecond}
+
+| 이름 | 설명 |
+| --- | --- |
+| getSecond() | 두 번째 끝점은 트리밍할 대상이며, 직교 좌표점이거나 실제 매개변수일 수 있습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setSecond{#setSecond}
+
+| 이름 | 설명 |
+| --- | --- |
+| setSecond(value) | 두 번째 끝점은 트리밍할 대상이며, 직교 좌표점이거나 실제 매개변수일 수 있습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getSameDirection{#getSameDirection}
+
+| 이름 | 설명 |
+| --- | --- |
+| getSameDirection() | 트리밍된 결과가 기본 곡선과 동일한 방향을 사용하는지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setSameDirection{#setSameDirection}
+
+| 이름 | 설명 |
+| --- | --- |
+| setSameDirection(value) | 트리밍된 결과가 기본 곡선과 동일한 방향을 사용하는지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getColor{#getColor}
+
+| 이름 | 설명 |
+| --- | --- |
+| getColor() | 선의 색상을 가져오거나 설정합니다. 기본값은 흰색(1, 1, 1)입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setColor{#setColor}
+
+| 이름 | 설명 |
+| --- | --- |
+| setColor(value) | 선의 색상을 가져오거나 설정합니다. 기본값은 흰색(1, 1, 1)입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNodes() | 모든 부모 노드를 가져옵니다. 엔터티는 기하학 인스턴싱을 위해 여러 부모 노드에 부착될 수 있습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExcluded() | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExcluded(value) | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNode() | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setParentNode(value) | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 이름 | 설명 |
+| --- | --- |
+| getScene() | 이 객체가 속한 씬을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEntityRendererKey() | 렌더러에 등록된 엔터티 렌더러의 키를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBoundingBox() | 현재 엔터티의 객체 공간 좌표계에서 경계 상자를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/tshape/_index.md
+++ b/korean/nodejs-java/aspose.threed/tshape/_index.md
@@ -1,0 +1,463 @@
+---
+title: "TShape"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/tshape/
+---
+## TShape class
+
+파라미터로 정의된 IFC 호환 T형.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | TShape의 생성자 |
+
+ **Result:**
+
+
+
+---
+
+
+### getDepth{#getDepth}
+
+| 이름 | 설명 |
+| --- | --- |
+| getDepth() | 웹의 길이를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDepth{#setDepth}
+
+| 이름 | 설명 |
+| --- | --- |
+| setDepth(value) | 웹의 길이를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlangeWidth{#getFlangeWidth}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFlangeWidth() | 플랜지의 길이를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlangeWidth{#setFlangeWidth}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFlangeWidth(value) | 플랜지의 길이를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getWebThickness{#getWebThickness}
+
+| 이름 | 설명 |
+| --- | --- |
+| getWebThickness() | 웹의 벽 두께를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setWebThickness{#setWebThickness}
+
+| 이름 | 설명 |
+| --- | --- |
+| setWebThickness(value) | 웹의 벽 두께를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlangeThickness{#getFlangeThickness}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFlangeThickness() | 플랜지의 벽 두께를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlangeThickness{#setFlangeThickness}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFlangeThickness(value) | 플랜지의 벽 두께를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFilletRadius{#getFilletRadius}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFilletRadius() | 웹과 플랜지 사이의 필렛 반경을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFilletRadius{#setFilletRadius}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFilletRadius(value) | 웹과 플랜지 사이의 필렛 반경을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlangeEdgeRadius{#getFlangeEdgeRadius}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFlangeEdgeRadius() | 플랜지 가장자리의 반경을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlangeEdgeRadius{#setFlangeEdgeRadius}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFlangeEdgeRadius(value) | 플랜지 가장자리의 반경을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getWebEdgeRadius{#getWebEdgeRadius}
+
+| 이름 | 설명 |
+| --- | --- |
+| getWebEdgeRadius() | 웹 가장자리의 반경을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setWebEdgeRadius{#setWebEdgeRadius}
+
+| 이름 | 설명 |
+| --- | --- |
+| setWebEdgeRadius(value) | 웹 가장자리의 반경을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNodes() | 모든 부모 노드를 가져옵니다. 엔터티는 기하학 인스턴싱을 위해 여러 부모 노드에 부착될 수 있습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExcluded() | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExcluded(value) | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNode() | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setParentNode(value) | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 이름 | 설명 |
+| --- | --- |
+| getScene() | 이 객체가 속한 씬을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtent{#getExtent}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExtent() | x 및 y 차원에서의 범위를 가져옵니다. |
+
+ **Result:**
+Vector2
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEntityRendererKey() | 렌더러에 등록된 엔터티 렌더러의 키를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBoundingBox() | 현재 엔터티의 객체 공간 좌표계에서 경계 상자를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/u3dloadoptions/_index.md
+++ b/korean/nodejs-java/aspose.threed/u3dloadoptions/_index.md
@@ -1,0 +1,146 @@
+---
+title: "U3dLoadOptions"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/u3dloadoptions/
+---
+## U3dLoadOptions class
+
+유니버설 3D 로드 옵션
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | U3dLoadOptions의 생성자 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlipCoordinateSystem{#getFlipCoordinateSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFlipCoordinateSystem() | 가져오기/내보내기 중에 제어점/법선의 좌표계 반전 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlipCoordinateSystem{#setFlipCoordinateSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFlipCoordinateSystem(value) | 가져오기/내보내기 중에 제어점/법선의 좌표계 반전 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileFormat() | 현재 저장/로드 옵션에 지정된 파일 형식을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEncoding() | 텍스트 기반 파일에 대한 기본 인코딩을 가져오거나 설정합니다. 기본값은 null이며, 이는 가져오기/내보내기 프로그램이 사용할 인코딩을 결정함을 의미합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileSystem() | 로드/저장 중 외부 종속성을 관리하는 방법을 사용자가 처리하도록 허용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFileSystem(value) | 로드/저장 중 외부 종속성을 관리하는 방법을 사용자가 처리하도록 허용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| 이름 | 설명 |
+| --- | --- |
+| getLookupPaths() | OBJ와 같은 일부 파일은 외부 파일에 의존하며, 조회 경로를 통해 Aspose.3D가 외부 파일을 찾아 로드할 수 있도록 합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileName() | 내보내기/가져오기 씬의 파일 이름입니다. 선택 사항이지만 OBJ의 재질과 같은 외부 자산을 직렬화할 때 유용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFileName(value) | 내보내기/가져오기 씬의 파일 이름입니다. 선택 사항이지만 OBJ의 재질과 같은 외부 자산을 직렬화할 때 유용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/u3dsaveoptions/_index.md
+++ b/korean/nodejs-java/aspose.threed/u3dsaveoptions/_index.md
@@ -1,0 +1,328 @@
+---
+title: "U3dSaveOptions"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/u3dsaveoptions/
+---
+## U3dSaveOptions class
+
+유니버설 3D 저장 옵션
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | U3dSaveOptions의 생성자 |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlipCoordinateSystem{#getFlipCoordinateSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFlipCoordinateSystem() | 가져오기/내보내기 중에 제어점/법선의 좌표계 반전 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlipCoordinateSystem{#setFlipCoordinateSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFlipCoordinateSystem(value) | 가져오기/내보내기 중에 제어점/법선의 좌표계 반전 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMeshCompression{#getMeshCompression}
+
+| 이름 | 설명 |
+| --- | --- |
+| getMeshCompression() | 메시 데이터 압축을 활성화할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMeshCompression{#setMeshCompression}
+
+| 이름 | 설명 |
+| --- | --- |
+| setMeshCompression(value) | 메시 데이터 압축을 활성화할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportNormals{#getExportNormals}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExportNormals() | 노멀 데이터를 내보낼지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportNormals{#setExportNormals}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExportNormals(value) | 노멀 데이터를 내보낼지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportTextureCoordinates{#getExportTextureCoordinates}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExportTextureCoordinates() | 텍스처 좌표를 내보낼지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextureCoordinates{#setExportTextureCoordinates}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExportTextureCoordinates(value) | 텍스처 좌표를 내보낼지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportVertexDiffuse{#getExportVertexDiffuse}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExportVertexDiffuse() | 버텍스의 확산 색상을 내보낼지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportVertexDiffuse{#setExportVertexDiffuse}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExportVertexDiffuse(value) | 버텍스의 확산 색상을 내보낼지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportVertexSpecular{#getExportVertexSpecular}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExportVertexSpecular() | 버텍스의 반사 색상을 내보낼지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportVertexSpecular{#setExportVertexSpecular}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExportVertexSpecular(value) | 버텍스의 반사 색상을 내보낼지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEmbedTextures{#getEmbedTextures}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEmbedTextures() | 외부 텍스처를 U3D 파일에 포함합니다. 기본값은 false입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setEmbedTextures{#setEmbedTextures}
+
+| 이름 | 설명 |
+| --- | --- |
+| setEmbedTextures(value) | 외부 텍스처를 U3D 파일에 포함합니다. 기본값은 false입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportTextures{#getExportTextures}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExportTextures() | 씬에서 사용된 텍스처를 출력 디렉터리로 복사합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextures{#setExportTextures}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExportTextures(value) | 씬에서 사용된 텍스처를 출력 디렉터리로 복사합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileFormat() | 현재 저장/로드 옵션에 지정된 파일 형식을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEncoding() | 텍스트 기반 파일에 대한 기본 인코딩을 가져오거나 설정합니다. 기본값은 null이며, 이는 가져오기/내보내기 프로그램이 사용할 인코딩을 결정함을 의미합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileSystem() | 로드/저장 중 외부 종속성을 관리하는 방법을 사용자가 처리하도록 허용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFileSystem(value) | 로드/저장 중 외부 종속성을 관리하는 방법을 사용자가 처리하도록 허용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| 이름 | 설명 |
+| --- | --- |
+| getLookupPaths() | OBJ와 같은 일부 파일은 외부 파일에 의존하며, 조회 경로를 통해 Aspose.3D가 외부 파일을 찾아 로드할 수 있도록 합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileName() | 내보내기/가져오기 씬의 파일 이름입니다. 선택 사항이지만 OBJ의 재질과 같은 외부 자산을 직렬화할 때 유용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFileName(value) | 내보내기/가져오기 씬의 파일 이름입니다. 선택 사항이지만 OBJ의 재질과 같은 외부 자산을 직렬화할 때 유용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/usdsaveoptions/_index.md
+++ b/korean/nodejs-java/aspose.threed/usdsaveoptions/_index.md
@@ -1,0 +1,237 @@
+---
+title: "UsdSaveOptions"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/usdsaveoptions/
+---
+## UsdSaveOptions class
+
+USD/USDZ 형식에 대한 저장 옵션.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | FileFormat.USD 형식으로 새로운 UsdSaveOptions를 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload(fileFormat) | 지정된 USD/USDZ 형식으로 새로운 UsdSaveOptions를 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getPrimitiveToMesh{#getPrimitiveToMesh}
+
+| 이름 | 설명 |
+| --- | --- |
+| getPrimitiveToMesh() | 내보내기 중에 기본 엔터티를 메쉬로 변환합니다. 또는 기본 엔터티를 출력 파일에 직접 인코딩합니다(비공식 기본 엔터티인 Dish, Torus 등에 대해 Aspose의 확장 정의를 사용합니다). 기본값은 true입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setPrimitiveToMesh{#setPrimitiveToMesh}
+
+| 이름 | 설명 |
+| --- | --- |
+| setPrimitiveToMesh(value) | 내보내기 중에 기본 엔터티를 메쉬로 변환합니다. 또는 기본 엔터티를 출력 파일에 직접 인코딩합니다(비공식 기본 엔터티인 Dish, Torus 등에 대해 Aspose의 확장 정의를 사용합니다). 기본값은 true입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportMetaData{#getExportMetaData}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExportMetaData() | USD의 customData 필드를 통해 노드의 속성을 내보냅니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportMetaData{#setExportMetaData}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExportMetaData(value) | USD의 customData 필드를 통해 노드의 속성을 내보냅니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMaterialConverter{#getMaterialConverter}
+
+| 이름 | 설명 |
+| --- | --- |
+| getMaterialConverter() | 기하학 재질을 PBR 재질로 변환하는 사용자 지정 변환기입니다. 이 값이 지정되지 않은 경우 USD 내보내기 프로그램은 표준 재질을 자동으로 PBR 재질로 변환합니다. 기본값은 null입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMaterialConverter{#setMaterialConverter}
+
+| 이름 | 설명 |
+| --- | --- |
+| setMaterialConverter(value) | 기하학 재질을 PBR 재질로 변환하는 사용자 지정 변환기입니다. 이 값이 지정되지 않은 경우 USD 내보내기 프로그램은 표준 재질을 자동으로 PBR 재질로 변환합니다. 기본값은 null입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportTextures{#getExportTextures}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExportTextures() | 씬에서 사용된 텍스처를 출력 디렉터리로 복사합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextures{#setExportTextures}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExportTextures(value) | 씬에서 사용된 텍스처를 출력 디렉터리로 복사합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileFormat() | 현재 저장/로드 옵션에 지정된 파일 형식을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEncoding() | 텍스트 기반 파일에 대한 기본 인코딩을 가져오거나 설정합니다. 기본값은 null이며, 이는 가져오기/내보내기 프로그램이 사용할 인코딩을 결정함을 의미합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileSystem() | 로드/저장 중 외부 종속성을 관리하는 방법을 사용자가 처리하도록 허용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFileSystem(value) | 로드/저장 중 외부 종속성을 관리하는 방법을 사용자가 처리하도록 허용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| 이름 | 설명 |
+| --- | --- |
+| getLookupPaths() | OBJ와 같은 일부 파일은 외부 파일에 의존하며, 조회 경로를 통해 Aspose.3D가 외부 파일을 찾아 로드할 수 있도록 합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileName() | 내보내기/가져오기 씬의 파일 이름입니다. 선택 사항이지만 OBJ의 재질과 같은 외부 자산을 직렬화할 때 유용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFileName(value) | 내보내기/가져오기 씬의 파일 이름입니다. 선택 사항이지만 OBJ의 재질과 같은 외부 자산을 직렬화할 때 유용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/ushape/_index.md
+++ b/korean/nodejs-java/aspose.threed/ushape/_index.md
@@ -1,0 +1,437 @@
+---
+title: "UShape"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/ushape/
+---
+## UShape class
+
+매개변수로 정의된 IFC 호환 U-형.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | UShape 생성자 |
+
+ **Result:**
+
+
+
+---
+
+
+### getDepth{#getDepth}
+
+| 이름 | 설명 |
+| --- | --- |
+| getDepth() | 웹의 길이를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDepth{#setDepth}
+
+| 이름 | 설명 |
+| --- | --- |
+| setDepth(value) | 웹의 길이를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlangeWidth{#getFlangeWidth}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFlangeWidth() | 플랜지의 길이를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlangeWidth{#setFlangeWidth}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFlangeWidth(value) | 플랜지의 길이를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getWebThickness{#getWebThickness}
+
+| 이름 | 설명 |
+| --- | --- |
+| getWebThickness() | 웹의 두께를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setWebThickness{#setWebThickness}
+
+| 이름 | 설명 |
+| --- | --- |
+| setWebThickness(value) | 웹의 두께를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlangeThickness{#getFlangeThickness}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFlangeThickness() | 플랜지의 두께를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlangeThickness{#setFlangeThickness}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFlangeThickness(value) | 플랜지의 두께를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFilletRadius{#getFilletRadius}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFilletRadius() | 플랜지와 웹 사이의 필렛 반경을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFilletRadius{#setFilletRadius}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFilletRadius(value) | 플랜지와 웹 사이의 필렛 반경을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEdgeRadius{#getEdgeRadius}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEdgeRadius() | 플랜지 가장자리의 에지 반경을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setEdgeRadius{#setEdgeRadius}
+
+| 이름 | 설명 |
+| --- | --- |
+| setEdgeRadius(value) | 플랜지 가장자리의 에지 반경을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNodes() | 모든 부모 노드를 가져옵니다. 엔터티는 기하학 인스턴싱을 위해 여러 부모 노드에 부착될 수 있습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExcluded() | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExcluded(value) | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNode() | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setParentNode(value) | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 이름 | 설명 |
+| --- | --- |
+| getScene() | 이 객체가 속한 씬을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtent{#getExtent}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExtent() | x 및 y 차원에서의 범위를 가져옵니다. |
+
+ **Result:**
+Vector2
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEntityRendererKey() | 렌더러에 등록된 엔터티 렌더러의 키를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBoundingBox() | 현재 엔터티의 객체 공간 좌표계에서 경계 상자를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/vector2/_index.md
+++ b/korean/nodejs-java/aspose.threed/vector2/_index.md
@@ -1,0 +1,293 @@
+---
+title: "Vector2"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/vector2/
+---
+## Vector2 class
+
+두 개의 구성 요소를 가진 벡터.
+
+
+## Properties
+
+| 이름 | 설명 |
+| --- | --- |
+| x | x 구성 요소. |
+| y | y 구성 요소. |
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload(s) | Vector2 구조체의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| s | 숫자 | S. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload2(vec) | Vector2 구조체의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| vec | FVector2 | float 형식의 Vector. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload3{#constructor_overload3}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload3(x, y) | Vector2 구조체의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| x | 숫자 | x 좌표. |
+| y | 숫자 | y 좌표. |
+
+ **Result:**
+
+
+
+---
+
+
+### getU{#getU}
+
+| 이름 | 설명 |
+| --- | --- |
+| getU() | Vector2가 매핑 좌표로 사용될 경우 U 구성 요소를 가져오거나 설정합니다. 이는 x 구성 요소의 별칭입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setU{#setU}
+
+| 이름 | 설명 |
+| --- | --- |
+| setU(value) | Vector2가 매핑 좌표로 사용될 경우 U 구성 요소를 가져오거나 설정합니다. 이는 x 구성 요소의 별칭입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getV{#getV}
+
+| 이름 | 설명 |
+| --- | --- |
+| getV() | Vector2가 매핑 좌표로 사용될 경우 V 구성 요소를 가져오거나 설정합니다. 이는 y 구성 요소의 별칭입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setV{#setV}
+
+| 이름 | 설명 |
+| --- | --- |
+| setV(value) | Vector2가 매핑 좌표로 사용될 경우 V 구성 요소를 가져오거나 설정합니다. 이는 y 구성 요소의 별칭입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLength{#getLength}
+
+| 이름 | 설명 |
+| --- | --- |
+| getLength() | 길이를 가져옵니다. 길이. |
+
+ **Result:**
+
+
+
+---
+
+
+### dot{#dot}
+
+| 이름 | 설명 |
+| --- | --- |
+| dot(rhs) | 두 벡터의 내적을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| rhs | Vector2 | 우변 값입니다. |
+
+ **Result:**
+숫자
+
+
+---
+
+
+### equals{#equals}
+
+| 이름 | 설명 |
+| --- | --- |
+| equals(rhs) | 두 vector2가 같은지 확인합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| rhs | Vector2 | 우변 값. |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### hashCode{#hashCode}
+
+| 이름 | 설명 |
+| --- | --- |
+| hashCode() | Vector2의 해시 코드를 가져옵니다. |
+
+ **Result:**
+숫자
+
+
+---
+
+
+### equals{#equals}
+
+| 이름 | 설명 |
+| --- | --- |
+| equals(obj) | 두 vector2가 같은지 확인합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| obj | Object | 비교할 객체. |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### toString{#toString}
+
+| 이름 | 설명 |
+| --- | --- |
+| toString() | 현재 Vector2를 나타내는 java.lang.String을 반환합니다. |
+
+ **Result:**
+String
+
+
+---
+
+
+### cross{#cross}
+
+| 이름 | 설명 |
+| --- | --- |
+| cross(v) | 두 벡터의 외적 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+|  | Vector2 | null |
+
+ **Result:**
+숫자
+
+
+---
+
+
+### normalize{#normalize}
+
+| 이름 | 설명 |
+| --- | --- |
+| normalize() | 이 인스턴스를 정규화합니다. |
+
+ **Result:**
+Vector2
+
+
+---
+
+
+### compareTo{#compareTo}
+
+| 이름 | 설명 |
+| --- | --- |
+| compareTo(other) | 현재 벡터를 다른 인스턴스와 비교합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| othe | Vector2 | null |
+
+ **Result:**
+숫자
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/vector3/_index.md
+++ b/korean/nodejs-java/aspose.threed/vector3/_index.md
@@ -1,0 +1,347 @@
+---
+title: "Vector3"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/vector3/
+---
+## Vector3 class
+
+세 개의 구성 요소를 가진 벡터.
+
+
+## Properties
+
+| 이름 | 설명 |
+| --- | --- |
+| x | x 구성 요소. |
+| y | y 구성 요소. |
+| z | z 구성 요소. |
+| ORIGIN | 원점 위치를 가져옵니다. 원점. |
+| UNIT_SCALE | 단위 스케일 벡터를 가져옵니다. |
+| X_AXIS | X 축을 가져옵니다. X 축. |
+| Y_AXIS | Y 축을 가져옵니다. Y 축. |
+| Z_AXIS | Z 축을 가져옵니다. Z 축. |
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload(x, y, z) | Vector3 구조체의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| x | 숫자 | x 좌표. |
+| y | 숫자 | y 좌표. |
+| z | 숫자 | z 좌표. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload2(vec) | Vector3 구조체의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| vec | FVector3 | x 좌표. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload3{#constructor_overload3}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload3(v) | Vector3 구조체의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| v | 숫자 | V. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload4{#constructor_overload4}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload4(vec4) | Vector3 구조체의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| vec4 | Vector4 | Vec4. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLength2{#getLength2}
+
+| 이름 | 설명 |
+| --- | --- |
+| getLength2() | 길이의 제곱을 가져옵니다. length2. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLength{#getLength}
+
+| 이름 | 설명 |
+| --- | --- |
+| getLength() | 이 벡터의 길이를 가져옵니다. 길이. |
+
+ **Result:**
+
+
+
+---
+
+
+### equals{#equals}
+
+| 이름 | 설명 |
+| --- | --- |
+| equals(obj) | 두 vector3가 같은지 확인합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| obj | Object | 동등성을 확인할 객체입니다. |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### hashCode{#hashCode}
+
+| 이름 | 설명 |
+| --- | --- |
+| hashCode() | Vector3의 해시 코드를 가져옵니다 |
+
+ **Result:**
+숫자
+
+
+---
+
+
+### dot{#dot}
+
+| 이름 | 설명 |
+| --- | --- |
+| dot(rhs) | 두 벡터의 내적을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| rhs | Vector3 | 우변 값입니다. |
+
+ **Result:**
+숫자
+
+
+---
+
+
+### normalize{#normalize}
+
+| 이름 | 설명 |
+| --- | --- |
+| normalize() | 이 인스턴스를 정규화합니다. |
+
+ **Result:**
+Vector3
+
+
+---
+
+
+### sin{#sin}
+
+| 이름 | 설명 |
+| --- | --- |
+| sin() | 각 구성 요소에 대한 사인 값을 계산합니다 |
+
+ **Result:**
+Vector3
+
+
+---
+
+
+### cos{#cos}
+
+| 이름 | 설명 |
+| --- | --- |
+| cos() | 각 구성 요소에 대한 코사인 값을 계산합니다 |
+
+ **Result:**
+Vector3
+
+
+---
+
+
+### cross{#cross}
+
+| 이름 | 설명 |
+| --- | --- |
+| cross(rhs) | 두 벡터의 외적 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| rhs | Vector3 | 우변 값입니다. |
+
+ **Result:**
+Vector3
+
+
+---
+
+
+### set{#set}
+
+| 이름 | 설명 |
+| --- | --- |
+| set(newX, newY, newZ) | 한 번의 호출로 x/y/z 구성 요소를 설정합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| newX | 숫자 | x 구성 요소. |
+| newY | 숫자 | y 구성 요소. |
+| newZ | 숫자 | z 구성 요소. |
+
+ **Result:**
+Vector3
+
+
+---
+
+
+### toString{#toString}
+
+| 이름 | 설명 |
+| --- | --- |
+| toString() | 현재 Vector3를 나타내는 java.lang.String을 반환합니다. |
+
+ **Result:**
+String
+
+
+---
+
+
+### angleBetween{#angleBetween}
+
+| 이름 | 설명 |
+| --- | --- |
+| angleBetween(dir, up) | 두 방향 사이의 내부 각도를 계산합니다. 두 방향은 정규화되지 않은 벡터일 수 있습니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| dir | Vector3 | 비교할 방향 벡터 |
+| up | Vector3 | 두 방향이 공유하는 평면의 up 벡터 |
+
+ **Result:**
+숫자
+
+
+---
+
+
+### angleBetween{#angleBetween}
+
+| 이름 | 설명 |
+| --- | --- |
+| angleBetween(dir) | 두 방향 사이의 내부 각도를 계산합니다. 두 방향은 정규화되지 않은 벡터일 수 있습니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| dir | Vector3 | 비교할 방향 벡터 |
+
+ **Result:**
+숫자
+
+
+---
+
+
+### compareTo{#compareTo}
+
+| 이름 | 설명 |
+| --- | --- |
+| compareTo(other) | 현재 벡터를 다른 인스턴스와 비교합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| othe | Vector3 | null |
+
+ **Result:**
+숫자
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/vector4/_index.md
+++ b/korean/nodejs-java/aspose.threed/vector4/_index.md
@@ -1,0 +1,246 @@
+---
+title: "Vector4"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/vector4/
+---
+## Vector4 class
+
+네 개의 구성 요소를 가진 벡터.
+
+
+## Properties
+
+| 이름 | 설명 |
+| --- | --- |
+| x | x 구성 요소. |
+| y | y 구성 요소. |
+| z | z 구성 요소. |
+| w | w 구성 요소입니다. |
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload(vec, w) | Vector4 구조체의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| vec | Vector3 | Vec. |
+| w | 숫자 | 너비. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload2(vec) | Vector4 구조체의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| vec | Vector3 | Vec. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload3{#constructor_overload3}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload3(vec) | Vector4 구조체의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| vec | FVector4 | Vec. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload4{#constructor_overload4}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload4(x, y, z) | Vector4 구조체의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| x | 숫자 | x 좌표. |
+| y | 숫자 | y 좌표. |
+| z | 숫자 | z 좌표. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload5{#constructor_overload5}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload5(x, y, z, w) | Vector4 구조체의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| x | 숫자 | x 좌표. |
+| y | 숫자 | y 좌표. |
+| z | 숫자 | z 좌표. |
+| w | 숫자 | 너비. |
+
+ **Result:**
+
+
+
+---
+
+
+### set{#set}
+
+| 이름 | 설명 |
+| --- | --- |
+| set(newX, newY, newZ) | 벡터의 xyz 구성 요소를 한 번에 설정하고, w는 1로 설정됩니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| newX | 숫자 | 새 X 구성 요소. |
+| newY | 숫자 | 새 Y 구성 요소. |
+| newZ | 숫자 | 새 Z 구성 요소. |
+
+ **Result:**
+
+
+
+---
+
+
+### equals{#equals}
+
+| 이름 | 설명 |
+| --- | --- |
+| equals(obj) | 두 벡터가 같은지 확인합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| ob | Object | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### hashCode{#hashCode}
+
+| 이름 | 설명 |
+| --- | --- |
+| hashCode() | 이 벡터의 해시 코드를 가져옵니다. |
+
+ **Result:**
+숫자
+
+
+---
+
+
+### set{#set}
+
+| 이름 | 설명 |
+| --- | --- |
+| set(newX, newY, newZ, newW) | 벡터의 모든 구성 요소를 한 번에 설정합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| newX | 숫자 | 새 X 구성 요소. |
+| newY | 숫자 | 새 Y 구성 요소. |
+| newZ | 숫자 | 새 Z 구성 요소. |
+| newW | 숫자 | 새 W 구성 요소. |
+
+ **Result:**
+숫자
+
+
+---
+
+
+### toString{#toString}
+
+| 이름 | 설명 |
+| --- | --- |
+| toString() | 현재 Vector4를 나타내는 java.lang.String을 반환합니다. |
+
+ **Result:**
+String
+
+
+---
+
+
+### compareTo{#compareTo}
+
+| 이름 | 설명 |
+| --- | --- |
+| compareTo(other) | 현재 벡터를 다른 인스턴스와 비교합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| othe | Vector4 | null |
+
+ **Result:**
+숫자
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/vertex/_index.md
+++ b/korean/nodejs-java/aspose.threed/vertex/_index.md
@@ -1,0 +1,187 @@
+---
+title: "정점"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/vertex/
+---
+## Vertex class
+
+TriMesh에서 원시 정점을 액세스하는 데 사용되는 정점 참조.  @hideconstructor
+
+
+## 메서드
+
+### compareTo{#compareTo}
+
+| 이름 | 설명 |
+| --- | --- |
+| compareTo(other) | 정점을 다른 정점 인스턴스와 비교합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| othe | 정점 | null |
+
+ **Result:**
+숫자
+
+
+---
+
+
+### readVector4{#readVector4}
+
+| 이름 | 설명 |
+| --- | --- |
+| readVector4(field) | vector4 필드를 읽습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| field | VertexField | Vector4/FVector4 데이터 타입을 가진 필드 |
+
+ **Result:**
+Vector4
+
+
+---
+
+
+### readFVector4{#readFVector4}
+
+| 이름 | 설명 |
+| --- | --- |
+| readFVector4(field) | vector4 필드를 읽습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| field | VertexField | Vector4/FVector4 데이터 타입을 가진 필드 |
+
+ **Result:**
+FVector4
+
+
+---
+
+
+### readVector3{#readVector3}
+
+| 이름 | 설명 |
+| --- | --- |
+| readVector3(field) | vector3 필드를 읽습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| field | VertexField | Vector3/FVector3 데이터 유형을 가진 필드 |
+
+ **Result:**
+Vector3
+
+
+---
+
+
+### readFVector3{#readFVector3}
+
+| 이름 | 설명 |
+| --- | --- |
+| readFVector3(field) | vector3 필드를 읽습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| field | VertexField | Vector3/FVector3 데이터 유형을 가진 필드 |
+
+ **Result:**
+FVector3
+
+
+---
+
+
+### readVector2{#readVector2}
+
+| 이름 | 설명 |
+| --- | --- |
+| readVector2(field) | vector2 필드를 읽습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| field | VertexField | Vector2/FVector2 데이터 유형을 가진 필드 |
+
+ **Result:**
+Vector2
+
+
+---
+
+
+### readFVector2{#readFVector2}
+
+| 이름 | 설명 |
+| --- | --- |
+| readFVector2(field) | vector2 필드를 읽습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| field | VertexField | Vector2/FVector2 데이터 유형을 가진 필드 |
+
+ **Result:**
+FVector2
+
+
+---
+
+
+### readDouble{#readDouble}
+
+| 이름 | 설명 |
+| --- | --- |
+| readDouble(field) | double 필드를 읽습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| field | VertexField | float/double 호환 데이터 유형을 가진 필드 |
+
+ **Result:**
+숫자
+
+
+---
+
+
+### readFloat{#readFloat}
+
+| 이름 | 설명 |
+| --- | --- |
+| readFloat(field) | float 필드를 읽습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| field | VertexField | float/double 호환 데이터 유형을 가진 필드 |
+
+ **Result:**
+숫자
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/vertexdeclaration/_index.md
+++ b/korean/nodejs-java/aspose.threed/vertexdeclaration/_index.md
@@ -1,0 +1,201 @@
+---
+title: "VertexDeclaration"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/vertexdeclaration/
+---
+## VertexDeclaration class
+
+사용자 정의 정점 구조의 선언
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getSealed{#getSealed}
+
+| 이름 | 설명 |
+| --- | --- |
+| getSealed() | VertexDeclaration은 com.aspose.threed.TriMesh`1 또는 TriMesh에 사용된 경우 봉인되며, 더 이상 수정할 수 없습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getCount{#getCount}
+
+| 이름 | 설명 |
+| --- | --- |
+| getCount() | 이 VertexDeclaration에 정의된 모든 필드의 개수를 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getSize{#getSize}
+
+| 이름 | 설명 |
+| --- | --- |
+| getSize() | 버텍스 구조의 바이트 단위 크기입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### get{#get}
+
+| 이름 | 설명 |
+| --- | --- |
+| get(index) |  |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| 이름 | 설명 |
+| --- | --- |
+| clear() | 모든 필드를 지웁니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### addField{#addField}
+
+| 이름 | 설명 |
+| --- | --- |
+| addField(dataType, semantic, index, alias) | 새 버텍스 필드를 추가합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| dataType | 숫자 | VertexFieldDataType |
+| semantic | VertexFieldSemantic | VertexFieldSemantic |
+| 인덱스 | 숫자 | 동일 필드 의미에 대한 인덱스이며, -1은 자동 생성입니다. |
+| alias | String | 필드의 별칭 이름 |
+
+ **Result:**
+
+
+
+---
+
+
+### fromGeometry{#fromGeometry}
+
+| 이름 | 설명 |
+| --- | --- |
+| fromGeometry(geometry, useFloat) | Geometry 레이아웃을 기반으로 VertexDeclaration을 생성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| geometr | Geometry | null |
+| useFloat | boolean | double 타입 대신 float를 사용합니다. |
+
+ **Result:**
+VertexDeclaration
+
+
+---
+
+
+### compareTo{#compareTo}
+
+| 이름 | 설명 |
+| --- | --- |
+| compareTo(other) | 이 인스턴스를 지정된 객체와 비교하고 그 상대값에 대한 표시를 반환합니다. |
+
+ **Result:**
+VertexDeclaration
+
+
+---
+
+
+### toString{#toString}
+
+| 이름 | 설명 |
+| --- | --- |
+| toString() |  |
+
+ **Result:**
+String
+
+
+---
+
+
+### hashCode{#hashCode}
+
+| 이름 | 설명 |
+| --- | --- |
+| hashCode() |  |
+
+ **Result:**
+숫자
+
+
+---
+
+
+### equals{#equals}
+
+| 이름 | 설명 |
+| --- | --- |
+| equals(obj) | 이 인스턴스와 지정된 객체(또한 VertexDeclaration 객체여야 함)가 동일한 값을 갖는지 여부를 결정합니다. |
+
+ **Result:**
+숫자
+
+
+---
+
+
+### iterator{#iterator}
+
+| 이름 | 설명 |
+| --- | --- |
+| iterator() | 내부 사용을 위해 예약되었습니다. |
+
+ **Result:**
+숫자
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/vertexelement/_index.md
+++ b/korean/nodejs-java/aspose.threed/vertexelement/_index.md
@@ -1,0 +1,165 @@
+---
+title: "VertexElement"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/vertexelement/
+---
+## VertexElement class
+
+정점 요소의 기본 클래스.  정점 요소 유형은 VertexElementType으로 식별됩니다.  VertexElement는 정점 요소가 기하학 표면에 어떻게 매핑되는지와 매핑 정보가 메모리에 어떻게 배치되는지를 설명합니다.  VertexElement는 Normals, UVs 또는 기타 종류의 정보를 포함합니다.  @hideconstructor
+
+
+## 메서드
+
+### getVertexElementType{#getVertexElementType}
+
+| 이름 | 설명 |
+| --- | --- |
+| getVertexElementType() | VertexElement의 유형을 가져옵니다. 속성 값은 VertexElementType 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getMappingMode() | 요소가 매핑되는 방식을 가져오거나 설정합니다. 속성 값은 MappingMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setMappingMode(value) | 요소가 매핑되는 방식을 가져오거나 설정합니다. 속성 값은 MappingMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getReferenceMode() | 요소가 참조되는 방식을 가져오거나 설정합니다. 속성 값은 ReferenceMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setReferenceMode(value) | 요소가 참조되는 방식을 가져오거나 설정합니다. 속성 값은 ReferenceMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| 이름 | 설명 |
+| --- | --- |
+| getIndices() | 인덱스 데이터를 가져옵니다. 인덱스 배열. |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| 이름 | 설명 |
+| --- | --- |
+| setIndices(data) | 인덱스 로드 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 데이터 | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| 이름 | 설명 |
+| --- | --- |
+| clear() | 이 정점 요소의 모든 데이터를 지웁니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| 이름 | 설명 |
+| --- | --- |
+| toString() | 버텍스 요소의 문자열 표현. |
+
+ **Result:**
+String
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/vertexelementbinormal/_index.md
+++ b/korean/nodejs-java/aspose.threed/vertexelementbinormal/_index.md
@@ -1,0 +1,229 @@
+---
+title: "VertexElementBinormal"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/vertexelementbinormal/
+---
+## VertexElementBinormal class
+
+지정된 구성 요소에 대한 이중법선 벡터를 정의합니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | VertexElementBinormal 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getData{#getData}
+
+| 이름 | 설명 |
+| --- | --- |
+| getData() | 버텍스 데이터를 가져옵니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| 이름 | 설명 |
+| --- | --- |
+| getVertexElementType() | VertexElement의 유형을 가져옵니다. 속성 값은 VertexElementType 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getMappingMode() | 요소가 매핑되는 방식을 가져오거나 설정합니다. 속성 값은 MappingMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setMappingMode(value) | 요소가 매핑되는 방식을 가져오거나 설정합니다. 속성 값은 MappingMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getReferenceMode() | 요소가 참조되는 방식을 가져오거나 설정합니다. 속성 값은 ReferenceMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setReferenceMode(value) | 요소가 참조되는 방식을 가져오거나 설정합니다. 속성 값은 ReferenceMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| 이름 | 설명 |
+| --- | --- |
+| getIndices() | 인덱스 데이터를 가져옵니다. 인덱스 배열. |
+
+ **Result:**
+
+
+
+---
+
+
+### copyTo{#copyTo}
+
+| 이름 | 설명 |
+| --- | --- |
+| copyTo(target) | 지정된 요소에 데이터를 복사합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 대상 | VertexElementVector4 | 대상. |
+
+ **Result:**
+
+
+
+---
+
+
+### setData{#setData}
+
+| 이름 | 설명 |
+| --- | --- |
+| setData(data) | 데이터 로드 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 데이터 | Vector4[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| 이름 | 설명 |
+| --- | --- |
+| clear() | 직접 배열과 인덱스 배열에서 모든 요소를 제거합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| 이름 | 설명 |
+| --- | --- |
+| setIndices(data) | 인덱스 로드 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 데이터 | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| 이름 | 설명 |
+| --- | --- |
+| toString() | 버텍스 요소의 문자열 표현. |
+
+ **Result:**
+String
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/vertexelementdoublestemplate/_index.md
+++ b/korean/nodejs-java/aspose.threed/vertexelementdoublestemplate/_index.md
@@ -1,0 +1,216 @@
+---
+title: "VertexElementDoublesTemplate"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/vertexelementdoublestemplate/
+---
+## VertexElementDoublesTemplate class
+
+구체적인 VertexElement 구현을 정의하기 위한 도우미 클래스.  @hideconstructor
+
+
+## 메서드
+
+### getData{#getData}
+
+| 이름 | 설명 |
+| --- | --- |
+| getData() | 버텍스 데이터를 가져옵니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| 이름 | 설명 |
+| --- | --- |
+| getVertexElementType() | VertexElement의 유형을 가져옵니다. 속성 값은 VertexElementType 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getMappingMode() | 요소가 매핑되는 방식을 가져오거나 설정합니다. 속성 값은 MappingMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setMappingMode(value) | 요소가 매핑되는 방식을 가져오거나 설정합니다. 속성 값은 MappingMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getReferenceMode() | 요소가 참조되는 방식을 가져오거나 설정합니다. 속성 값은 ReferenceMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setReferenceMode(value) | 요소가 참조되는 방식을 가져오거나 설정합니다. 속성 값은 ReferenceMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| 이름 | 설명 |
+| --- | --- |
+| getIndices() | 인덱스 데이터를 가져옵니다. 인덱스 배열. |
+
+ **Result:**
+
+
+
+---
+
+
+### copyTo{#copyTo}
+
+| 이름 | 설명 |
+| --- | --- |
+| copyTo(target) | 지정된 요소에 데이터를 복사합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 대상 | VertexElementDoublesTemplate | 대상. |
+
+ **Result:**
+
+
+
+---
+
+
+### setData{#setData}
+
+| 이름 | 설명 |
+| --- | --- |
+| setData(data) | 데이터 로드 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 데이터 | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| 이름 | 설명 |
+| --- | --- |
+| clear() | 직접 배열과 인덱스 배열에서 모든 요소를 제거합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| 이름 | 설명 |
+| --- | --- |
+| setIndices(data) | 인덱스 로드 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 데이터 | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| 이름 | 설명 |
+| --- | --- |
+| toString() | 버텍스 요소의 문자열 표현. |
+
+ **Result:**
+String
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/vertexelementedgecrease/_index.md
+++ b/korean/nodejs-java/aspose.threed/vertexelementedgecrease/_index.md
@@ -1,0 +1,229 @@
+---
+title: "VertexElementEdgeCrease"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/vertexelementedgecrease/
+---
+## VertexElementEdgeCrease class
+
+지정된 구성 요소에 대한 에지 크리스를 정의합니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | VertexElementEdgeCrease 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getData{#getData}
+
+| 이름 | 설명 |
+| --- | --- |
+| getData() | 버텍스 데이터를 가져옵니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| 이름 | 설명 |
+| --- | --- |
+| getVertexElementType() | VertexElement의 유형을 가져옵니다. 속성 값은 VertexElementType 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getMappingMode() | 요소가 매핑되는 방식을 가져오거나 설정합니다. 속성 값은 MappingMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setMappingMode(value) | 요소가 매핑되는 방식을 가져오거나 설정합니다. 속성 값은 MappingMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getReferenceMode() | 요소가 참조되는 방식을 가져오거나 설정합니다. 속성 값은 ReferenceMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setReferenceMode(value) | 요소가 참조되는 방식을 가져오거나 설정합니다. 속성 값은 ReferenceMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| 이름 | 설명 |
+| --- | --- |
+| getIndices() | 인덱스 데이터를 가져옵니다. 인덱스 배열. |
+
+ **Result:**
+
+
+
+---
+
+
+### copyTo{#copyTo}
+
+| 이름 | 설명 |
+| --- | --- |
+| copyTo(target) | 지정된 요소에 데이터를 복사합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 대상 | VertexElementDoublesTemplate | 대상. |
+
+ **Result:**
+
+
+
+---
+
+
+### setData{#setData}
+
+| 이름 | 설명 |
+| --- | --- |
+| setData(data) | 데이터 로드 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 데이터 | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| 이름 | 설명 |
+| --- | --- |
+| clear() | 직접 배열과 인덱스 배열에서 모든 요소를 제거합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| 이름 | 설명 |
+| --- | --- |
+| setIndices(data) | 인덱스 로드 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 데이터 | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| 이름 | 설명 |
+| --- | --- |
+| toString() | 버텍스 요소의 문자열 표현. |
+
+ **Result:**
+String
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/vertexelementhole/_index.md
+++ b/korean/nodejs-java/aspose.threed/vertexelementhole/_index.md
@@ -1,0 +1,191 @@
+---
+title: "VertexElementHole"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/vertexelementhole/
+---
+## VertexElementHole class
+
+지정된 폴리곤이 구멍인지 여부를 정의합니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | VertexElementHole 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getData{#getData}
+
+| 이름 | 설명 |
+| --- | --- |
+| getData() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| 이름 | 설명 |
+| --- | --- |
+| getVertexElementType() | VertexElement의 유형을 가져옵니다. 속성 값은 VertexElementType 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getMappingMode() | 요소가 매핑되는 방식을 가져오거나 설정합니다. 속성 값은 MappingMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setMappingMode(value) | 요소가 매핑되는 방식을 가져오거나 설정합니다. 속성 값은 MappingMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getReferenceMode() | 요소가 참조되는 방식을 가져오거나 설정합니다. 속성 값은 ReferenceMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setReferenceMode(value) | 요소가 참조되는 방식을 가져오거나 설정합니다. 속성 값은 ReferenceMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| 이름 | 설명 |
+| --- | --- |
+| getIndices() | 인덱스 데이터를 가져옵니다. 인덱스 배열. |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| 이름 | 설명 |
+| --- | --- |
+| clear() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| 이름 | 설명 |
+| --- | --- |
+| setIndices(data) | 인덱스 로드 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 데이터 | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| 이름 | 설명 |
+| --- | --- |
+| toString() | 버텍스 요소의 문자열 표현. |
+
+ **Result:**
+String
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/vertexelementintstemplate/_index.md
+++ b/korean/nodejs-java/aspose.threed/vertexelementintstemplate/_index.md
@@ -1,0 +1,216 @@
+---
+title: "VertexElementIntsTemplate"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/vertexelementintstemplate/
+---
+## VertexElementIntsTemplate class
+
+구체적인 VertexElement 구현을 정의하기 위한 도우미 클래스.  @hideconstructor
+
+
+## 메서드
+
+### getData{#getData}
+
+| 이름 | 설명 |
+| --- | --- |
+| getData() | 버텍스 데이터를 가져옵니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| 이름 | 설명 |
+| --- | --- |
+| getVertexElementType() | VertexElement의 유형을 가져옵니다. 속성 값은 VertexElementType 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getMappingMode() | 요소가 매핑되는 방식을 가져오거나 설정합니다. 속성 값은 MappingMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setMappingMode(value) | 요소가 매핑되는 방식을 가져오거나 설정합니다. 속성 값은 MappingMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getReferenceMode() | 요소가 참조되는 방식을 가져오거나 설정합니다. 속성 값은 ReferenceMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setReferenceMode(value) | 요소가 참조되는 방식을 가져오거나 설정합니다. 속성 값은 ReferenceMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| 이름 | 설명 |
+| --- | --- |
+| getIndices() | 인덱스 데이터를 가져옵니다. 인덱스 배열. |
+
+ **Result:**
+
+
+
+---
+
+
+### copyTo{#copyTo}
+
+| 이름 | 설명 |
+| --- | --- |
+| copyTo(target) | 지정된 요소에 데이터를 복사합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 대상 | VertexElementIntsTemplate | 대상. |
+
+ **Result:**
+
+
+
+---
+
+
+### setData{#setData}
+
+| 이름 | 설명 |
+| --- | --- |
+| setData(data) | 데이터 로드 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 데이터 | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| 이름 | 설명 |
+| --- | --- |
+| clear() | 직접 배열과 인덱스 배열에서 모든 요소를 제거합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| 이름 | 설명 |
+| --- | --- |
+| setIndices(data) | 인덱스 로드 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 데이터 | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| 이름 | 설명 |
+| --- | --- |
+| toString() | 버텍스 요소의 문자열 표현. |
+
+ **Result:**
+String
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/vertexelementmaterial/_index.md
+++ b/korean/nodejs-java/aspose.threed/vertexelementmaterial/_index.md
@@ -1,0 +1,178 @@
+---
+title: "VertexElementMaterial"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/vertexelementmaterial/
+---
+## VertexElementMaterial class
+
+지정된 구성 요소에 대한 재질 인덱스를 정의합니다.  노드는 여러 재질을 가질 수 있으며, VertexElementMaterial은 기하학의 다른 부분을 서로 다른 재질로 렌더링하는 데 사용됩니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | VertexElementMaterial 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| 이름 | 설명 |
+| --- | --- |
+| getVertexElementType() | VertexElement의 유형을 가져옵니다. 속성 값은 VertexElementType 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getMappingMode() | 요소가 매핑되는 방식을 가져오거나 설정합니다. 속성 값은 MappingMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setMappingMode(value) | 요소가 매핑되는 방식을 가져오거나 설정합니다. 속성 값은 MappingMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getReferenceMode() | 요소가 참조되는 방식을 가져오거나 설정합니다. 속성 값은 ReferenceMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setReferenceMode(value) | 요소가 참조되는 방식을 가져오거나 설정합니다. 속성 값은 ReferenceMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| 이름 | 설명 |
+| --- | --- |
+| getIndices() | 인덱스 데이터를 가져옵니다. 인덱스 배열. |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| 이름 | 설명 |
+| --- | --- |
+| clear() | 직접 배열과 인덱스 배열에서 모든 요소를 제거합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| 이름 | 설명 |
+| --- | --- |
+| setIndices(data) | 인덱스 로드 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 데이터 | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| 이름 | 설명 |
+| --- | --- |
+| toString() | 버텍스 요소의 문자열 표현. |
+
+ **Result:**
+String
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/vertexelementnormal/_index.md
+++ b/korean/nodejs-java/aspose.threed/vertexelementnormal/_index.md
@@ -1,0 +1,229 @@
+---
+title: "VertexElementNormal"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/vertexelementnormal/
+---
+## VertexElementNormal class
+
+지정된 구성 요소에 대한 법선 벡터를 정의합니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | VertexElementNormal 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getData{#getData}
+
+| 이름 | 설명 |
+| --- | --- |
+| getData() | 버텍스 데이터를 가져옵니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| 이름 | 설명 |
+| --- | --- |
+| getVertexElementType() | VertexElement의 유형을 가져옵니다. 속성 값은 VertexElementType 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getMappingMode() | 요소가 매핑되는 방식을 가져오거나 설정합니다. 속성 값은 MappingMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setMappingMode(value) | 요소가 매핑되는 방식을 가져오거나 설정합니다. 속성 값은 MappingMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getReferenceMode() | 요소가 참조되는 방식을 가져오거나 설정합니다. 속성 값은 ReferenceMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setReferenceMode(value) | 요소가 참조되는 방식을 가져오거나 설정합니다. 속성 값은 ReferenceMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| 이름 | 설명 |
+| --- | --- |
+| getIndices() | 인덱스 데이터를 가져옵니다. 인덱스 배열. |
+
+ **Result:**
+
+
+
+---
+
+
+### copyTo{#copyTo}
+
+| 이름 | 설명 |
+| --- | --- |
+| copyTo(target) | 지정된 요소에 데이터를 복사합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 대상 | VertexElementVector4 | 대상. |
+
+ **Result:**
+
+
+
+---
+
+
+### setData{#setData}
+
+| 이름 | 설명 |
+| --- | --- |
+| setData(data) | 데이터 로드 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 데이터 | Vector4[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| 이름 | 설명 |
+| --- | --- |
+| clear() | 직접 배열과 인덱스 배열에서 모든 요소를 제거합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| 이름 | 설명 |
+| --- | --- |
+| setIndices(data) | 인덱스 로드 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 데이터 | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| 이름 | 설명 |
+| --- | --- |
+| toString() | 버텍스 요소의 문자열 표현. |
+
+ **Result:**
+String
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/vertexelementpolygongroup/_index.md
+++ b/korean/nodejs-java/aspose.threed/vertexelementpolygongroup/_index.md
@@ -1,0 +1,229 @@
+---
+title: "VertexElementPolygonGroup"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/vertexelementpolygongroup/
+---
+## VertexElementPolygonGroup class
+
+관련 폴리곤을 함께 묶기 위해 지정된 구성 요소에 대한 폴리곤 그룹을 정의합니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | VertexElementPolygonGroup 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getData{#getData}
+
+| 이름 | 설명 |
+| --- | --- |
+| getData() | 버텍스 데이터를 가져옵니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| 이름 | 설명 |
+| --- | --- |
+| getVertexElementType() | VertexElement의 유형을 가져옵니다. 속성 값은 VertexElementType 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getMappingMode() | 요소가 매핑되는 방식을 가져오거나 설정합니다. 속성 값은 MappingMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setMappingMode(value) | 요소가 매핑되는 방식을 가져오거나 설정합니다. 속성 값은 MappingMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getReferenceMode() | 요소가 참조되는 방식을 가져오거나 설정합니다. 속성 값은 ReferenceMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setReferenceMode(value) | 요소가 참조되는 방식을 가져오거나 설정합니다. 속성 값은 ReferenceMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| 이름 | 설명 |
+| --- | --- |
+| getIndices() | 인덱스 데이터를 가져옵니다. 인덱스 배열. |
+
+ **Result:**
+
+
+
+---
+
+
+### copyTo{#copyTo}
+
+| 이름 | 설명 |
+| --- | --- |
+| copyTo(target) | 지정된 요소에 데이터를 복사합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 대상 | VertexElementIntsTemplate | 대상. |
+
+ **Result:**
+
+
+
+---
+
+
+### setData{#setData}
+
+| 이름 | 설명 |
+| --- | --- |
+| setData(data) | 데이터 로드 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 데이터 | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| 이름 | 설명 |
+| --- | --- |
+| clear() | 직접 배열과 인덱스 배열에서 모든 요소를 제거합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| 이름 | 설명 |
+| --- | --- |
+| setIndices(data) | 인덱스 로드 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 데이터 | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| 이름 | 설명 |
+| --- | --- |
+| toString() | 버텍스 요소의 문자열 표현. |
+
+ **Result:**
+String
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/vertexelementsmoothinggroup/_index.md
+++ b/korean/nodejs-java/aspose.threed/vertexelementsmoothinggroup/_index.md
@@ -1,0 +1,229 @@
+---
+title: "VertexElementSmoothingGroup"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/vertexelementsmoothinggroup/
+---
+## VertexElementSmoothingGroup class
+
+스무딩 그룹은 매끄러운 표면을 형성하는 것처럼 보이는 폴리곤 메시의 폴리곤 그룹입니다.  DOS용 3D Studio Max와 같은 초기 3D 모델링 소프트웨어는 각 메시 정점에 대한 법선 벡터 저장을 피하기 위해 스무딩 그룹을 사용했습니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | VertexElementSmoothingGroup 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getData{#getData}
+
+| 이름 | 설명 |
+| --- | --- |
+| getData() | 버텍스 데이터를 가져옵니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| 이름 | 설명 |
+| --- | --- |
+| getVertexElementType() | VertexElement의 유형을 가져옵니다. 속성 값은 VertexElementType 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getMappingMode() | 요소가 매핑되는 방식을 가져오거나 설정합니다. 속성 값은 MappingMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setMappingMode(value) | 요소가 매핑되는 방식을 가져오거나 설정합니다. 속성 값은 MappingMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getReferenceMode() | 요소가 참조되는 방식을 가져오거나 설정합니다. 속성 값은 ReferenceMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setReferenceMode(value) | 요소가 참조되는 방식을 가져오거나 설정합니다. 속성 값은 ReferenceMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| 이름 | 설명 |
+| --- | --- |
+| getIndices() | 인덱스 데이터를 가져옵니다. 인덱스 배열. |
+
+ **Result:**
+
+
+
+---
+
+
+### copyTo{#copyTo}
+
+| 이름 | 설명 |
+| --- | --- |
+| copyTo(target) | 지정된 요소에 데이터를 복사합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 대상 | VertexElementIntsTemplate | 대상. |
+
+ **Result:**
+
+
+
+---
+
+
+### setData{#setData}
+
+| 이름 | 설명 |
+| --- | --- |
+| setData(data) | 데이터 로드 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 데이터 | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| 이름 | 설명 |
+| --- | --- |
+| clear() | 직접 배열과 인덱스 배열에서 모든 요소를 제거합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| 이름 | 설명 |
+| --- | --- |
+| setIndices(data) | 인덱스 로드 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 데이터 | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| 이름 | 설명 |
+| --- | --- |
+| toString() | 버텍스 요소의 문자열 표현. |
+
+ **Result:**
+String
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/vertexelementspecular/_index.md
+++ b/korean/nodejs-java/aspose.threed/vertexelementspecular/_index.md
@@ -1,0 +1,229 @@
+---
+title: "VertexElementSpecular"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/vertexelementspecular/
+---
+## VertexElementSpecular class
+
+지정된 구성 요소에 대한 반사광 색상을 정의합니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | VertexElementSpecular 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getData{#getData}
+
+| 이름 | 설명 |
+| --- | --- |
+| getData() | 버텍스 데이터를 가져옵니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| 이름 | 설명 |
+| --- | --- |
+| getVertexElementType() | VertexElement의 유형을 가져옵니다. 속성 값은 VertexElementType 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getMappingMode() | 요소가 매핑되는 방식을 가져오거나 설정합니다. 속성 값은 MappingMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setMappingMode(value) | 요소가 매핑되는 방식을 가져오거나 설정합니다. 속성 값은 MappingMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getReferenceMode() | 요소가 참조되는 방식을 가져오거나 설정합니다. 속성 값은 ReferenceMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setReferenceMode(value) | 요소가 참조되는 방식을 가져오거나 설정합니다. 속성 값은 ReferenceMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| 이름 | 설명 |
+| --- | --- |
+| getIndices() | 인덱스 데이터를 가져옵니다. 인덱스 배열. |
+
+ **Result:**
+
+
+
+---
+
+
+### copyTo{#copyTo}
+
+| 이름 | 설명 |
+| --- | --- |
+| copyTo(target) | 지정된 요소에 데이터를 복사합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 대상 | VertexElementVector4 | 대상. |
+
+ **Result:**
+
+
+
+---
+
+
+### setData{#setData}
+
+| 이름 | 설명 |
+| --- | --- |
+| setData(data) | 데이터 로드 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 데이터 | Vector4[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| 이름 | 설명 |
+| --- | --- |
+| clear() | 직접 배열과 인덱스 배열에서 모든 요소를 제거합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| 이름 | 설명 |
+| --- | --- |
+| setIndices(data) | 인덱스 로드 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 데이터 | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| 이름 | 설명 |
+| --- | --- |
+| toString() | 버텍스 요소의 문자열 표현. |
+
+ **Result:**
+String
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/vertexelementtangent/_index.md
+++ b/korean/nodejs-java/aspose.threed/vertexelementtangent/_index.md
@@ -1,0 +1,229 @@
+---
+title: "VertexElementTangent"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/vertexelementtangent/
+---
+## VertexElementTangent class
+
+지정된 구성 요소에 대한 접선 벡터를 정의합니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | VertexElementTangent 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getData{#getData}
+
+| 이름 | 설명 |
+| --- | --- |
+| getData() | 버텍스 데이터를 가져옵니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| 이름 | 설명 |
+| --- | --- |
+| getVertexElementType() | VertexElement의 유형을 가져옵니다. 속성 값은 VertexElementType 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getMappingMode() | 요소가 매핑되는 방식을 가져오거나 설정합니다. 속성 값은 MappingMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setMappingMode(value) | 요소가 매핑되는 방식을 가져오거나 설정합니다. 속성 값은 MappingMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getReferenceMode() | 요소가 참조되는 방식을 가져오거나 설정합니다. 속성 값은 ReferenceMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setReferenceMode(value) | 요소가 참조되는 방식을 가져오거나 설정합니다. 속성 값은 ReferenceMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| 이름 | 설명 |
+| --- | --- |
+| getIndices() | 인덱스 데이터를 가져옵니다. 인덱스 배열. |
+
+ **Result:**
+
+
+
+---
+
+
+### copyTo{#copyTo}
+
+| 이름 | 설명 |
+| --- | --- |
+| copyTo(target) | 지정된 요소에 데이터를 복사합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 대상 | VertexElementVector4 | 대상. |
+
+ **Result:**
+
+
+
+---
+
+
+### setData{#setData}
+
+| 이름 | 설명 |
+| --- | --- |
+| setData(data) | 데이터 로드 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 데이터 | Vector4[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| 이름 | 설명 |
+| --- | --- |
+| clear() | 직접 배열과 인덱스 배열에서 모든 요소를 제거합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| 이름 | 설명 |
+| --- | --- |
+| setIndices(data) | 인덱스 로드 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 데이터 | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| 이름 | 설명 |
+| --- | --- |
+| toString() | 버텍스 요소의 문자열 표현. |
+
+ **Result:**
+String
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/vertexelementuserdata/_index.md
+++ b/korean/nodejs-java/aspose.threed/vertexelementuserdata/_index.md
@@ -1,0 +1,204 @@
+---
+title: "VertexElementUserData"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/vertexelementuserdata/
+---
+## VertexElementUserData class
+
+지정된 구성 요소에 대한 사용자 정의 데이터를 정의합니다.  일반적으로 이는 특수 목적을 위한 애플리케이션 전용 데이터입니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | VertexElementUserData 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getData{#getData}
+
+| 이름 | 설명 |
+| --- | --- |
+| getData() | 이 요소에 첨부된 사용자 데이터 |
+
+ **Result:**
+
+
+
+---
+
+
+### setData{#setData}
+
+| 이름 | 설명 |
+| --- | --- |
+| setData(value) | 이 요소에 첨부된 사용자 데이터 |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| 이름 | 설명 |
+| --- | --- |
+| getVertexElementType() | VertexElement의 유형을 가져옵니다. 속성 값은 VertexElementType 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getMappingMode() | 요소가 매핑되는 방식을 가져오거나 설정합니다. 속성 값은 MappingMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setMappingMode(value) | 요소가 매핑되는 방식을 가져오거나 설정합니다. 속성 값은 MappingMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getReferenceMode() | 요소가 참조되는 방식을 가져오거나 설정합니다. 속성 값은 ReferenceMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setReferenceMode(value) | 요소가 참조되는 방식을 가져오거나 설정합니다. 속성 값은 ReferenceMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| 이름 | 설명 |
+| --- | --- |
+| getIndices() | 인덱스 데이터를 가져옵니다. 인덱스 배열. |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| 이름 | 설명 |
+| --- | --- |
+| clear() | 이 정점 요소의 모든 데이터를 지웁니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| 이름 | 설명 |
+| --- | --- |
+| setIndices(data) | 인덱스 로드 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 데이터 | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| 이름 | 설명 |
+| --- | --- |
+| toString() | 버텍스 요소의 문자열 표현. |
+
+ **Result:**
+String
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/vertexelementuv/_index.md
+++ b/korean/nodejs-java/aspose.threed/vertexelementuv/_index.md
@@ -1,0 +1,248 @@
+---
+title: "VertexElementUV"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/vertexelementuv/
+---
+## VertexElementUV class
+
+지정된 구성 요소에 대한 UV 좌표를 정의합니다.  기하학은 여러 VertexElementUV 요소를 가질 수 있으며, 각 요소는 서로 다른 TextureMappings를 가집니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | VertexElementUV 클래스의 새 인스턴스를 초기화합니다. 기본 텍스처 매핑 유형은 TextureMapping.DIFFUSE입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor_overload(textureMapping) | VertexElementUV 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| textureMapping | TextureMapping | TextureMapping |
+
+ **Result:**
+
+
+
+---
+
+
+### getData{#getData}
+
+| 이름 | 설명 |
+| --- | --- |
+| getData() | 버텍스 데이터를 가져옵니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| 이름 | 설명 |
+| --- | --- |
+| getVertexElementType() | VertexElement의 유형을 가져옵니다. 속성 값은 VertexElementType 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getMappingMode() | 요소가 매핑되는 방식을 가져오거나 설정합니다. 속성 값은 MappingMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setMappingMode(value) | 요소가 매핑되는 방식을 가져오거나 설정합니다. 속성 값은 MappingMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getReferenceMode() | 요소가 참조되는 방식을 가져오거나 설정합니다. 속성 값은 ReferenceMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setReferenceMode(value) | 요소가 참조되는 방식을 가져오거나 설정합니다. 속성 값은 ReferenceMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| 이름 | 설명 |
+| --- | --- |
+| getIndices() | 인덱스 데이터를 가져옵니다. 인덱스 배열. |
+
+ **Result:**
+
+
+
+---
+
+
+### copyTo{#copyTo}
+
+| 이름 | 설명 |
+| --- | --- |
+| copyTo(target) | 지정된 요소에 데이터를 복사합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 대상 | VertexElementVector4 | 대상. |
+
+ **Result:**
+
+
+
+---
+
+
+### setData{#setData}
+
+| 이름 | 설명 |
+| --- | --- |
+| setData(data) | 데이터 로드 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 데이터 | Vector4[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| 이름 | 설명 |
+| --- | --- |
+| clear() | 직접 배열과 인덱스 배열에서 모든 요소를 제거합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| 이름 | 설명 |
+| --- | --- |
+| setIndices(data) | 인덱스 로드 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 데이터 | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| 이름 | 설명 |
+| --- | --- |
+| toString() | 버텍스 요소의 문자열 표현. |
+
+ **Result:**
+String
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/vertexelementvector4/_index.md
+++ b/korean/nodejs-java/aspose.threed/vertexelementvector4/_index.md
@@ -1,0 +1,216 @@
+---
+title: "VertexElementVector4"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/vertexelementvector4/
+---
+## VertexElementVector4 class
+
+구체적인 VertexElement 구현을 정의하기 위한 도우미 클래스.  @hideconstructor
+
+
+## 메서드
+
+### getData{#getData}
+
+| 이름 | 설명 |
+| --- | --- |
+| getData() | 버텍스 데이터를 가져옵니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| 이름 | 설명 |
+| --- | --- |
+| getVertexElementType() | VertexElement의 유형을 가져옵니다. 속성 값은 VertexElementType 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getMappingMode() | 요소가 매핑되는 방식을 가져오거나 설정합니다. 속성 값은 MappingMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setMappingMode(value) | 요소가 매핑되는 방식을 가져오거나 설정합니다. 속성 값은 MappingMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getReferenceMode() | 요소가 참조되는 방식을 가져오거나 설정합니다. 속성 값은 ReferenceMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setReferenceMode(value) | 요소가 참조되는 방식을 가져오거나 설정합니다. 속성 값은 ReferenceMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| 이름 | 설명 |
+| --- | --- |
+| getIndices() | 인덱스 데이터를 가져옵니다. 인덱스 배열. |
+
+ **Result:**
+
+
+
+---
+
+
+### copyTo{#copyTo}
+
+| 이름 | 설명 |
+| --- | --- |
+| copyTo(target) | 지정된 요소에 데이터를 복사합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 대상 | VertexElementVector4 | 대상. |
+
+ **Result:**
+
+
+
+---
+
+
+### setData{#setData}
+
+| 이름 | 설명 |
+| --- | --- |
+| setData(data) | 데이터 로드 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 데이터 | Vector4[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| 이름 | 설명 |
+| --- | --- |
+| clear() | 직접 배열과 인덱스 배열에서 모든 요소를 제거합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| 이름 | 설명 |
+| --- | --- |
+| setIndices(data) | 인덱스 로드 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 데이터 | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| 이름 | 설명 |
+| --- | --- |
+| toString() | 버텍스 요소의 문자열 표현. |
+
+ **Result:**
+String
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/vertexelementvertexcolor/_index.md
+++ b/korean/nodejs-java/aspose.threed/vertexelementvertexcolor/_index.md
@@ -1,0 +1,229 @@
+---
+title: "VertexElementVertexColor"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/vertexelementvertexcolor/
+---
+## VertexElementVertexColor class
+
+지정된 구성 요소에 대한 정점 색상을 정의합니다
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | VertexElementVertexColor 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getData{#getData}
+
+| 이름 | 설명 |
+| --- | --- |
+| getData() | 버텍스 데이터를 가져옵니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| 이름 | 설명 |
+| --- | --- |
+| getVertexElementType() | VertexElement의 유형을 가져옵니다. 속성 값은 VertexElementType 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getMappingMode() | 요소가 매핑되는 방식을 가져오거나 설정합니다. 속성 값은 MappingMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setMappingMode(value) | 요소가 매핑되는 방식을 가져오거나 설정합니다. 속성 값은 MappingMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getReferenceMode() | 요소가 참조되는 방식을 가져오거나 설정합니다. 속성 값은 ReferenceMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setReferenceMode(value) | 요소가 참조되는 방식을 가져오거나 설정합니다. 속성 값은 ReferenceMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| 이름 | 설명 |
+| --- | --- |
+| getIndices() | 인덱스 데이터를 가져옵니다. 인덱스 배열. |
+
+ **Result:**
+
+
+
+---
+
+
+### copyTo{#copyTo}
+
+| 이름 | 설명 |
+| --- | --- |
+| copyTo(target) | 지정된 요소에 데이터를 복사합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 대상 | VertexElementVector4 | 대상. |
+
+ **Result:**
+
+
+
+---
+
+
+### setData{#setData}
+
+| 이름 | 설명 |
+| --- | --- |
+| setData(data) | 데이터 로드 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 데이터 | Vector4[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| 이름 | 설명 |
+| --- | --- |
+| clear() | 직접 배열과 인덱스 배열에서 모든 요소를 제거합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| 이름 | 설명 |
+| --- | --- |
+| setIndices(data) | 인덱스 로드 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 데이터 | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| 이름 | 설명 |
+| --- | --- |
+| toString() | 버텍스 요소의 문자열 표현. |
+
+ **Result:**
+String
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/vertexelementvertexcrease/_index.md
+++ b/korean/nodejs-java/aspose.threed/vertexelementvertexcrease/_index.md
@@ -1,0 +1,229 @@
+---
+title: "VertexElementVertexCrease"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/vertexelementvertexcrease/
+---
+## VertexElementVertexCrease class
+
+지정된 구성 요소에 대한 정점 크리스를 정의합니다
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | VertexElementVertexCrease 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getData{#getData}
+
+| 이름 | 설명 |
+| --- | --- |
+| getData() | 버텍스 데이터를 가져옵니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| 이름 | 설명 |
+| --- | --- |
+| getVertexElementType() | VertexElement의 유형을 가져옵니다. 속성 값은 VertexElementType 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getMappingMode() | 요소가 매핑되는 방식을 가져오거나 설정합니다. 속성 값은 MappingMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setMappingMode(value) | 요소가 매핑되는 방식을 가져오거나 설정합니다. 속성 값은 MappingMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getReferenceMode() | 요소가 참조되는 방식을 가져오거나 설정합니다. 속성 값은 ReferenceMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setReferenceMode(value) | 요소가 참조되는 방식을 가져오거나 설정합니다. 속성 값은 ReferenceMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| 이름 | 설명 |
+| --- | --- |
+| getIndices() | 인덱스 데이터를 가져옵니다. 인덱스 배열. |
+
+ **Result:**
+
+
+
+---
+
+
+### copyTo{#copyTo}
+
+| 이름 | 설명 |
+| --- | --- |
+| copyTo(target) | 지정된 요소에 데이터를 복사합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 대상 | VertexElementDoublesTemplate | 대상. |
+
+ **Result:**
+
+
+
+---
+
+
+### setData{#setData}
+
+| 이름 | 설명 |
+| --- | --- |
+| setData(data) | 데이터 로드 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 데이터 | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| 이름 | 설명 |
+| --- | --- |
+| clear() | 직접 배열과 인덱스 배열에서 모든 요소를 제거합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| 이름 | 설명 |
+| --- | --- |
+| setIndices(data) | 인덱스 로드 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 데이터 | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| 이름 | 설명 |
+| --- | --- |
+| toString() | 버텍스 요소의 문자열 표현. |
+
+ **Result:**
+String
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/vertexelementvisibility/_index.md
+++ b/korean/nodejs-java/aspose.threed/vertexelementvisibility/_index.md
@@ -1,0 +1,191 @@
+---
+title: "VertexElementVisibility"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/vertexelementvisibility/
+---
+## VertexElementVisibility class
+
+지정된 구성 요소가 보이는지 여부를 정의합니다
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | VertexElementVisibility 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getData{#getData}
+
+| 이름 | 설명 |
+| --- | --- |
+| getData() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| 이름 | 설명 |
+| --- | --- |
+| getVertexElementType() | VertexElement의 유형을 가져옵니다. 속성 값은 VertexElementType 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getMappingMode() | 요소가 매핑되는 방식을 가져오거나 설정합니다. 속성 값은 MappingMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setMappingMode(value) | 요소가 매핑되는 방식을 가져오거나 설정합니다. 속성 값은 MappingMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getReferenceMode() | 요소가 참조되는 방식을 가져오거나 설정합니다. 속성 값은 ReferenceMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setReferenceMode(value) | 요소가 참조되는 방식을 가져오거나 설정합니다. 속성 값은 ReferenceMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| 이름 | 설명 |
+| --- | --- |
+| getIndices() | 인덱스 데이터를 가져옵니다. 인덱스 배열. |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| 이름 | 설명 |
+| --- | --- |
+| clear() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| 이름 | 설명 |
+| --- | --- |
+| setIndices(data) | 인덱스 로드 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 데이터 | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| 이름 | 설명 |
+| --- | --- |
+| toString() | 버텍스 요소의 문자열 표현. |
+
+ **Result:**
+String
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/vertexelementweight/_index.md
+++ b/korean/nodejs-java/aspose.threed/vertexelementweight/_index.md
@@ -1,0 +1,229 @@
+---
+title: "VertexElementWeight"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/vertexelementweight/
+---
+## VertexElementWeight class
+
+지정된 구성 요소에 대한 블렌드 가중치를 정의합니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | VertexElementWeight 클래스의 새 인스턴스를 초기화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getData{#getData}
+
+| 이름 | 설명 |
+| --- | --- |
+| getData() | 버텍스 데이터를 가져옵니다 |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| 이름 | 설명 |
+| --- | --- |
+| getVertexElementType() | VertexElement의 유형을 가져옵니다. 속성 값은 VertexElementType 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getMappingMode() | 요소가 매핑되는 방식을 가져오거나 설정합니다. 속성 값은 MappingMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setMappingMode(value) | 요소가 매핑되는 방식을 가져오거나 설정합니다. 속성 값은 MappingMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getReferenceMode() | 요소가 참조되는 방식을 가져오거나 설정합니다. 속성 값은 ReferenceMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setReferenceMode(value) | 요소가 참조되는 방식을 가져오거나 설정합니다. 속성 값은 ReferenceMode 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| 이름 | 설명 |
+| --- | --- |
+| getIndices() | 인덱스 데이터를 가져옵니다. 인덱스 배열. |
+
+ **Result:**
+
+
+
+---
+
+
+### copyTo{#copyTo}
+
+| 이름 | 설명 |
+| --- | --- |
+| copyTo(target) | 지정된 요소에 데이터를 복사합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 대상 | VertexElementDoublesTemplate | 대상. |
+
+ **Result:**
+
+
+
+---
+
+
+### setData{#setData}
+
+| 이름 | 설명 |
+| --- | --- |
+| setData(data) | 데이터 로드 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 데이터 | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| 이름 | 설명 |
+| --- | --- |
+| clear() | 직접 배열과 인덱스 배열에서 모든 요소를 제거합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| 이름 | 설명 |
+| --- | --- |
+| setIndices(data) | 인덱스 로드 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 데이터 | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| 이름 | 설명 |
+| --- | --- |
+| toString() | 버텍스 요소의 문자열 표현. |
+
+ **Result:**
+String
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/vertexfield/_index.md
+++ b/korean/nodejs-java/aspose.threed/vertexfield/_index.md
@@ -1,0 +1,146 @@
+---
+title: "VertexField"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/vertexfield/
+---
+## VertexField class
+
+정점 필드 메모리 레이아웃 설명.  @hideconstructor
+
+
+## 메서드
+
+### getDataType{#getDataType}
+
+| 이름 | 설명 |
+| --- | --- |
+| getDataType() | 이 필드의 데이터 유형입니다. 속성 값은 VertexFieldDataType 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getSemantic{#getSemantic}
+
+| 이름 | 설명 |
+| --- | --- |
+| getSemantic() | 이 필드의 사용 의미입니다. 속성 값은 VertexFieldSemantic 정수 상수입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAlias{#getAlias}
+
+| 이름 | 설명 |
+| --- | --- |
+| getAlias() | com.aspose.threed.SemanticAttribute 특성으로 주석된 별칭 |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndex{#getIndex}
+
+| 이름 | 설명 |
+| --- | --- |
+| getIndex() | 동일한 의미를 가진 정점 레이아웃에서 이 필드의 인덱스입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getOffset{#getOffset}
+
+| 이름 | 설명 |
+| --- | --- |
+| getOffset() | 이 필드의 바이트 단위 오프셋입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getSize{#getSize}
+
+| 이름 | 설명 |
+| --- | --- |
+| getSize() | 이 필드의 바이트 단위 크기입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### hashCode{#hashCode}
+
+| 이름 | 설명 |
+| --- | --- |
+| hashCode() |  |
+
+ **Result:**
+숫자
+
+
+---
+
+
+### equals{#equals}
+
+| 이름 | 설명 |
+| --- | --- |
+| equals(obj) | 이 인스턴스와 지정된 객체(또한 VertexField 객체여야 함)가 동일한 값을 갖는지 여부를 결정합니다. |
+
+ **Result:**
+숫자
+
+
+---
+
+
+### compareTo{#compareTo}
+
+| 이름 | 설명 |
+| --- | --- |
+| compareTo(other) | 이 인스턴스를 지정된 객체와 비교하고 그 상대값에 대한 표시를 반환합니다. |
+
+ **Result:**
+숫자
+
+
+---
+
+
+### toString{#toString}
+
+| 이름 | 설명 |
+| --- | --- |
+| toString() |  |
+
+ **Result:**
+String
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/viewport/_index.md
+++ b/korean/nodejs-java/aspose.threed/viewport/_index.md
@@ -1,0 +1,185 @@
+---
+title: "Viewport"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/viewport/
+---
+## Viewport class
+
+com.aspose.threed.IRenderTarget은 장면을 렌더링하기 위해 최소 하나의 뷰포트를 포함합니다.  @hideconstructor
+
+
+## 메서드
+
+### getFrustum{#getFrustum}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFrustum() | 이 Viewport의 카메라를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFrustum{#setFrustum}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFrustum(value) | 이 Viewport의 카메라를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEnabled{#getEnabled}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEnabled() | 이 Viewport를 활성화하거나 비활성화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setEnabled{#setEnabled}
+
+| 이름 | 설명 |
+| --- | --- |
+| setEnabled(value) | 이 Viewport를 활성화하거나 비활성화합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getRenderTarget{#getRenderTarget}
+
+| 이름 | 설명 |
+| --- | --- |
+| getRenderTarget() | 이 뷰포트를 만든 렌더 타겟을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getArea{#getArea}
+
+| 이름 | 설명 |
+| --- | --- |
+| getArea() | 렌더 타겟에서 뷰포트의 영역을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setArea{#setArea}
+
+| 이름 | 설명 |
+| --- | --- |
+| setArea(value) | 렌더 타겟에서 뷰포트의 영역을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getZOrder{#getZOrder}
+
+| 이름 | 설명 |
+| --- | --- |
+| getZOrder() | 뷰포트의 Z-순서를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setZOrder{#setZOrder}
+
+| 이름 | 설명 |
+| --- | --- |
+| setZOrder(value) | 뷰포트의 Z-순서를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getBackgroundColor{#getBackgroundColor}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBackgroundColor() | 뷰포트의 배경 색상을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setBackgroundColor{#setBackgroundColor}
+
+| 이름 | 설명 |
+| --- | --- |
+| setBackgroundColor(value) | 뷰포트의 배경 색상을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDepthClear{#getDepthClear}
+
+| 이름 | 설명 |
+| --- | --- |
+| getDepthClear() | 깊이 버퍼 비트가 설정된 상태에서 뷰포트를 클리어할 때 사용되는 깊이 값을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDepthClear{#setDepthClear}
+
+| 이름 | 설명 |
+| --- | --- |
+| setDepthClear(value) | 깊이 버퍼 비트가 설정된 상태에서 뷰포트를 클리어할 때 사용되는 깊이 값을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/watermark/_index.md
+++ b/korean/nodejs-java/aspose.threed/watermark/_index.md
@@ -1,0 +1,96 @@
+---
+title: "Watermark"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/watermark/
+---
+## Watermark class
+
+메시에서 블라인드 워터마크를 인코딩/디코딩하기 위한 유틸리티.  @hideconstructor
+
+
+## 메서드
+
+### encodeWatermark{#encodeWatermark}
+
+| 이름 | 설명 |
+| --- | --- |
+| encodeWatermark(input, text) | 텍스트를 메쉬의 블라인드 워터마크로 인코딩합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| input | Mesh | 블라인드 워터마크를 인코딩할 메쉬 |
+| text | String | 메쉬에 인코딩할 텍스트 |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### encodeWatermark{#encodeWatermark}
+
+| 이름 | 설명 |
+| --- | --- |
+| encodeWatermark(input, text, password) | 텍스트를 메쉬의 블라인드 워터마크로 인코딩합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| input | Mesh | 블라인드 워터마크를 인코딩할 메쉬 |
+| text | String | 메쉬에 인코딩할 텍스트 |
+| password | String | 워터마크를 보호하기 위한 비밀번호이며, 선택 사항입니다. |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### decodeWatermark{#decodeWatermark}
+
+| 이름 | 설명 |
+| --- | --- |
+| decodeWatermark(input) | 메쉬에서 워터마크를 디코드합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| input | Mesh | 워터마크를 추출할 메쉬 |
+
+ **Result:**
+String
+
+
+---
+
+
+### decodeWatermark{#decodeWatermark}
+
+| 이름 | 설명 |
+| --- | --- |
+| decodeWatermark(input, password) | 메쉬에서 워터마크를 디코드합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| input | Mesh | 워터마크를 추출할 메쉬 |
+| password | String | 워터마크를 복호화하기 위한 비밀번호 |
+
+ **Result:**
+String
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/windowhandle/_index.md
+++ b/korean/nodejs-java/aspose.threed/windowhandle/_index.md
@@ -1,0 +1,13 @@
+---
+title: "WindowHandle"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/windowhandle/
+---
+## WindowHandle class
+
+다양한 플랫폼용 캡슐화된 윈도우 핸들.  @hideconstructor
+
+

--- a/korean/nodejs-java/aspose.threed/xloadoptions/_index.md
+++ b/korean/nodejs-java/aspose.threed/xloadoptions/_index.md
@@ -1,0 +1,152 @@
+---
+title: "XLoadOptions"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/xloadoptions/
+---
+## XLoadOptions class
+
+DirectX X 파일에 대한 로드 옵션.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor(contentType) | XLoadOptions의 생성자 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| contentType | FileContentType | FileContentType |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlipCoordinateSystem{#getFlipCoordinateSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFlipCoordinateSystem() | 좌표계를 뒤집습니다. 기본값은 true입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlipCoordinateSystem{#setFlipCoordinateSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFlipCoordinateSystem(value) | 좌표계를 뒤집습니다. 기본값은 true입니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileFormat() | 현재 저장/로드 옵션에 지정된 파일 형식을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEncoding() | 텍스트 기반 파일에 대한 기본 인코딩을 가져오거나 설정합니다. 기본값은 null이며, 이는 가져오기/내보내기 프로그램이 사용할 인코딩을 결정함을 의미합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileSystem() | 로드/저장 중 외부 종속성을 관리하는 방법을 사용자가 처리하도록 허용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFileSystem(value) | 로드/저장 중 외부 종속성을 관리하는 방법을 사용자가 처리하도록 허용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| 이름 | 설명 |
+| --- | --- |
+| getLookupPaths() | OBJ와 같은 일부 파일은 외부 파일에 의존하며, 조회 경로를 통해 Aspose.3D가 외부 파일을 찾아 로드할 수 있도록 합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFileName() | 내보내기/가져오기 씬의 파일 이름입니다. 선택 사항이지만 OBJ의 재질과 같은 외부 자산을 직렬화할 때 유용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFileName(value) | 내보내기/가져오기 씬의 파일 이름입니다. 선택 사항이지만 OBJ의 재질과 같은 외부 자산을 직렬화할 때 유용합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/ziparchivefilesystem/_index.md
+++ b/korean/nodejs-java/aspose.threed/ziparchivefilesystem/_index.md
@@ -1,0 +1,75 @@
+---
+title: "ZipArchiveFileSystem"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/ziparchivefilesystem/
+---
+## ZipArchiveFileSystem class
+
+지정된 zip 파일 또는 zip 스트림에 대한 읽기 전용 액세스를 제공하는 파일 시스템. 파일 시스템은 열기/저장 작업 후에 해제됩니다.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor(fileName) | 파일 이름을 통해 ZipArchiveFileSystem을 생성합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| fileNam | String | null |
+
+ **Result:**
+
+
+
+---
+
+
+### readFile{#readFile}
+
+| 이름 | 설명 |
+| --- | --- |
+| readFile(fileName, options) | 읽기를 위해 파일을 엽니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| fileNam | String | null |
+| 옵션 | IOConfig | null |
+
+ **Result:**
+Stream
+
+
+---
+
+
+### writeFile{#writeFile}
+
+| 이름 | 설명 |
+| --- | --- |
+| writeFile(fileName, options) | 쓰기를 위해 파일을 엽니다. 이 클래스에서는 구현되지 않았습니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| fileNam | String | null |
+| 옵션 | IOConfig | null |
+
+ **Result:**
+Stream
+
+
+---
+
+
+

--- a/korean/nodejs-java/aspose.threed/zshape/_index.md
+++ b/korean/nodejs-java/aspose.threed/zshape/_index.md
@@ -1,0 +1,437 @@
+---
+title: "ZShape"
+second_title: "Java를 통해 Node.js용 Aspose.3D API 레퍼런스"
+description: 
+type: docs
+
+url: /ko/nodejs-java/aspose.threed/zshape/
+---
+## ZShape class
+
+매개변수로 정의된 IFC 호환 Z형 프로파일.
+
+
+## 메서드
+
+### constructor{#constructor}
+
+| 이름 | 설명 |
+| --- | --- |
+| constructor() | ZShape의 생성자 |
+
+ **Result:**
+
+
+
+---
+
+
+### getDepth{#getDepth}
+
+| 이름 | 설명 |
+| --- | --- |
+| getDepth() | 웹의 길이를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDepth{#setDepth}
+
+| 이름 | 설명 |
+| --- | --- |
+| setDepth(value) | 웹의 길이를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlangeWidth{#getFlangeWidth}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFlangeWidth() | 플랜지의 길이를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlangeWidth{#setFlangeWidth}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFlangeWidth(value) | 플랜지의 길이를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getWebThickness{#getWebThickness}
+
+| 이름 | 설명 |
+| --- | --- |
+| getWebThickness() | 벽의 두께를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setWebThickness{#setWebThickness}
+
+| 이름 | 설명 |
+| --- | --- |
+| setWebThickness(value) | 벽의 두께를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlangeThickness{#getFlangeThickness}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFlangeThickness() | 플랜지의 두께를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlangeThickness{#setFlangeThickness}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFlangeThickness(value) | 플랜지의 두께를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFilletRadius{#getFilletRadius}
+
+| 이름 | 설명 |
+| --- | --- |
+| getFilletRadius() | 플랜지와 웹 사이의 필렛 반경을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFilletRadius{#setFilletRadius}
+
+| 이름 | 설명 |
+| --- | --- |
+| setFilletRadius(value) | 플랜지와 웹 사이의 필렛 반경을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEdgeRadius{#getEdgeRadius}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEdgeRadius() | 플랜지 가장자리의 반경을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setEdgeRadius{#setEdgeRadius}
+
+| 이름 | 설명 |
+| --- | --- |
+| setEdgeRadius(value) | 플랜지 가장자리의 반경을 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNodes() | 모든 부모 노드를 가져옵니다. 엔터티는 기하학 인스턴싱을 위해 여러 부모 노드에 부착될 수 있습니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExcluded() | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| 이름 | 설명 |
+| --- | --- |
+| setExcluded(value) | 내보내기 중에 이 엔터티를 제외할지 여부를 가져오거나 설정합니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| getParentNode() | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| 이름 | 설명 |
+| --- | --- |
+| setParentNode(value) | 첫 번째 부모 노드를 가져오거나 설정합니다. 첫 번째 부모 노드를 설정하면 이 엔터티는 다른 부모 노드에서 분리됩니다. 부모 노드. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| 이름 | 설명 |
+| --- | --- |
+| getScene() | 이 객체가 속한 씬을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| 이름 | 설명 |
+| --- | --- |
+| getName() | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| 이름 | 설명 |
+| --- | --- |
+| setName(value) | 이름을 가져오거나 설정합니다. 이름. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperties() | 모든 속성의 컬렉션을 가져옵니다. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtent{#getExtent}
+
+| 이름 | 설명 |
+| --- | --- |
+| getExtent() | x 및 y 차원에서의 범위를 가져옵니다. |
+
+ **Result:**
+Vector2
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| 이름 | 설명 |
+| --- | --- |
+| getEntityRendererKey() | 렌더러에 등록된 엔터티 렌더러의 키를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| 이름 | 설명 |
+| --- | --- |
+| getBoundingBox() | 현재 엔터티의 객체 공간 좌표계에서 경계 상자를 가져옵니다. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 동적 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | 속성 | 제거할 속성은 무엇입니까 |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| removeProperty(property) | 이름으로 식별된 지정된 속성을 제거합니다. |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propert | String | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| getProperty(property) | 지정된 속성의 값을 가져옵니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| setProperty(property, value) | 지정된 속성의 값을 설정합니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성 | String | 속성 이름 |
+| value | Object | 속성의 값 |
+
+ **Result:**
+Object
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| 이름 | 설명 |
+| --- | --- |
+| findProperty(propertyName) | 속성을 찾습니다. 동적 속성 (Created by CreateDynamicProperty/SetProperty) 또는 네이티브 속성(Identified by its name) 일 수 있습니다 |
+
+ **Parameters:**
+
+| 이름 | 유형 | 설명 |
+| --- | --- | --- |
+| propertyName | String | 속성 이름. |
+
+ **Result:**
+속성
+
+
+---
+
+
+


### PR DESCRIPTION
Automated translation of the NODEJS-JAVA API Reference to **Korean** (`ko`) generated by RDA.

- Pages translated: 204/204
- Errors: 0
- Source: `english/nodejs-java`
- Output: `korean/nodejs-java`

🤖 Generated by RDA