### PR TITLE
[auto] Translate NODEJS-JAVA API Reference to Spanish

### DIFF
--- a/spanish/nodejs-java/_index.md
+++ b/spanish/nodejs-java/_index.md
@@ -1,0 +1,13 @@
+---
+title: "Aspose.3D para Node.js vía Java"
+type: docs
+weight: 11
+url: /es/nodejs-java/
+description: "Las referencias de API de Aspose.3D para Node.js vía Java contienen ejemplos, fragmentos de código y documentación de la API. Proporciona paquetes, clases, interfaces y otros detalles de la API."
+is_root: true
+---
+
+## Packages
+| Paquete | Descripción |
+| --- | --- |
+| [aspose.threed](./aspose.threed) |  |

--- a/spanish/nodejs-java/aspose.threed/_index.md
+++ b/spanish/nodejs-java/aspose.threed/_index.md
@@ -1,0 +1,217 @@
+---
+title: "aspose.threed"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+keywords: "Aspose.3D for Node.js via Java, Aspose.3D, STL, OBJ, Aspose API Reference."
+type: docs
+weight: 10
+url: /es/nodejs-java/aspose.threed/
+---
+
+
+## Clases
+
+| Clase | Descripción |
+| --- | --- |
+| [A3DObject](../aspose.threed/a3dobject) | La clase base de todos los objetos Aspose.ThreeD, todas las subclases admitirán propiedades dinámicas. |
+| [A3dwSaveOptions](../aspose.threed/a3dwsaveoptions) | Opciones de guardado para el formato A3DW. |
+| [AmfSaveOptions](../aspose.threed/amfsaveoptions) | Opciones de guardado para AMF |
+| [AnimationChannel](../aspose.threed/animationchannel) | Un canal asigna el campo componente de una propiedad a un conjunto de secuencias de fotogramas clave  @hideconstructor |
+| [AnimationClip](../aspose.threed/animationclip) | El clip de Animación es una colección de animaciones.  La escena puede tener uno o más clips de animación. |
+| [AnimationNode](../aspose.threed/animationnode) | Aspose.3D admite jerarquía de animación, cada animación puede estar compuesta por varias animaciones y la definición de fotogramas clave de la animación.  AnimationNode define la transformación del valor de una propiedad a lo largo del tiempo, por ejemplo, el nodo de animación puede usarse para controlar la transformación de un nodo o otras propiedades numéricas del objeto A3DObject. |
+| [ArbitraryProfile](../aspose.threed/arbitraryprofile) | Esta clase le permite construir un perfil 2D directamente a partir de una curva arbitraria. |
+| [AssetInfo](../aspose.threed/assetinfo) | Información del activo.  La información del activo puede adjuntarse a una Escena.  La Escena hija puede tener su propio AssetInfo para sobrescribir la definición del padre. |
+| [BindPoint](../aspose.threed/bindpoint) | Un BindPoint suele crearse en la propiedad de un objeto, algunos tipos de propiedad contienen múltiples campos componentes (como un campo Vector3),  BindPoint generará un canal para cada campo componente y conectará el campo a una o más instancias de secuencia de fotogramas clave a través de los canales. |
+| [Bone](../aspose.threed/bone) | Un hueso define el subconjunto del punto de control de la geometría y el peso de mezcla definido para cada punto de control.  El objeto Bone no puede usarse directamente, se utiliza una instancia de SkinDeformer para deformar la geometría, y SkinDeformer viene con un conjunto de huesos, cada hueso vinculado a un nodo.  NOTA: Un punto de control de una geometría puede estar vinculado a más de un Bone. |
+| [BonePose](../aspose.threed/bonepose) | El BonePose contiene la matriz de transformación para un nodo de hueso |
+| [BoundingBox](../aspose.threed/boundingbox) | El cuadro delimitador alineado a los ejes |
+| [BoundingBox2D](../aspose.threed/boundingbox2d) | El cuadro delimitador alineado a los ejes para Vector2 |
+| [Box](../aspose.threed/box) | Caja. |
+| [Camera](../aspose.threed/camera) | La cámara describe el punto de vista del observador que mira la escena. |
+| [Circle](../aspose.threed/circle) | Una curva Círculo consiste en un conjunto de puntos en el borde de la forma circular. |
+| [CircleShape](../aspose.threed/circleshape) | Perfil de círculo compatible con IFC, que puede usarse para construir una malla mediante LinearExtrusion |
+| [ColladaSaveOptions](../aspose.threed/colladasaveoptions) | Opciones de guardado para collada |
+| [CompositeCurve](../aspose.threed/compositecurve) | Un CompositeCurve está compuesto por varios segmentos de curva. |
+| [CShape](../aspose.threed/cshape) | Perfil en forma de C compatible con IFC definido por parámetros. La posición central del perfil está en el centro del cuadro delimitador. |
+| [Curve](../aspose.threed/curve) | La clase base de todas las implementaciones de curvas.  @hideconstructor |
+| [CustomObject](../aspose.threed/customobject) | Los metadatos o objetos personalizados utilizados en archivos 3D son gestionados por esta clase. Todas las propiedades personalizadas se guardan como propiedades dinámicas. |
+| [Cylinder](../aspose.threed/cylinder) | Cilindro parametrizado. También puede usarse para representar el cono cuando uno de radiusTop/radiusBottom es cero. |
+| [Deformer](../aspose.threed/deformer) | Clase base para SkinDeformer y MorphTargetDeformer |
+| [DescriptorSetUpdater](../aspose.threed/descriptorsetupdater) | Esta clase permite actualizar el com.aspose.threed.IDescriptorSet en una operación en cadena.  @hideconstructor |
+| [Discreet3dsLoadOptions](../aspose.threed/discreet3dsloadoptions) | Opciones de carga para archivo 3DS. |
+| [Discreet3dsSaveOptions](../aspose.threed/discreet3dssaveoptions) | Opciones de guardado para archivo 3DS. |
+| [Dish](../aspose.threed/dish) | Plato parametrizado. |
+| [DracoFormat](../aspose.threed/dracoformat) | Formato Google Draco  @hideconstructor |
+| [DracoSaveOptions](../aspose.threed/dracosaveoptions) | Opciones de guardado para archivos Google draco |
+| [DriverException](../aspose.threed/driverexception) | La excepción generada por los controladores internos de renderizado.  @hideconstructor |
+| [DummyFileSystem](../aspose.threed/dummyfilesystem) | Las operaciones de lectura/escritura son operaciones ficticias. |
+| [Ellipse](../aspose.threed/ellipse) | Una Elipse define un conjunto de puntos que forman la forma de una elipse. |
+| [EllipseShape](../aspose.threed/ellipseshape) | Forma de elipse compatible con IFC definida por parámetros. La posición central del perfil está en el centro del cuadro delimitador. |
+| [EndPoint](../aspose.threed/endpoint) | El punto final para recortar la curva, puede ser un valor de parámetro o un punto cartesiano. |
+| [Entity](../aspose.threed/entity) | La clase base de todas las entidades.  Entity representa un objeto concreto que está adjunto bajo un nodo como Light/Geometry. |
+| [EntityRenderer](../aspose.threed/entityrenderer) | Subclase esto para implementar renderizado para diferentes tipos de entidades. |
+| [EntityRendererKey](../aspose.threed/entityrendererkey) | La clave del renderizador de entidad registrado |
+| [ExportException](../aspose.threed/exportexception) | Excepciones cuando Aspose.3D no pudo exportar la escena a un archivo |
+| [Extrapolation](../aspose.threed/extrapolation) | La extrapolación define qué hacer cuando el valor muestreado está fuera del rango definido por los primeros y últimos fotogramas clave.  @hideconstructor |
+| [FbxLoadOptions](../aspose.threed/fbxloadoptions) | Opciones de carga para formato Fbx. |
+| [FbxSaveOptions](../aspose.threed/fbxsaveoptions) | Opciones de guardado para archivo Fbx. |
+| [FileFormat](../aspose.threed/fileformat) | Definición del formato de archivo  @hideconstructor |
+| [FileFormatType](../aspose.threed/fileformattype) | Tipo de formato de archivo  @hideconstructor |
+| [FileSystem](../aspose.threed/filesystem) | Encapsulación del sistema de archivos.  Aspose.3D usará esto para leer/escribir dependencias.  @hideconstructor |
+| [FMatrix4](../aspose.threed/fmatrix4) | Matriz 4x4 con todos los componentes en tipo flotante |
+| [FontFile](../aspose.threed/fontfile) | El archivo de fuente contiene definiciones de glifos, se usa para crear el perfil de texto.  @hideconstructor |
+| [Frustum](../aspose.threed/frustum) | La clase base de Cámara y Luz  @hideconstructor |
+| [FVector2](../aspose.threed/fvector2) | Un vector flotante con dos componentes. |
+| [FVector3](../aspose.threed/fvector3) | Un vector flotante con tres componentes. |
+| [FVector4](../aspose.threed/fvector4) | Un vector flotante con cuatro componentes. |
+| [Geometry](../aspose.threed/geometry) | La clase base de todos los objetos geométricos renderizables (como Mesh, NurbsSurface, Patch, etc.).  La clase base Geometry admite:  Gestión de puntos de control, los puntos de control definen la estructura espacial 3D base de la geometría; los diferentes tipos geométricos tienen diferentes formas de definir modelos 3D concretos. Definición de elementos de vértice, los elementos de vértice aplican información adicional como normales, coordenadas uv o colores de vértice a la geometría; vea VertexElement para más detalles. Deformación de objetos, Deformer puede enlazarse para animar la forma de la geometría. |
+| [GlobalTransform](../aspose.threed/globaltransform) | La transformación global es similar a Transform pero es inmutable mientras representa la transformación final evaluada.  Se utiliza un sistema de coordenadas de mano derecha al evaluar la transformación global  @hideconstructor |
+| [GLSLSource](../aspose.threed/glslsource) | El código fuente de los shaders en GLSL |
+| [GltfLoadOptions](../aspose.threed/gltfloadoptions) | Opciones de carga para el formato glTF |
+| [GltfSaveOptions](../aspose.threed/gltfsaveoptions) | Opciones de guardado para el formato glTF. |
+| [HollowCircleShape](../aspose.threed/hollowcircleshape) | Perfil circular hueco compatible con IFC. |
+| [HollowRectangleShape](../aspose.threed/hollowrectangleshape) | Forma rectangular hueca compatible con IFC con esquinas redondeadas internas/externas. |
+| [HShape](../aspose.threed/hshape) | HShape proporciona los parámetros definitorios de una forma 'H' o 'I'. |
+| [Html5SaveOptions](../aspose.threed/html5saveoptions) | Opciones de guardado para HTML5 |
+| [ImageRenderOptions](../aspose.threed/imagerenderoptions) | Opciones para Scene.render(com.aspose.threed.Camera, java.lang.String, com.aspose.threed.Vector2, java.lang.String, com.aspose.threed.ImageRenderOptions) y Scene.render(com.aspose.threed.Camera, com.aspose.threed.TextureData, com.aspose.threed.ImageRenderOptions) |
+| [ImportException](../aspose.threed/importexception) | Excepción cuando Aspose.3D no pudo abrir la fuente especificada |
+| [InitializationException](../aspose.threed/initializationexception) | Excepciones en la inicialización del pipeline de renderizado |
+| [IOConfig](../aspose.threed/ioconfig) | Configuración de E/S para serialización/deserialización.  El usuario puede especificar configuraciones detalladas como la ruta de búsqueda de dependencias  o configuraciones relacionadas con el formato aquí  @hideconstructor |
+| [IOUtils](../aspose.threed/ioutils) | Utilidades para escribir matrices/vectores en un escritor binario  @hideconstructor |
+| [KeyFrame](../aspose.threed/keyframe) | Un fotograma clave se define principalmente por un tiempo y un valor; para algunos tipos de interpolación, también se utilizan tangente/ tensión/ sesgo/ continuidad al calcular el valor muestreado final.  Los valores muestreados en una posición de tiempo sin fotograma clave se interpolan mediante fotogramas clave entre el fotograma clave anterior y el siguiente.  Los valores antes/después del primer/último fotograma clave se calculan con la clase Extrapolation. |
+| [KeyframeSequence](../aspose.threed/keyframesequence) | La secuencia de fotogramas clave, describe la transformación de un valor muestreado a lo largo del tiempo. |
+| [LambertMaterial](../aspose.threed/lambertmaterial) | Material para el modelo de sombreado Lambert |
+| [License](../aspose.threed/license) | Proporciona métodos para licenciar el componente. |
+| [Light](../aspose.threed/light) | La luz ilumina la escena.  La fórmula para calcular la atenuación total de la luz es:  A = ConstantAttenuation + (Dist  LinearAttenuation) + ((Dist^2)  QuadraticAttenuation) |
+| [Line](../aspose.threed/line) | Una polilínea es una ruta definida por un conjunto de puntos con Geometry.ControlPoints, y conectada por Segments, lo que significa que también puede ser un conjunto de segmentos de línea conectados. La línea suele ser un objeto lineal, lo que significa que no puede usarse para representar una curva; para representar una curva, se utiliza NurbsCurve. |
+| [LinearExtrusion](../aspose.threed/linearextrusion) | La extrusión lineal toma una forma 2D como entrada y extiende la forma en la tercera dimensión. |
+| [LoadOptions](../aspose.threed/loadoptions) | La clase base para configurar opciones en la carga de archivos para diferentes tipos  @hideconstructor |
+| [LocalFileSystem](../aspose.threed/localfilesystem) | El LocalFileSystem asignará las operaciones de lectura/escritura al directorio local. |
+| [LShape](../aspose.threed/lshape) | Perfil en forma de L compatible con IFC que se define mediante parámetros. |
+| [Material](../aspose.threed/material) | Material define los parámetros necesarios para la apariencia visual de la geometría.  Aspose.3D proporciona modelos de sombreado para LambertMaterial, PhongMaterial y ShaderMaterial  @hideconstructor |
+| [MathUtils](../aspose.threed/mathutils) | Un conjunto de utilidades matemáticas útiles.  @hideconstructor |
+| [Matrix4](../aspose.threed/matrix4) | Implementación de matriz 4x4. |
+| [MemoryFileSystem](../aspose.threed/memoryfilesystem) | El MemoryFileSystem asignará las operaciones de lectura/escritura a la memoria. |
+| [Mesh](../aspose.threed/mesh) | Una malla está compuesta por muchos polígonos de n lados. |
+| [Metered](../aspose.threed/metered) | Proporciona métodos para establecer la clave medida. |
+| [MirroredProfile](../aspose.threed/mirroredprofile) | Perfil espejo compatible con IFC.  Este perfil define un nuevo perfil al reflejar el perfil base respecto al eje y. |
+| [MorphTargetChannel](../aspose.threed/morphtargetchannel) | Un MorphTargetChannel es utilizado por MorphTargetDeformer para organizar las geometrías objetivo. Algunos formatos de archivo como FBX admiten múltiples canales en paralelo. El peso está entre 0 y 1.0, y el peso predeterminado para el objetivo es 0.0; |
+| [MorphTargetDeformer](../aspose.threed/morphtargetdeformer) | MorphTargetDeformer proporciona animación por vértice. MorphTargetDeformer organiza todos los objetivos a través de MorphTargetChannel, cada canal puede organizar múltiples objetivos. Un uso común del deformador de objetivos de morfología es aplicar expresiones faciales a un personaje. Más detalles pueden encontrarse en https://en.wikipedia.org/wiki/Morph_target_animation |
+| [Node](../aspose.threed/node) | Representa un elemento en el grafo de escena. Un grafo de escena es un árbol de objetos Node. Los servicios de gestión del árbol están contenidos en esta clase. Nota: el SDK Aspose.3D no verifica la validez del grafo de escena construido. Es responsabilidad del llamador asegurarse de que no genere grafos cíclicos en una jerarquía de nodos. Además de la gestión del árbol, esta clase define todas las propiedades necesarias para describir la posición del objeto en la escena. Esta información incluye las propiedades básicas de Translación, Rotación y Escalado, y las opciones más avanzadas para pivotes, límites y atributos de articulaciones IK como la rigidez y el amortiguamiento. Cuando se crea por primera vez, el objeto Node está "empty" (es decir, es un objeto sin representación gráfica que solo contiene la información de posición). En este estado, puede usarse para representar padres en la estructura del árbol de nodos pero no mucho más. El uso normal de este tipo de objetos es añadirles una entidad que especializará el nodo (ver "Entity"). La entidad es un objeto por sí misma y está conectada al Node. Esto también significa que la misma entidad puede compartirse entre varios nodos. Cámara, Luz, Malla, etc... son todas entidades y todas derivan de la clase base Entity. |
+| [NurbsCurve](../aspose.threed/nurbscurve) | Una curva NURBS es una curva representada por NURBS (Non-uniform rational basis spline). Una curva NURBS se define por su Order, un conjunto de Geometry.ControlPoints ponderados y un KnotVectors. El componente w en el punto de control se usa como peso del punto de control, sea que sea CurveDimension.TWO_DIMENSIONAL o CurveDimension.THREE_DIMENSIONAL. |
+| [NurbsDirection](../aspose.threed/nurbsdirection) | Una NurbsSurface 3D tiene dos direcciones, NurbsSurface.U y NurbsSurface.V; NurbsDirection define los datos para cada dirección. Una dirección es en realidad una curva NURBS, lo que significa que también se define por su Order, un KnotVectors y un conjunto de puntos de control ponderados (definidos en NurbsSurface). |
+| [NurbsSurface](../aspose.threed/nurbssurface) | NurbsSurface es una superficie representada por NURBS (Non-uniform rational basis spline). Una NurbsSurface se define por dos NurbsDirectionU y V. El componente w en el punto de control se usa como peso del punto de control, sea que el tipo de dirección sea CurveDimension.TWO_DIMENSIONAL o CurveDimension.THREE_DIMENSIONAL. |
+| [ObjLoadOptions](../aspose.threed/objloadoptions) | Opciones de carga para wavefront obj |
+| [ObjSaveOptions](../aspose.threed/objsaveoptions) | Opciones de guardado para archivo wavefront obj |
+| [ParameterizedProfile](../aspose.threed/parameterizedprofile) | La clase base de todos los perfiles parametrizados.  @hideconstructor |
+| [ParseException](../aspose.threed/parseexception) | Excepción cuando Aspose.3D no pudo analizar la entrada. |
+| [Patch](../aspose.threed/patch) | Un Patch es una superficie de modelado paramétrico, similar a NurbsSurface, también está definida por dos PatchDirection, la U y la V. Pero la diferencia entre Patch y NurbsSurface es que la curva PatchDirection puede ser una de PatchDirectionType.BEZIER, PatchDirectionType.QUADRATIC_BEZIER, PatchDirectionType.BASIS_SPLINE, PatchDirectionType.CARDINAL_SPLINE y PatchDirectionType.LINEAR |
+| [PatchDirection](../aspose.threed/patchdirection) | Dirección U y V del Patch. |
+| [PbrMaterial](../aspose.threed/pbrmaterial) | Material para renderizado físicamente basado en color albedo/metallic/roughness |
+| [PbrSpecularMaterial](../aspose.threed/pbrspecularmaterial) | Material para renderizado físicamente basado en color difuso/specular/glossiness |
+| [PdfFormat](../aspose.threed/pdfformat) | Formato de Documento Portátil de Adobe  @hideconstructor |
+| [PdfLoadOptions](../aspose.threed/pdfloadoptions) | Opciones para cargar PDF |
+| [PdfSaveOptions](../aspose.threed/pdfsaveoptions) | Las opciones de guardado al exportar PDF. |
+| [PhongMaterial](../aspose.threed/phongmaterial) | Material para el modelo de sombreado Blinn-Phong. |
+| [PixelMapping](../aspose.threed/pixelmapping) | @hideconstructor |
+| [Plane](../aspose.threed/plane) | Plano parametrizado. |
+| [PlyFormat](../aspose.threed/plyformat) | El formato PLY.  @hideconstructor |
+| [PlyLoadOptions](../aspose.threed/plyloadoptions) | Opciones de carga para archivos PLY |
+| [PlySaveOptions](../aspose.threed/plysaveoptions) | Opciones de guardado para exportar la escena como archivo PLY. |
+| [PointCloud](../aspose.threed/pointcloud) | La nube de puntos no contiene información de topología, solo los puntos de control y los elementos de vértice. |
+| [PolygonBuilder](../aspose.threed/polygonbuilder) | Una clase auxiliar para construir polígonos para Mesh |
+| [PolygonModifier](../aspose.threed/polygonmodifier) | Utilidades para modificar polígonos  @hideconstructor |
+| [Pose](../aspose.threed/pose) | La pose se usa para almacenar la matriz de transformación cuando la geometría está con skinning. La pose es un conjunto de BonePose, cada BonePose guarda la información concreta de transformación del nodo óseo. |
+| [PostProcessing](../aspose.threed/postprocessing) | Los efectos de post-procesado  @hideconstructor |
+| [Primitive](../aspose.threed/primitive) | Clase base para todas las primitivas |
+| [Profile](../aspose.threed/profile) | Perfil 2D en el plano xy  @hideconstructor |
+| [Property](../aspose.threed/property) | Clase para contener propiedades definidas por el usuario.  @hideconstructor |
+| [PropertyCollection](../aspose.threed/propertycollection) | La colección de propiedades  @hideconstructor |
+| [PushConstant](../aspose.threed/pushconstant) | Una utilidad para proporcionar datos al shader mediante push constant. |
+| [Pyramid](../aspose.threed/pyramid) | Pirámide parametrizada. |
+| [Quaternion](../aspose.threed/quaternion) | El cuaternión se usa normalmente para realizar rotaciones en gráficos por computadora. |
+| [Rect](../aspose.threed/rect) | Una clase para representar el rectángulo |
+| [RectangleShape](../aspose.threed/rectangleshape) | Forma rectangular compatible con IFC con esquinas redondeadas. |
+| [RectangularTorus](../aspose.threed/rectangulartorus) | Toro rectangular parametrizado. |
+| [RelativeRectangle](../aspose.threed/relativerectangle) | Rectángulo relativo  La fórmula entre el componente relativo y el valor absoluto es:  Escala  (Ancho de referencia) + desplazamiento  Así que si queremos que represente un valor absoluto, deje todos los campos de escala en cero y use los campos de desplazamiento en su lugar. |
+| [Renderer](../aspose.threed/renderer) | El contexto sobre el renderizador.  @hideconstructor |
+| [RendererVariableManager](../aspose.threed/renderervariablemanager) | Esta clase gestiona variables usadas en el renderizado  @hideconstructor |
+| [RenderFactory](../aspose.threed/renderfactory) | RenderFactory crea todos los recursos que se representan en la canalización de renderizado.  @hideconstructor |
+| [RenderParameters](../aspose.threed/renderparameters) | Describe los parámetros del objetivo de renderizado |
+| [RenderResource](../aspose.threed/renderresource) | La clase abstracta de todos los recursos de renderizado  Todos los recursos de renderizado se dispondrán cuando se libere el renderizador.  Clases como Mesh/Texture tendrán un RenderResource correspondiente  @hideconstructor |
+| [RenderState](../aspose.threed/renderstate) | Estado de renderizado para construir la canalización  Los cambios realizados en el estado de renderizado no afectarán a las instancias de la canalización creadas. |
+| [RevolvedAreaSolid](../aspose.threed/revolvedareasolid) | Esta clase representa un modelo sólido al girar una sección transversal proporcionada por un perfil alrededor de un eje. |
+| [RvmFormat](../aspose.threed/rvmformat) | El formato RVM  @hideconstructor |
+| [RvmLoadOptions](../aspose.threed/rvmloadoptions) | Opciones de carga para el archivo RVM del Sistema de Gestión de Diseño de Plantas AVEVA. |
+| [RvmSaveOptions](../aspose.threed/rvmsaveoptions) | Opciones de guardado para el archivo RVM de Aveva PDMS. |
+| [SaveOptions](../aspose.threed/saveoptions) | La clase base para configurar opciones al guardar archivos para diferentes tipos  @hideconstructor |
+| [Scene](../aspose.threed/scene) | Una escena es un objeto de nivel superior que contiene los nodos, geometrías, materiales, texturas, animaciones, poses, sub-escenas, etc.  La escena puede tener sub-escenas, funciona como soporte de múltiples documentos en archivos como collada/blender/fbx.  La jerarquía de nodos se puede acceder a través de RootNodeLibrary, que se utiliza para mantener una referencia de objetos no adjuntos durante la serialización (como metadatos u objetos personalizados) para que pueda usarse como una biblioteca. |
+| [SceneObject](../aspose.threed/sceneobject) | La clase raíz de los objetos que se almacenarán dentro de una escena. |
+| [ShaderException](../aspose.threed/shaderexception) | Excepciones relacionadas con shaders |
+| [ShaderMaterial](../aspose.threed/shadermaterial) | Un material de shader permite describir el material mediante un motor de renderizado externo o un lenguaje de shader.  ShaderMaterial usa ShaderTechnique para describir los detalles concretos de renderizado, y se utilizará el más adecuado según la plataforma de renderizado final.  Por ejemplo, su instancia de ShaderMaterial puede tener dos técnicas, una definida por HLSL y otra definida por GLSL.  En plataformas sin ventana, se debe usar GLSL en lugar de HLSL. |
+| [ShaderProgram](../aspose.threed/shaderprogram) | El programa de shader  @hideconstructor |
+| [ShaderSet](../aspose.threed/shaderset) | Programas de shader para cada tipo de material |
+| [ShaderSource](../aspose.threed/shadersource) | El código fuente del shader  @hideconstructor |
+| [ShaderTechnique](../aspose.threed/shadertechnique) | Una técnica de shader representa una implementación concreta de renderizado. |
+| [ShaderVariable](../aspose.threed/shadervariable) | Variable de shader |
+| [Shape](../aspose.threed/shape) | La forma describe la deformación en un conjunto de puntos de control, lo cual es similar al deformador de clúster en Maya.  Por ejemplo, podemos añadir una forma a una geometría creada.  Y la forma y la geometría tienen la misma información topológica pero diferentes posiciones de los puntos de control.  Con diferentes niveles de influencia, la geometría produce un efecto de deformación. |
+| [Skeleton](../aspose.threed/skeleton) | El esqueleto se usa principalmente en software CAD para ayudar al diseñador a manipular la transformación de la estructura esquelética; suele ser inútil fuera de los softwares CAD. Para que la jerarquía del esqueleto actúe como un solo objeto en el software CAD, es necesario marcar el nodo superior del Skeleton como la raíz estableciendo Type a SkeletonType.SKELETON, y todos los hijos a SkeletonType.BONE. |
+| [SkinDeformer](../aspose.threed/skindeformer) | Un deformador de piel contiene múltiples huesos para trabajar, cada hueso mezcla una parte de la geometría mediante los pesos de los puntos de control. |
+| [Sphere](../aspose.threed/sphere) | Esfera parametrizada. |
+| [SPIRVSource](../aspose.threed/spirvsource) | El shader compilado en formato SPIR-V. |
+| [StencilState](../aspose.threed/stencilstate) | Estados de stencil por cara.  @hideconstructor |
+| [StlLoadOptions](../aspose.threed/stlloadoptions) | Opciones de carga para STL |
+| [StlSaveOptions](../aspose.threed/stlsaveoptions) | Opciones de guardado para STL |
+| [SweptAreaSolid](../aspose.threed/sweptareasolid) | Un SweptAreaSolid construye una geometría barrendo un perfil a lo largo de una directriz. |
+| [Text](../aspose.threed/text) | Perfil de texto, este perfil describe contornos usando fuente y texto. |
+| [Texture](../aspose.threed/texture) | Esta clase define la textura a partir de un archivo externo. |
+| [TextureBase](../aspose.threed/texturebase) | Clase base para todas las texturas concretas.  Texture define el aspecto y la sensación de la superficie de una geometría. |
+| [TextureCodec](../aspose.threed/texturecodec) | Clase para gestionar codificadores y decodificadores de texturas. |
+| [TextureData](../aspose.threed/texturedata) | Esta clase contiene los datos sin procesar y la definición de formato de una textura. |
+| [TextureSlot](../aspose.threed/textureslot) | Ranura de textura en Material, puede enumerarse a través de la instancia del material.  @hideconstructor |
+| [Torus](../aspose.threed/torus) | Toro parametrizado. |
+| [Transform](../aspose.threed/transform) | Una transformación contiene información que permite acceder a la traslación/escala/rotación del objeto o a la matriz de transformación con el coste mínimo.  Esto se usa en la transformación local.  @hideconstructor |
+| [TransformBuilder](../aspose.threed/transformbuilder) | El TransformBuilder se usa para construir la matriz de transformación mediante una cadena de transformaciones. |
+| [TransformedCurve](../aspose.threed/transformedcurve) | Una TransformedCurve asigna una posición a una curva usando una matriz de transformación.  Esto permite realizar una transformación dentro de una TrimmedCurve o CompositeCurve. |
+| [TrapeziumShape](../aspose.threed/trapeziumshape) | Forma de trapecio compatible con IFC definida por parámetros. |
+| [TrialException](../aspose.threed/trialexception) | Esto se genera en Scene.Open/Scene.Save cuando no se aplican licencias.  Puedes desactivar esta excepción estableciendo SuppressTrialException a true. |
+| [TriMesh](../aspose.threed/trimesh) | Un TriMesh contiene datos sin procesar que pueden ser usados directamente por la GPU.  Esta clase es una utilidad para ayudar a construir una malla que solo contiene datos por vértice. |
+| [TrimmedCurve](../aspose.threed/trimmedcurve) | Una curva acotada que recorta la curva base en ambos extremos. |
+| [TShape](../aspose.threed/tshape) | Forma en T compatible con IFC definida por parámetros. |
+| [U3dLoadOptions](../aspose.threed/u3dloadoptions) | Opciones de carga para universal 3d |
+| [U3dSaveOptions](../aspose.threed/u3dsaveoptions) | Opciones de guardado para universal 3d |
+| [UsdSaveOptions](../aspose.threed/usdsaveoptions) | Opciones de guardado para formatos USD/USDZ. |
+| [UShape](../aspose.threed/ushape) | Forma en U compatible con IFC definida por parámetros. |
+| [Vector2](../aspose.threed/vector2) | Un vector con dos componentes. |
+| [Vector3](../aspose.threed/vector3) | Un vector con tres componentes. |
+| [Vector4](../aspose.threed/vector4) | Un vector con cuatro componentes. |
+| [Vertex](../aspose.threed/vertex) | Referencia de vértice, utilizada para acceder al vértice sin procesar en TriMesh.  @hideconstructor |
+| [VertexDeclaration](../aspose.threed/vertexdeclaration) | La declaración de la estructura de un vértice definido de forma personalizada |
+| [VertexElement](../aspose.threed/vertexelement) | Clase base de elementos de vértice.  Un tipo de elemento de vértice se identifica mediante VertexElementType.  Un VertexElement describe cómo el elemento de vértice se asigna a una superficie geométrica y cómo la información de asignación se organiza en memoria.  Un VertexElement contiene Normales, UVs u otro tipo de información.  @hideconstructor |
+| [VertexElementBinormal](../aspose.threed/vertexelementbinormal) | Define los vectores binormales para los componentes especificados. |
+| [VertexElementDoublesTemplate](../aspose.threed/vertexelementdoublestemplate) | Una clase auxiliar para definir implementaciones concretas de VertexElement.  @hideconstructor |
+| [VertexElementEdgeCrease](../aspose.threed/vertexelementedgecrease) | Define el pliegue del borde para los componentes especificados |
+| [VertexElementHole](../aspose.threed/vertexelementhole) | Define si el polígono especificado es un agujero |
+| [VertexElementIntsTemplate](../aspose.threed/vertexelementintstemplate) | Una clase auxiliar para definir implementaciones concretas de VertexElement.  @hideconstructor |
+| [VertexElementMaterial](../aspose.threed/vertexelementmaterial) | Define el índice de material para los componentes especificados.  Un nodo puede tener múltiples materiales, el VertexElementMaterial se utiliza para renderizar diferentes partes de la geometría con diferentes materiales. |
+| [VertexElementNormal](../aspose.threed/vertexelementnormal) | Define los vectores normales para los componentes especificados. |
+| [VertexElementPolygonGroup](../aspose.threed/vertexelementpolygongroup) | Define el grupo de polígonos para los componentes especificados para agrupar polígonos relacionados juntos. |
+| [VertexElementSmoothingGroup](../aspose.threed/vertexelementsmoothinggroup) | Un grupo de suavizado es un conjunto de polígonos en una malla de polígonos que debería aparecer como una superficie lisa.  Algunos softwares de modelado 3D tempranos, como 3D Studio Max para DOS, utilizaban grupos de suavizado para evitar almacenar el vector normal para cada vértice de la malla. |
+| [VertexElementSpecular](../aspose.threed/vertexelementspecular) | Define el color especular para los componentes especificados. |
+| [VertexElementTangent](../aspose.threed/vertexelementtangent) | Define los vectores tangentes para los componentes especificados. |
+| [VertexElementUserData](../aspose.threed/vertexelementuserdata) | Define datos de usuario personalizados para los componentes especificados.  Normalmente son datos específicos de la aplicación para un propósito especial. |
+| [VertexElementUV](../aspose.threed/vertexelementuv) | Define las coordenadas UV para los componentes especificados.  Una geometría puede tener múltiples elementos VertexElementUV, y cada uno tiene diferentes TextureMappings. |
+| [VertexElementVector4](../aspose.threed/vertexelementvector4) | Una clase auxiliar para definir implementaciones concretas de VertexElement.  @hideconstructor |
+| [VertexElementVertexColor](../aspose.threed/vertexelementvertexcolor) | Define el color del vértice para los componentes especificados |
+| [VertexElementVertexCrease](../aspose.threed/vertexelementvertexcrease) | Define el pliegue del vértice para los componentes especificados |
+| [VertexElementVisibility](../aspose.threed/vertexelementvisibility) | Define si los componentes especificados son visibles |
+| [VertexElementWeight](../aspose.threed/vertexelementweight) | Define el peso de mezcla para los componentes especificados. |
+| [VertexField](../aspose.threed/vertexfield) | Descripción del diseño de memoria del campo del vértice.  @hideconstructor |
+| [Viewport](../aspose.threed/viewport) | Un com.aspose.threed.IRenderTarget contiene al menos una ventana de visualización para renderizar la escena.  @hideconstructor |
+| [Watermark](../aspose.threed/watermark) | Utilidad para codificar/decodificar marca de agua ciega a/de una malla.  @hideconstructor |
+| [WindowHandle](../aspose.threed/windowhandle) | Manejador de ventana encapsulado para diferentes plataformas.  @hideconstructor |
+| [XLoadOptions](../aspose.threed/xloadoptions) | Las opciones de carga para archivos DirectX X. |
+| [ZipArchiveFileSystem](../aspose.threed/ziparchivefilesystem) | Sistema de archivos para proporcionar acceso de solo lectura al archivo zip especificado o al flujo zip.  El sistema de archivos se eliminará después de la operación de abrir/guardar. |
+| [ZShape](../aspose.threed/zshape) | Perfil en forma de Z compatible con IFC definido por parámetros. |
+| [CubeFace](../aspose.threed/cubeface) | Clase de utilidad que contiene constantes.  Cada cara de la textura del mapa cúbico  @hideconstructor |
+| [IndexDataType](../aspose.threed/indexdatatype) | Clase de utilidad que contiene constantes.  El tipo de datos de los elementos en com.aspose.threed.IIndexBuffer  @hideconstructor |

--- a/spanish/nodejs-java/aspose.threed/a3dobject/_index.md
+++ b/spanish/nodejs-java/aspose.threed/a3dobject/_index.md
@@ -1,0 +1,183 @@
+---
+title: "A3DObject"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/a3dobject/
+---
+## A3DObject class
+
+La clase base de todos los objetos Aspose.ThreeD, todas las subclases admitirán propiedades dinámicas.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor(name) | Inicializa una nueva instancia de la clase A3DObject. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| name | Cadena | Nombre |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload() | Inicializa una nueva instancia de la clase A3DObject sin nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/a3dwsaveoptions/_index.md
+++ b/spanish/nodejs-java/aspose.threed/a3dwsaveoptions/_index.md
@@ -1,0 +1,198 @@
+---
+title: "A3dwSaveOptions"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/a3dwsaveoptions/
+---
+## A3dwSaveOptions class
+
+Opciones de guardado para el formato A3DW.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Constructor de A3dwSaveOptions |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportMetaData{#getExportMetaData}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExportMetaData() | Exporta los metadatos asociados con Scene/Node al cliente. El valor predeterminado es true |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportMetaData{#setExportMetaData}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExportMetaData(value) | Exporta los metadatos asociados con Scene/Node al cliente. El valor predeterminado es true |
+
+ **Result:**
+
+
+
+---
+
+
+### getMetaDataPrefix{#getMetaDataPrefix}
+
+| Nombre | Descripción |
+| --- | --- |
+| getMetaDataPrefix() | Si esta propiedad no es nula, solo se exportarán las propiedades de Scene/Node que comiencen con este prefijo, y el prefijo será eliminado. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMetaDataPrefix{#setMetaDataPrefix}
+
+| Nombre | Descripción |
+| --- | --- |
+| setMetaDataPrefix(value) | Si esta propiedad no es nula, solo se exportarán las propiedades de Scene/Node que comiencen con este prefijo, y el prefijo será eliminado. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportTextures{#getExportTextures}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExportTextures() | Intenta copiar las texturas usadas en la escena al directorio de salida. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextures{#setExportTextures}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExportTextures(value) | Intenta copiar las texturas usadas en la escena al directorio de salida. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileFormat() | Obtiene el formato de archivo especificado en la opción actual de Guardar/Cargar. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEncoding() | Obtiene o establece la codificación predeterminada para archivos basados en texto. El valor predeterminado es null, lo que significa que el importador/exportador decidirá qué codificación usar. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileSystem() | Permite al usuario manejar cómo gestionar las dependencias externas durante la carga/guardado. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFileSystem(value) | Permite al usuario manejar cómo gestionar las dependencias externas durante la carga/guardado. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| Nombre | Descripción |
+| --- | --- |
+| getLookupPaths() | Algunos archivos como OBJ dependen de archivos externos; las rutas de búsqueda permiten que Aspose.3D busque el archivo externo para cargarlo. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileName() | El nombre de archivo de la escena de exportación/importación. Es opcional, pero útil al serializar recursos externos como el material de OBJ. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFileName(value) | El nombre de archivo de la escena de exportación/importación. Es opcional, pero útil al serializar recursos externos como el material de OBJ. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/amfsaveoptions/_index.md
+++ b/spanish/nodejs-java/aspose.threed/amfsaveoptions/_index.md
@@ -1,0 +1,172 @@
+---
+title: "AmfSaveOptions"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/amfsaveoptions/
+---
+## AmfSaveOptions class
+
+Opciones de guardado para AMF
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Constructor de AmfSaveOptions |
+
+ **Result:**
+
+
+
+---
+
+
+### getEnableCompression{#getEnableCompression}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEnableCompression() | Indica si se debe usar compresión para reducir el tamaño final del archivo, el valor predeterminado es verdadero. |
+
+ **Result:**
+
+
+
+---
+
+
+### setEnableCompression{#setEnableCompression}
+
+| Nombre | Descripción |
+| --- | --- |
+| setEnableCompression(value) | Indica si se debe usar compresión para reducir el tamaño final del archivo, el valor predeterminado es verdadero. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportTextures{#getExportTextures}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExportTextures() | Intenta copiar las texturas usadas en la escena al directorio de salida. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextures{#setExportTextures}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExportTextures(value) | Intenta copiar las texturas usadas en la escena al directorio de salida. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileFormat() | Obtiene el formato de archivo especificado en la opción actual de Guardar/Cargar. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEncoding() | Obtiene o establece la codificación predeterminada para archivos basados en texto. El valor predeterminado es null, lo que significa que el importador/exportador decidirá qué codificación usar. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileSystem() | Permite al usuario manejar cómo gestionar las dependencias externas durante la carga/guardado. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFileSystem(value) | Permite al usuario manejar cómo gestionar las dependencias externas durante la carga/guardado. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| Nombre | Descripción |
+| --- | --- |
+| getLookupPaths() | Algunos archivos como OBJ dependen de archivos externos; las rutas de búsqueda permiten que Aspose.3D busque el archivo externo para cargarlo. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileName() | El nombre de archivo de la escena de exportación/importación. Es opcional, pero útil al serializar recursos externos como el material de OBJ. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFileName(value) | El nombre de archivo de la escena de exportación/importación. Es opcional, pero útil al serializar recursos externos como el material de OBJ. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/animationchannel/_index.md
+++ b/spanish/nodejs-java/aspose.threed/animationchannel/_index.md
@@ -1,0 +1,113 @@
+---
+title: "AnimationChannel"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/animationchannel/
+---
+## AnimationChannel class
+
+Un canal asigna el campo componente de una propiedad a un conjunto de secuencias de fotogramas clave  @hideconstructor
+
+
+## Métodos
+
+### getComponentType{#getComponentType}
+
+| Nombre | Descripción |
+| --- | --- |
+| getComponentType() | Obtiene el tipo del campo del componente |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene el nombre del canal |
+
+ **Result:**
+
+
+
+---
+
+
+### getDefaultValue{#getDefaultValue}
+
+| Nombre | Descripción |
+| --- | --- |
+| getDefaultValue() | Obtiene o establece el valor predeterminado del canal. Si un canal no tiene secuencias de fotogramas clave conectadas, el valor predeterminado se utilizará durante la evaluación de la animación. Un escenario real: la animación solo anima la coordenada x de un nodo, las coordenadas y y z no se cambian, entonces el valor predeterminado se usará durante la evaluación completa de la traducción. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDefaultValue{#setDefaultValue}
+
+| Nombre | Descripción |
+| --- | --- |
+| setDefaultValue(value) | Obtiene o establece el valor predeterminado del canal. Si un canal no tiene secuencias de fotogramas clave conectadas, el valor predeterminado se utilizará durante la evaluación de la animación. Un escenario real: la animación solo anima la coordenada x de un nodo, las coordenadas y y z no se cambian, entonces el valor predeterminado se usará durante la evaluación completa de la traducción. |
+
+ **Result:**
+
+
+
+---
+
+
+### getKeyframeSequences{#getKeyframeSequences}
+
+| Nombre | Descripción |
+| --- | --- |
+| getKeyframeSequences() | Obtiene todas las secuencias de fotogramas clave dentro de este canal |
+
+ **Result:**
+
+
+
+---
+
+
+### addKeyframeSequence{#addKeyframeSequence}
+
+| Nombre | Descripción |
+| --- | --- |
+| addKeyframeSequence(sequence) | Agrega una secuencia de fotogramas clave a este canal |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| sequence | KeyframeSequence | La secuencia de fotogramas clave a agregar. |
+
+ **Result:**
+
+
+
+---
+
+
+### iterator{#iterator}
+
+| Nombre | Descripción |
+| --- | --- |
+| iterator() | Reservado para uso interno. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/animationclip/_index.md
+++ b/spanish/nodejs-java/aspose.threed/animationclip/_index.md
@@ -1,0 +1,306 @@
+---
+title: "AnimationClip"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/animationclip/
+---
+## AnimationClip class
+
+El clip de Animación es una colección de animaciones.  La escena puede tener uno o más clips de animación.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Inicializa una nueva instancia de la clase AnimationClip. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload(name) | Inicializa una nueva instancia de la clase AnimationClip. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| name | Cadena | Nombre |
+
+ **Result:**
+
+
+
+---
+
+
+### getAnimations{#getAnimations}
+
+| Nombre | Descripción |
+| --- | --- |
+| getAnimations() | Obtiene las animaciones contenidas dentro del clip. Las capas. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDescription{#getDescription}
+
+| Nombre | Descripción |
+| --- | --- |
+| getDescription() | Obtiene o establece la descripción de este clip de animación |
+
+ **Result:**
+
+
+
+---
+
+
+### setDescription{#setDescription}
+
+| Nombre | Descripción |
+| --- | --- |
+| setDescription(value) | Obtiene o establece la descripción de este clip de animación |
+
+ **Result:**
+
+
+
+---
+
+
+### getStart{#getStart}
+
+| Nombre | Descripción |
+| --- | --- |
+| getStart() | Obtiene o establece el tiempo en segundos del inicio del clip. |
+
+ **Result:**
+
+
+
+---
+
+
+### setStart{#setStart}
+
+| Nombre | Descripción |
+| --- | --- |
+| setStart(value) | Obtiene o establece el tiempo en segundos del inicio del clip. |
+
+ **Result:**
+
+
+
+---
+
+
+### getStop{#getStop}
+
+| Nombre | Descripción |
+| --- | --- |
+| getStop() | Obtiene o establece el tiempo en segundos del final del clip. |
+
+ **Result:**
+
+
+
+---
+
+
+### setStop{#setStop}
+
+| Nombre | Descripción |
+| --- | --- |
+| setStop(value) | Obtiene o establece el tiempo en segundos del final del clip. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Nombre | Descripción |
+| --- | --- |
+| getScene() | Obtiene la escena a la que pertenece este objeto |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### createAnimationNode{#createAnimationNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| createAnimationNode(nodeName) | Una función abreviada para crear y registrar el nodo de animación en el clip actual. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| nodeName | Cadena | Nombre del nuevo nodo de animación |
+
+ **Result:**
+AnimationNode
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/animationnode/_index.md
+++ b/spanish/nodejs-java/aspose.threed/animationnode/_index.md
@@ -1,0 +1,312 @@
+---
+title: "AnimationNode"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/animationnode/
+---
+## AnimationNode class
+
+Aspose.3D admite jerarquía de animación, cada animación puede estar compuesta por varias animaciones y la definición de fotogramas clave de la animación.  AnimationNode define la transformación del valor de una propiedad a lo largo del tiempo, por ejemplo, el nodo de animación puede usarse para controlar la transformación de un nodo o otras propiedades numéricas del objeto A3DObject.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor(name) | Inicializa una nueva instancia de la clase AnimationNode. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| name | Cadena | Nombre |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload() | Inicializa una nueva instancia de la clase AnimationNode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getBindPoints{#getBindPoints}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBindPoints() | Obtiene los puntos de enlace de propiedad actuales |
+
+ **Result:**
+
+
+
+---
+
+
+### getSubAnimations{#getSubAnimations}
+
+| Nombre | Descripción |
+| --- | --- |
+| getSubAnimations() | Obtiene los nodos de subanimación bajo las animaciones actuales |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### findBindPoint{#findBindPoint}
+
+| Nombre | Descripción |
+| --- | --- |
+| findBindPoint(name) | Busca el punto de enlace por nombre. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| name | Cadena | Nombre del punto de enlace a buscar. |
+
+ **Result:**
+BindPoint
+
+
+---
+
+
+### getBindPoint{#getBindPoint}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBindPoint(target, propName, create) | Obtiene el punto de enlace de animación en la propiedad dada. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| target | A3DObject | En qué objeto crear el punto de enlace. |
+| propName | Cadena | El nombre de la propiedad. |
+| crear | boolean | Si se establece en |
+
+ **Result:**
+BindPoint
+
+
+---
+
+
+### getKeyframeSequence{#getKeyframeSequence}
+
+| Nombre | Descripción |
+| --- | --- |
+| getKeyframeSequence(target, propName, channelName, create) | Obtiene la secuencia de fotogramas clave en la propiedad y canal dados. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| target | A3DObject | En qué instancia crear la secuencia de fotogramas clave. |
+| propName | Cadena | El nombre de la propiedad. |
+| channelName | Cadena | El nombre del canal. |
+| crear | boolean | Si se establece en |
+
+ **Result:**
+KeyframeSequence
+
+
+---
+
+
+### getKeyframeSequence{#getKeyframeSequence}
+
+| Nombre | Descripción |
+| --- | --- |
+| getKeyframeSequence(target, propName, create) | Obtiene la secuencia de fotogramas clave en la propiedad dada. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| target | A3DObject | En qué instancia crear la secuencia de fotogramas clave. |
+| propName | Cadena | El nombre de la propiedad. |
+| crear | boolean | Si se establece en |
+
+ **Result:**
+KeyframeSequence
+
+
+---
+
+
+### createBindPoint{#createBindPoint}
+
+| Nombre | Descripción |
+| --- | --- |
+| createBindPoint(obj, propName) | Crea un BindPoint basado en el tipo de datos de la propiedad. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| obj | A3DObject | Object. |
+| propName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+BindPoint
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/arbitraryprofile/_index.md
+++ b/spanish/nodejs-java/aspose.threed/arbitraryprofile/_index.md
@@ -1,0 +1,313 @@
+---
+title: "ArbitraryProfile"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/arbitraryprofile/
+---
+## ArbitraryProfile class
+
+Esta clase le permite construir un perfil 2D directamente a partir de una curva arbitraria.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Constructor de ArbitraryProfile |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload(curve) | Constructor de ArbitraryProfile con una curva inicial. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| curv | Curva | null |
+
+ **Result:**
+
+
+
+---
+
+
+### getCurve{#getCurve}
+
+| Nombre | Descripción |
+| --- | --- |
+| getCurve() | La Curva utilizada para construir el perfil |
+
+ **Result:**
+
+
+
+---
+
+
+### setCurve{#setCurve}
+
+| Nombre | Descripción |
+| --- | --- |
+| setCurve(value) | La Curva utilizada para construir el perfil |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNodes() | Obtiene todos los nodos padre; una entidad puede estar adjunta a varios nodos padre para la instanciación de geometría. Los nodos. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExcluded() | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExcluded(value) | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNode() | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setParentNode(value) | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Nombre | Descripción |
+| --- | --- |
+| getScene() | Obtiene la escena a la que pertenece este objeto |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEntityRendererKey() | Obtiene la clave del renderizador de entidad registrado en el renderizador |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBoundingBox() | Obtiene el cuadro delimitador de la entidad actual en su sistema de coordenadas de espacio de objeto. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/assetinfo/_index.md
+++ b/spanish/nodejs-java/aspose.threed/assetinfo/_index.md
@@ -1,0 +1,586 @@
+---
+title: "AssetInfo"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/assetinfo/
+---
+## AssetInfo class
+
+Información del activo.  La información del activo puede adjuntarse a una Escena.  La Escena hija puede tener su propio AssetInfo para sobrescribir la definición del padre.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Inicializa una nueva instancia de la clase AssetInfo. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload(name) | Inicializa una nueva instancia de la clase AssetInfo. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| name | Cadena | Nombre |
+
+ **Result:**
+
+
+
+---
+
+
+### getCreationTime{#getCreationTime}
+
+| Nombre | Descripción |
+| --- | --- |
+| getCreationTime() | Obtiene o establece la hora de creación de este activo |
+
+ **Result:**
+
+
+
+---
+
+
+### getModificationTime{#getModificationTime}
+
+| Nombre | Descripción |
+| --- | --- |
+| getModificationTime() | Obtiene o establece la hora de modificación de este activo |
+
+ **Result:**
+
+
+
+---
+
+
+### getAmbient{#getAmbient}
+
+| Nombre | Descripción |
+| --- | --- |
+| getAmbient() | Obtiene o establece el color ambiental predeterminado de este activo |
+
+ **Result:**
+
+
+
+---
+
+
+### getUrl{#getUrl}
+
+| Nombre | Descripción |
+| --- | --- |
+| getUrl() | Obtiene o establece la URL de este activo. |
+
+ **Result:**
+
+
+
+---
+
+
+### setUrl{#setUrl}
+
+| Nombre | Descripción |
+| --- | --- |
+| setUrl(value) | Obtiene o establece la URL de este activo. |
+
+ **Result:**
+
+
+
+---
+
+
+### getApplicationVendor{#getApplicationVendor}
+
+| Nombre | Descripción |
+| --- | --- |
+| getApplicationVendor() | Obtiene o establece el nombre del proveedor de la aplicación |
+
+ **Result:**
+
+
+
+---
+
+
+### setApplicationVendor{#setApplicationVendor}
+
+| Nombre | Descripción |
+| --- | --- |
+| setApplicationVendor(value) | Obtiene o establece el nombre del proveedor de la aplicación |
+
+ **Result:**
+
+
+
+---
+
+
+### getCopyright{#getCopyright}
+
+| Nombre | Descripción |
+| --- | --- |
+| getCopyright() | Obtiene o establece los derechos de autor del documento |
+
+ **Result:**
+
+
+
+---
+
+
+### setCopyright{#setCopyright}
+
+| Nombre | Descripción |
+| --- | --- |
+| setCopyright(value) | Obtiene o establece los derechos de autor del documento |
+
+ **Result:**
+
+
+
+---
+
+
+### getApplicationName{#getApplicationName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getApplicationName() | Obtiene o establece la aplicación que creó este activo |
+
+ **Result:**
+
+
+
+---
+
+
+### setApplicationName{#setApplicationName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setApplicationName(value) | Obtiene o establece la aplicación que creó este activo |
+
+ **Result:**
+
+
+
+---
+
+
+### getApplicationVersion{#getApplicationVersion}
+
+| Nombre | Descripción |
+| --- | --- |
+| getApplicationVersion() | Obtiene o establece la versión de la aplicación que creó este activo. |
+
+ **Result:**
+
+
+
+---
+
+
+### setApplicationVersion{#setApplicationVersion}
+
+| Nombre | Descripción |
+| --- | --- |
+| setApplicationVersion(value) | Obtiene o establece la versión de la aplicación que creó este activo. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTitle{#getTitle}
+
+| Nombre | Descripción |
+| --- | --- |
+| getTitle() | Obtiene o establece el título de este activo |
+
+ **Result:**
+
+
+
+---
+
+
+### setTitle{#setTitle}
+
+| Nombre | Descripción |
+| --- | --- |
+| setTitle(value) | Obtiene o establece el título de este activo |
+
+ **Result:**
+
+
+
+---
+
+
+### getSubject{#getSubject}
+
+| Nombre | Descripción |
+| --- | --- |
+| getSubject() | Obtiene o establece el asunto de este activo |
+
+ **Result:**
+
+
+
+---
+
+
+### setSubject{#setSubject}
+
+| Nombre | Descripción |
+| --- | --- |
+| setSubject(value) | Obtiene o establece el asunto de este activo |
+
+ **Result:**
+
+
+
+---
+
+
+### getAuthor{#getAuthor}
+
+| Nombre | Descripción |
+| --- | --- |
+| getAuthor() | Obtiene o establece el autor de este activo |
+
+ **Result:**
+
+
+
+---
+
+
+### setAuthor{#setAuthor}
+
+| Nombre | Descripción |
+| --- | --- |
+| setAuthor(value) | Obtiene o establece el autor de este activo |
+
+ **Result:**
+
+
+
+---
+
+
+### getKeywords{#getKeywords}
+
+| Nombre | Descripción |
+| --- | --- |
+| getKeywords() | Obtiene o establece las palabras clave de este activo |
+
+ **Result:**
+
+
+
+---
+
+
+### setKeywords{#setKeywords}
+
+| Nombre | Descripción |
+| --- | --- |
+| setKeywords(value) | Obtiene o establece las palabras clave de este activo |
+
+ **Result:**
+
+
+
+---
+
+
+### getRevision{#getRevision}
+
+| Nombre | Descripción |
+| --- | --- |
+| getRevision() | Obtiene o establece el número de revisión de este activo, normalmente usado en sistemas de control de versiones. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRevision{#setRevision}
+
+| Nombre | Descripción |
+| --- | --- |
+| setRevision(value) | Obtiene o establece el número de revisión de este activo, normalmente usado en sistemas de control de versiones. |
+
+ **Result:**
+
+
+
+---
+
+
+### getComment{#getComment}
+
+| Nombre | Descripción |
+| --- | --- |
+| getComment() | Obtiene o establece el comentario de este activo. |
+
+ **Result:**
+
+
+
+---
+
+
+### setComment{#setComment}
+
+| Nombre | Descripción |
+| --- | --- |
+| setComment(value) | Obtiene o establece el comentario de este activo. |
+
+ **Result:**
+
+
+
+---
+
+
+### getUnitName{#getUnitName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getUnitName() | Obtiene o establece la unidad de longitud usada en este activo. p. ej. cm/m/km/pulgada/pies |
+
+ **Result:**
+
+
+
+---
+
+
+### setUnitName{#setUnitName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setUnitName(value) | Obtiene o establece la unidad de longitud usada en este activo. p. ej. cm/m/km/pulgada/pies |
+
+ **Result:**
+
+
+
+---
+
+
+### getUnitScaleFactor{#getUnitScaleFactor}
+
+| Nombre | Descripción |
+| --- | --- |
+| getUnitScaleFactor() | Obtiene o establece el factor de escala al metro del mundo real. Esto se ignora durante la serialización si el nombre de la unidad es nulo. |
+
+ **Result:**
+
+
+
+---
+
+
+### setUnitScaleFactor{#setUnitScaleFactor}
+
+| Nombre | Descripción |
+| --- | --- |
+| setUnitScaleFactor(value) | Obtiene o establece el factor de escala al metro del mundo real. Esto se ignora durante la serialización si el nombre de la unidad es nulo. |
+
+ **Result:**
+
+
+
+---
+
+
+### getCoordinatedSystem{#getCoordinatedSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| getCoordinatedSystem() | Obtiene o establece el sistema de coordenadas usado en este recurso. |
+
+ **Result:**
+
+
+
+---
+
+
+### getUpVector{#getUpVector}
+
+| Nombre | Descripción |
+| --- | --- |
+| getUpVector() | Obtiene o establece el vector ascendente usado en este recurso. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/bindpoint/_index.md
+++ b/spanish/nodejs-java/aspose.threed/bindpoint/_index.md
@@ -1,0 +1,386 @@
+---
+title: "BindPoint"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/bindpoint/
+---
+## BindPoint class
+
+Un BindPoint suele crearse en la propiedad de un objeto, algunos tipos de propiedad contienen múltiples campos componentes (como un campo Vector3),  BindPoint generará un canal para cada campo componente y conectará el campo a una o más instancias de secuencia de fotogramas clave a través de los canales.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor(scene, prop) | Inicializa una nueva instancia de la clase BindPoint. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| escena | Scene | La escena que contiene la animación. |
+| prop | Property | Propiedad. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty() | Obtiene la propiedad asociada con CurveMapping |
+
+ **Result:**
+
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(value) | Obtiene la propiedad asociada con CurveMapping |
+
+ **Result:**
+
+
+
+---
+
+
+### getChannelsCount{#getChannelsCount}
+
+| Nombre | Descripción |
+| --- | --- |
+| getChannelsCount() | Obtiene el número total de canales de propiedad definidos en este mapeo de curva de animación. |
+
+ **Result:**
+Número
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+Número
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+Número
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+Número
+
+
+---
+
+
+### get{#get}
+
+| Nombre | Descripción |
+| --- | --- |
+| get(channelName) |  |
+
+ **Result:**
+Número
+
+
+---
+
+
+### getKeyframeSequence{#getKeyframeSequence}
+
+| Nombre | Descripción |
+| --- | --- |
+| getKeyframeSequence(channelName) | Obtiene la primera secuencia de fotogramas clave en el canal especificado |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| channelName | Cadena | El nombre del canal a buscar |
+
+ **Result:**
+KeyframeSequence
+
+
+---
+
+
+### getKeyframeSequences{#getKeyframeSequences}
+
+| Nombre | Descripción |
+| --- | --- |
+| getKeyframeSequences(channelName) | Obtiene todas las secuencias de fotogramas clave en el canal especificado |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| channelName | Cadena | El nombre del canal a buscar |
+
+ **Result:**
+0, Culture=neutral, PublicKeyToken=f071c641d0b4582b]]
+
+
+---
+
+
+### createKeyframeSequence{#createKeyframeSequence}
+
+| Nombre | Descripción |
+| --- | --- |
+| createKeyframeSequence(name) | Crea una nueva curva y la conecta al primer canal del mapeo de curvas |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| name | Cadena | El nombre de la nueva secuencia. |
+
+ **Result:**
+KeyframeSequence
+
+
+---
+
+
+### bindKeyframeSequence{#bindKeyframeSequence}
+
+| Nombre | Descripción |
+| --- | --- |
+| bindKeyframeSequence(channelName, sequence) | Vincula la secuencia de fotogramas clave al canal especificado |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| channelName | Cadena | A qué canal se vinculará la secuencia de fotogramas clave |
+| sequence | KeyframeSequence | La secuencia de fotogramas clave a vincular |
+
+ **Result:**
+KeyframeSequence
+
+
+---
+
+
+### getChannel{#getChannel}
+
+| Nombre | Descripción |
+| --- | --- |
+| getChannel(channelName) | Obtiene el canal por el nombre dado |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| channelName | Cadena | El nombre del canal a buscar |
+
+ **Result:**
+AnimationChannel
+
+
+---
+
+
+### addChannel{#addChannel}
+
+| Nombre | Descripción |
+| --- | --- |
+| addChannel(name, value) | Agrega la propiedad de canal especificada. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| name | Cadena | Nombre. |
+| valor | Objeto | Valor. |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### addChannel{#addChannel}
+
+| Nombre | Descripción |
+| --- | --- |
+| addChannel(name, type, value) | Agrega la propiedad de canal especificada. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| name | Cadena | Nombre. |
+| type | Clase | Tipo. |
+| valor | Objeto | Valor. |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### resetChannels{#resetChannels}
+
+| Nombre | Descripción |
+| --- | --- |
+| resetChannels() | Vacía los canales de propiedades de este mapeo de curvas de animación. |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### toString{#toString}
+
+| Nombre | Descripción |
+| --- | --- |
+| toString() | Formatea el objeto a cadena |
+
+ **Result:**
+Cadena
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/bone/_index.md
+++ b/spanish/nodejs-java/aspose.threed/bone/_index.md
@@ -1,0 +1,339 @@
+---
+title: "Bone"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/bone/
+---
+## Bone class
+
+Un hueso define el subconjunto del punto de control de la geometría y el peso de mezcla definido para cada punto de control.  El objeto Bone no puede usarse directamente, se utiliza una instancia de SkinDeformer para deformar la geometría, y SkinDeformer viene con un conjunto de huesos, cada hueso vinculado a un nodo.  NOTA: Un punto de control de una geometría puede estar vinculado a más de un Bone.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor(name) | Inicializa una nueva instancia de la clase Bone. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| name | Cadena | Nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload() | Inicializa una nueva instancia de la clase Bone. |
+
+ **Result:**
+
+
+
+---
+
+
+### getWeightCount{#getWeightCount}
+
+| Nombre | Descripción |
+| --- | --- |
+| getWeightCount() | Obtiene el recuento de pesos, esto se amplía automáticamente mediante setWeight(int, double) |
+
+ **Result:**
+
+
+
+---
+
+
+### getTransform{#getTransform}
+
+| Nombre | Descripción |
+| --- | --- |
+| getTransform() | Obtiene o establece la matriz de transformación del nodo que contiene el bone. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTransform{#setTransform}
+
+| Nombre | Descripción |
+| --- | --- |
+| setTransform(value) | Obtiene o establece la matriz de transformación del nodo que contiene el bone. |
+
+ **Result:**
+
+
+
+---
+
+
+### getBoneTransform{#getBoneTransform}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBoneTransform() | Obtiene o establece la matriz de transformación del bone. |
+
+ **Result:**
+
+
+
+---
+
+
+### setBoneTransform{#setBoneTransform}
+
+| Nombre | Descripción |
+| --- | --- |
+| setBoneTransform(value) | Obtiene o establece la matriz de transformación del bone. |
+
+ **Result:**
+
+
+
+---
+
+
+### getNode{#getNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getNode() | Obtiene o establece el nodo. El nodo bone es el bone al que se adjunta la piel, el SkinDeformer usará el nodo bone para influir en el desplazamiento de los puntos de control. El nodo bone suele tener un Skeleton adjunto, pero no es obligatorio. El Skeleton adjunto suele ser usado por el software DCC para mostrar el esqueleto al usuario. |
+
+ **Result:**
+
+
+
+---
+
+
+### setNode{#setNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setNode(value) | Obtiene o establece el nodo. El nodo bone es el bone al que se adjunta la piel, el SkinDeformer usará el nodo bone para influir en el desplazamiento de los puntos de control. El nodo bone suele tener un Skeleton adjunto, pero no es obligatorio. El Skeleton adjunto suele ser usado por el software DCC para mostrar el esqueleto al usuario. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### get{#get}
+
+| Nombre | Descripción |
+| --- | --- |
+| get(index) |  |
+
+ **Result:**
+
+
+
+---
+
+
+### set{#set}
+
+| Nombre | Descripción |
+| --- | --- |
+| set(index, value) |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getWeight{#getWeight}
+
+| Nombre | Descripción |
+| --- | --- |
+| getWeight(index) | Obtiene el peso del punto de control especificado por el índice |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| index | Número | Índice del punto de control |
+
+ **Result:**
+Número
+
+
+---
+
+
+### setWeight{#setWeight}
+
+| Nombre | Descripción |
+| --- | --- |
+| setWeight(index, weight) | Establece el peso para el punto de control especificado por el índice |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| index | Número | Índice del punto de control |
+| peso | Número | Nuevo peso |
+
+ **Result:**
+Número
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/bonepose/_index.md
+++ b/spanish/nodejs-java/aspose.threed/bonepose/_index.md
@@ -1,0 +1,107 @@
+---
+title: "BonePose"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/bonepose/
+---
+## BonePose class
+
+El BonePose contiene la matriz de transformación para un nodo de hueso
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getNode{#getNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getNode() | Obtiene o establece el nodo de la escena, apunta a un nodo de esqueleto con piel |
+
+ **Result:**
+
+
+
+---
+
+
+### setNode{#setNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setNode(value) | Obtiene o establece el nodo de la escena, apunta a un nodo de esqueleto con piel |
+
+ **Result:**
+
+
+
+---
+
+
+### getMatrix{#getMatrix}
+
+| Nombre | Descripción |
+| --- | --- |
+| getMatrix() | Obtiene o establece la matriz de transformación del nodo en la pose actual. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMatrix{#setMatrix}
+
+| Nombre | Descripción |
+| --- | --- |
+| setMatrix(value) | Obtiene o establece la matriz de transformación del nodo en la pose actual. |
+
+ **Result:**
+
+
+
+---
+
+
+### isLocal{#isLocal}
+
+| Nombre | Descripción |
+| --- | --- |
+| isLocal() | Obtiene o establece si la matriz está definida en coordenadas locales. true si esta instancia está en espacio local; de lo contrario, false significa espacio global. |
+
+ **Result:**
+
+
+
+---
+
+
+### setLocal{#setLocal}
+
+| Nombre | Descripción |
+| --- | --- |
+| setLocal(value) | Obtiene o establece si la matriz está definida en coordenadas locales. true si esta instancia está en espacio local; de lo contrario, false significa espacio global. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/boundingbox/_index.md
+++ b/spanish/nodejs-java/aspose.threed/boundingbox/_index.md
@@ -1,0 +1,198 @@
+---
+title: "BoundingBox"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/boundingbox/
+---
+## BoundingBox class
+
+El cuadro delimitador alineado a los ejes
+
+
+## Propiedades
+
+| Nombre | Descripción |
+| --- | --- |
+| NULL | La caja delimitadora nula |
+| INFINITE | La caja delimitadora infinita |
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload(minimum, maximum) | Inicializa una caja delimitadora finita con la esquina mínima y máxima dadas |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| minimum | Vector3 | La esquina mínima |
+| maximum | Vector3 | La esquina máxima |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload2(minX, minY, minZ, maxX, maxY, maxZ) | Inicializa una caja delimitadora finita con la esquina mínima y máxima dadas |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtent{#getExtent}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExtent() | Obtiene la extensión de la caja delimitadora. El valor de la propiedad es la constante entera BoundingBoxExtent. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMinimum{#getMinimum}
+
+| Nombre | Descripción |
+| --- | --- |
+| getMinimum() | La esquina mínima de la caja delimitadora |
+
+ **Result:**
+
+
+
+---
+
+
+### getMaximum{#getMaximum}
+
+| Nombre | Descripción |
+| --- | --- |
+| getMaximum() | La esquina máxima de la caja delimitadora |
+
+ **Result:**
+
+
+
+---
+
+
+### getSize{#getSize}
+
+| Nombre | Descripción |
+| --- | --- |
+| getSize() | El tamaño del cuadro delimitador |
+
+ **Result:**
+
+
+
+---
+
+
+### getCenter{#getCenter}
+
+| Nombre | Descripción |
+| --- | --- |
+| getCenter() | El centro del cuadro delimitador. |
+
+ **Result:**
+
+
+
+---
+
+
+### fromGeometry{#fromGeometry}
+
+| Nombre | Descripción |
+| --- | --- |
+| fromGeometry(geometry) | Construir un cuadro delimitador a partir de la geometría dada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| geometría | Geometría | null |
+
+ **Result:**
+BoundingBox
+
+
+---
+
+
+### toString{#toString}
+
+| Nombre | Descripción |
+| --- | --- |
+| toString() | Obtiene la representación en cadena del cuadro delimitador. |
+
+ **Result:**
+Cadena
+
+
+---
+
+
+### hashCode{#hashCode}
+
+| Nombre | Descripción |
+| --- | --- |
+| hashCode() | Devuelve el código hash para esta instancia |
+
+ **Result:**
+Número
+
+
+---
+
+
+### equals{#equals}
+
+| Nombre | Descripción |
+| --- | --- |
+| equals(obj) | Determina si dos objetos son iguales |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| ob | Objeto | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/boundingbox2d/_index.md
+++ b/spanish/nodejs-java/aspose.threed/boundingbox2d/_index.md
@@ -1,0 +1,146 @@
+---
+title: "BoundingBox2D"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/boundingbox2d/
+---
+## BoundingBox2D class
+
+El cuadro delimitador alineado a los ejes para Vector2
+
+
+## Propiedades
+
+| Nombre | Descripción |
+| --- | --- |
+| NULL | La caja delimitadora nula |
+| INFINITE | La caja delimitadora infinita |
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload(minimum, maximum) | Inicializa una caja delimitadora finita con la esquina mínima y máxima dadas |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| minimum | Vector2 | La esquina mínima |
+| maximum | Vector2 | La esquina máxima |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtent{#getExtent}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExtent() | Obtiene la extensión de la caja delimitadora. El valor de la propiedad es la constante entera BoundingBoxExtent. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMinimum{#getMinimum}
+
+| Nombre | Descripción |
+| --- | --- |
+| getMinimum() | La esquina mínima de la caja delimitadora |
+
+ **Result:**
+
+
+
+---
+
+
+### getMaximum{#getMaximum}
+
+| Nombre | Descripción |
+| --- | --- |
+| getMaximum() | La esquina máxima de la caja delimitadora |
+
+ **Result:**
+
+
+
+---
+
+
+### merge{#merge}
+
+| Nombre | Descripción |
+| --- | --- |
+| merge(pt) | Fusiona la nueva caja en la caja delimitadora actual. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| p | Vector2 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### merge{#merge}
+
+| Nombre | Descripción |
+| --- | --- |
+| merge(bb) | Fusiona la nueva caja en la caja delimitadora actual. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| b | BoundingBox2D | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| Nombre | Descripción |
+| --- | --- |
+| toString() | Obtiene la representación en cadena del cuadro delimitador. |
+
+ **Result:**
+Cadena
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/box/_index.md
+++ b/spanish/nodejs-java/aspose.threed/box/_index.md
@@ -1,0 +1,535 @@
+---
+title: "Box"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/box/
+---
+## Box class
+
+Caja.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Inicializa una nueva instancia de la clase Box. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload(length, width, height) | Inicializa una nueva instancia de la clase Box. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| length | Número | Longitud de la caja alineada en el eje z. |
+| ancho | Número | Ancho de la caja alineada en el eje x. |
+| height | Número | Altura de la caja alineada en el eje y. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload2(name, length, width, height, lengthSegments, widthSegments, heightSegments) | Inicializa una nueva instancia de la clase Box. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| name | Cadena | Nombre de la caja. |
+| length | Número | Longitud de la caja alineada en el eje z. |
+| ancho | Número | Ancho de la caja alineada en el eje x. |
+| height | Número | Altura de la caja alineada en el eje y. |
+| lengthSegments | Número | Segmentos de longitud. |
+| widthSegments | Número | Segmentos de ancho. |
+| heightSegments | Número | Segmentos de altura. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLengthSegments{#getLengthSegments}
+
+| Nombre | Descripción |
+| --- | --- |
+| getLengthSegments() | Obtiene o establece los segmentos de longitud. |
+
+ **Result:**
+
+
+
+---
+
+
+### setLengthSegments{#setLengthSegments}
+
+| Nombre | Descripción |
+| --- | --- |
+| setLengthSegments(value) | Obtiene o establece los segmentos de longitud. |
+
+ **Result:**
+
+
+
+---
+
+
+### getWidthSegments{#getWidthSegments}
+
+| Nombre | Descripción |
+| --- | --- |
+| getWidthSegments() | Obtiene o establece los segmentos de ancho |
+
+ **Result:**
+
+
+
+---
+
+
+### setWidthSegments{#setWidthSegments}
+
+| Nombre | Descripción |
+| --- | --- |
+| setWidthSegments(value) | Obtiene o establece los segmentos de ancho |
+
+ **Result:**
+
+
+
+---
+
+
+### getHeightSegments{#getHeightSegments}
+
+| Nombre | Descripción |
+| --- | --- |
+| getHeightSegments() | Obtiene o establece los segmentos de altura. |
+
+ **Result:**
+
+
+
+---
+
+
+### setHeightSegments{#setHeightSegments}
+
+| Nombre | Descripción |
+| --- | --- |
+| setHeightSegments(value) | Obtiene o establece los segmentos de altura. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLength{#getLength}
+
+| Nombre | Descripción |
+| --- | --- |
+| getLength() | Obtiene o establece la longitud de la caja alineada en el eje z. La longitud alineada en el eje z. |
+
+ **Result:**
+
+
+
+---
+
+
+### setLength{#setLength}
+
+| Nombre | Descripción |
+| --- | --- |
+| setLength(value) | Obtiene o establece la longitud de la caja alineada en el eje z. La longitud alineada en el eje z. |
+
+ **Result:**
+
+
+
+---
+
+
+### getWidth{#getWidth}
+
+| Nombre | Descripción |
+| --- | --- |
+| getWidth() | Obtiene o establece el ancho de la caja alineada en el eje x. El ancho alineado en el eje x. |
+
+ **Result:**
+
+
+
+---
+
+
+### setWidth{#setWidth}
+
+| Nombre | Descripción |
+| --- | --- |
+| setWidth(value) | Obtiene o establece el ancho de la caja alineada en el eje x. El ancho alineado en el eje x. |
+
+ **Result:**
+
+
+
+---
+
+
+### getHeight{#getHeight}
+
+| Nombre | Descripción |
+| --- | --- |
+| getHeight() | Obtiene o establece la altura de la caja alineada en el eje y. La altura alineada en el eje y. |
+
+ **Result:**
+
+
+
+---
+
+
+### setHeight{#setHeight}
+
+| Nombre | Descripción |
+| --- | --- |
+| setHeight(value) | Obtiene o establece la altura de la caja alineada en el eje y. La altura alineada en el eje y. |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastShadows{#getCastShadows}
+
+| Nombre | Descripción |
+| --- | --- |
+| getCastShadows() | Obtiene o establece si esta geometría puede proyectar sombra |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastShadows{#setCastShadows}
+
+| Nombre | Descripción |
+| --- | --- |
+| setCastShadows(value) | Obtiene o establece si esta geometría puede proyectar sombra |
+
+ **Result:**
+
+
+
+---
+
+
+### getReceiveShadows{#getReceiveShadows}
+
+| Nombre | Descripción |
+| --- | --- |
+| getReceiveShadows() | Obtiene o establece si esta geometría puede recibir sombra. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReceiveShadows{#setReceiveShadows}
+
+| Nombre | Descripción |
+| --- | --- |
+| setReceiveShadows(value) | Obtiene o establece si esta geometría puede recibir sombra. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNodes() | Obtiene todos los nodos padre; una entidad puede estar adjunta a varios nodos padre para la instanciación de geometría. Los nodos. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExcluded() | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExcluded(value) | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNode() | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setParentNode(value) | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Nombre | Descripción |
+| --- | --- |
+| getScene() | Obtiene la escena a la que pertenece este objeto |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### toMesh{#toMesh}
+
+| Nombre | Descripción |
+| --- | --- |
+| toMesh() | Convertir el objeto actual a malla |
+
+ **Result:**
+Malla
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBoundingBox() | Obtiene el cuadro delimitador de la entidad actual en su sistema de coordenadas de espacio de objeto. |
+
+ **Result:**
+Malla
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEntityRendererKey() | Obtiene la clave del renderizador de entidad registrado en el renderizador |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/camera/_index.md
+++ b/spanish/nodejs-java/aspose.threed/camera/_index.md
@@ -1,0 +1,813 @@
+---
+title: "Cámara"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/camera/
+---
+## Camera class
+
+La cámara describe el punto de vista del observador que mira la escena.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Inicializa una nueva instancia de la clase Camera. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload(projectionType) | Inicializa una nueva instancia de la clase Camera. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| projectionType | ProjectionType | ProjectionType |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload2(name) | Inicializa una nueva instancia de la clase Camera. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| name | Cadena | Nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload3{#constructor_overload3}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload3(name, projectionType) | Inicializa una nueva instancia de la clase Camera. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| name | Cadena | Nombre. |
+| projectionType | ProjectionType | ProjectionType |
+
+ **Result:**
+
+
+
+---
+
+
+### getApertureMode{#getApertureMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getApertureMode() | Obtiene o establece el modo de apertura de la cámara. El valor de la propiedad es la constante entera ApertureMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setApertureMode{#setApertureMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setApertureMode(value) | Obtiene o establece el modo de apertura de la cámara. El valor de la propiedad es la constante entera ApertureMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFieldOfView{#getFieldOfView}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFieldOfView() | Obtiene o establece el campo de visión de la cámara en grados; esta propiedad se usa solo cuando ApertureMode es ApertureMode.HORIZONTAL o ApertureMode.VERTICAL |
+
+ **Result:**
+
+
+
+---
+
+
+### setFieldOfView{#setFieldOfView}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFieldOfView(value) | Obtiene o establece el campo de visión de la cámara en grados; esta propiedad se usa solo cuando ApertureMode es ApertureMode.HORIZONTAL o ApertureMode.VERTICAL |
+
+ **Result:**
+
+
+
+---
+
+
+### getFieldOfViewX{#getFieldOfViewX}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFieldOfViewX() | Obtiene o establece el campo de visión horizontal de la cámara en grados; esta propiedad se usa solo cuando ApertureMode es ApertureMode.HORIZ_AND_VERT |
+
+ **Result:**
+
+
+
+---
+
+
+### setFieldOfViewX{#setFieldOfViewX}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFieldOfViewX(value) | Obtiene o establece el campo de visión horizontal de la cámara en grados; esta propiedad se usa solo cuando ApertureMode es ApertureMode.HORIZ_AND_VERT |
+
+ **Result:**
+
+
+
+---
+
+
+### getFieldOfViewY{#getFieldOfViewY}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFieldOfViewY() | Obtiene o establece el campo de visión vertical de la cámara en grados; esta propiedad se usa solo cuando ApertureMode es ApertureMode.HORIZ_AND_VERT |
+
+ **Result:**
+
+
+
+---
+
+
+### setFieldOfViewY{#setFieldOfViewY}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFieldOfViewY(value) | Obtiene o establece el campo de visión vertical de la cámara en grados; esta propiedad se usa solo cuando ApertureMode es ApertureMode.HORIZ_AND_VERT |
+
+ **Result:**
+
+
+
+---
+
+
+### getWidth{#getWidth}
+
+| Nombre | Descripción |
+| --- | --- |
+| getWidth() | Obtiene o establece el ancho del plano de visión medido en pulgadas. |
+
+ **Result:**
+
+
+
+---
+
+
+### setWidth{#setWidth}
+
+| Nombre | Descripción |
+| --- | --- |
+| setWidth(value) | Obtiene o establece el ancho del plano de visión medido en pulgadas. |
+
+ **Result:**
+
+
+
+---
+
+
+### getHeight{#getHeight}
+
+| Nombre | Descripción |
+| --- | --- |
+| getHeight() | Obtiene o establece la altura del plano de visión medido en pulgadas. |
+
+ **Result:**
+
+
+
+---
+
+
+### setHeight{#setHeight}
+
+| Nombre | Descripción |
+| --- | --- |
+| setHeight(value) | Obtiene o establece la altura del plano de visión medido en pulgadas. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAspectRatio{#getAspectRatio}
+
+| Nombre | Descripción |
+| --- | --- |
+| getAspectRatio() | Obtiene o establece la relación de aspecto del plano de visión. |
+
+ **Result:**
+
+
+
+---
+
+
+### setAspectRatio{#setAspectRatio}
+
+| Nombre | Descripción |
+| --- | --- |
+| setAspectRatio(value) | Obtiene o establece la relación de aspecto del plano de visión. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMagnification{#getMagnification}
+
+| Nombre | Descripción |
+| --- | --- |
+| getMagnification() | Obtiene o establece la ampliación utilizada en la cámara ortográfica. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMagnification{#setMagnification}
+
+| Nombre | Descripción |
+| --- | --- |
+| setMagnification(value) | Obtiene o establece la ampliación utilizada en la cámara ortográfica. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProjectionType{#getProjectionType}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProjectionType() | Obtiene o establece el tipo de proyección de la cámara. Por defecto se utiliza la proyección en perspectiva. El valor de la propiedad es la constante entera ProjectionType. |
+
+ **Result:**
+
+
+
+---
+
+
+### setProjectionType{#setProjectionType}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProjectionType(value) | Obtiene o establece el tipo de proyección de la cámara. Por defecto se utiliza la proyección en perspectiva. El valor de la propiedad es la constante entera ProjectionType. |
+
+ **Result:**
+
+
+
+---
+
+
+### getRotationMode{#getRotationMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getRotationMode() | Obtiene o establece el modo de orientación del frustum. Esta propiedad solo funciona cuando Target es nulo. Si el valor es RotationMode.FIXED_TARGET, la dirección siempre se calcula mediante la propiedad LookAt. De lo contrario, LookAt siempre se calcula mediante Direction. El valor de la propiedad es la constante entera RotationMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRotationMode{#setRotationMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setRotationMode(value) | Obtiene o establece el modo de orientación del frustum. Esta propiedad solo funciona cuando Target es nulo. Si el valor es RotationMode.FIXED_TARGET, la dirección siempre se calcula mediante la propiedad LookAt. De lo contrario, LookAt siempre se calcula mediante Direction. El valor de la propiedad es la constante entera RotationMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getNearPlane{#getNearPlane}
+
+| Nombre | Descripción |
+| --- | --- |
+| getNearPlane() | Obtiene o establece la distancia del plano cercano del frustum. |
+
+ **Result:**
+
+
+
+---
+
+
+### setNearPlane{#setNearPlane}
+
+| Nombre | Descripción |
+| --- | --- |
+| setNearPlane(value) | Obtiene o establece la distancia del plano cercano del frustum. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFarPlane{#getFarPlane}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFarPlane() | Obtiene o establece la distancia del plano lejano del frustum. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFarPlane{#setFarPlane}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFarPlane(value) | Obtiene o establece la distancia del plano lejano del frustum. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAspect{#getAspect}
+
+| Nombre | Descripción |
+| --- | --- |
+| getAspect() | Obtiene o establece la relación de aspecto del frustum |
+
+ **Result:**
+
+
+
+---
+
+
+### setAspect{#setAspect}
+
+| Nombre | Descripción |
+| --- | --- |
+| setAspect(value) | Obtiene o establece la relación de aspecto del frustum |
+
+ **Result:**
+
+
+
+---
+
+
+### getOrthoHeight{#getOrthoHeight}
+
+| Nombre | Descripción |
+| --- | --- |
+| getOrthoHeight() | Obtiene o establece la altura cuando el frustum está en proyección ortográfica. |
+
+ **Result:**
+
+
+
+---
+
+
+### setOrthoHeight{#setOrthoHeight}
+
+| Nombre | Descripción |
+| --- | --- |
+| setOrthoHeight(value) | Obtiene o establece la altura cuando el frustum está en proyección ortográfica. |
+
+ **Result:**
+
+
+
+---
+
+
+### getUp{#getUp}
+
+| Nombre | Descripción |
+| --- | --- |
+| getUp() | Obtiene o establece la dirección ascendente de la cámara |
+
+ **Result:**
+
+
+
+---
+
+
+### setUp{#setUp}
+
+| Nombre | Descripción |
+| --- | --- |
+| setUp(value) | Obtiene o establece la dirección ascendente de la cámara |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookAt{#getLookAt}
+
+| Nombre | Descripción |
+| --- | --- |
+| getLookAt() | Obtiene o establece la posición de interés a la que la cámara está mirando. |
+
+ **Result:**
+
+
+
+---
+
+
+### setLookAt{#setLookAt}
+
+| Nombre | Descripción |
+| --- | --- |
+| setLookAt(value) | Obtiene o establece la posición de interés a la que la cámara está mirando. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDirection{#getDirection}
+
+| Nombre | Descripción |
+| --- | --- |
+| getDirection() | Obtiene o establece la dirección a la que la cámara está mirando. Los cambios en esta propiedad también afectarán a LookAt y Target. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDirection{#setDirection}
+
+| Nombre | Descripción |
+| --- | --- |
+| setDirection(value) | Obtiene o establece la dirección a la que la cámara está mirando. Los cambios en esta propiedad también afectarán a LookAt y Target. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTarget{#getTarget}
+
+| Nombre | Descripción |
+| --- | --- |
+| getTarget() | Obtiene o establece el objetivo al que la cámara está mirando. Si el usuario admite esta propiedad, debe ser anterior a la propiedad LookAt. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTarget{#setTarget}
+
+| Nombre | Descripción |
+| --- | --- |
+| setTarget(value) | Obtiene o establece el objetivo al que la cámara está mirando. Si el usuario admite esta propiedad, debe ser anterior a la propiedad LookAt. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNodes() | Obtiene todos los nodos padre; una entidad puede estar adjunta a varios nodos padre para la instanciación de geometría. Los nodos. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExcluded() | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExcluded(value) | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNode() | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setParentNode(value) | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Nombre | Descripción |
+| --- | --- |
+| getScene() | Obtiene la escena a la que pertenece este objeto |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### moveForward{#moveForward}
+
+| Nombre | Descripción |
+| --- | --- |
+| moveForward(distance) | Mueve la cámara hacia adelante en su dirección o objetivo. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| distancia | Número | Cuánto tiempo mover hacia adelante |
+
+ **Result:**
+
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBoundingBox() | Obtiene el cuadro delimitador de la entidad actual en su sistema de coordenadas de espacio de objeto. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEntityRendererKey() | Obtiene la clave del renderizador de entidad registrado en el renderizador |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/circle/_index.md
+++ b/spanish/nodejs-java/aspose.threed/circle/_index.md
@@ -1,0 +1,339 @@
+---
+title: "Circle"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/circle/
+---
+## Circle class
+
+Una curva Círculo consiste en un conjunto de puntos en el borde de la forma circular.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Constructor de Circle |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload(radius) | Constructor de Circle |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| radius | Número | El radio de la curva del círculo. |
+
+ **Result:**
+
+
+
+---
+
+
+### getRadius{#getRadius}
+
+| Nombre | Descripción |
+| --- | --- |
+| getRadius() | El radio de la curva del círculo, el valor predeterminado es 10 |
+
+ **Result:**
+
+
+
+---
+
+
+### setRadius{#setRadius}
+
+| Nombre | Descripción |
+| --- | --- |
+| setRadius(value) | El radio de la curva del círculo, el valor predeterminado es 10 |
+
+ **Result:**
+
+
+
+---
+
+
+### getColor{#getColor}
+
+| Nombre | Descripción |
+| --- | --- |
+| getColor() | Obtiene o establece el color de la línea, el valor predeterminado es blanco(1, 1, 1) |
+
+ **Result:**
+
+
+
+---
+
+
+### setColor{#setColor}
+
+| Nombre | Descripción |
+| --- | --- |
+| setColor(value) | Obtiene o establece el color de la línea, el valor predeterminado es blanco(1, 1, 1) |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNodes() | Obtiene todos los nodos padre; una entidad puede estar adjunta a varios nodos padre para la instanciación de geometría. Los nodos. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExcluded() | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExcluded(value) | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNode() | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setParentNode(value) | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Nombre | Descripción |
+| --- | --- |
+| getScene() | Obtiene la escena a la que pertenece este objeto |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEntityRendererKey() | Obtiene la clave del renderizador de entidad registrado en el renderizador |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBoundingBox() | Obtiene el cuadro delimitador de la entidad actual en su sistema de coordenadas de espacio de objeto. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/circleshape/_index.md
+++ b/spanish/nodejs-java/aspose.threed/circleshape/_index.md
@@ -1,0 +1,326 @@
+---
+title: "CircleShape"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/circleshape/
+---
+## CircleShape class
+
+Perfil de círculo compatible con IFC, que puede usarse para construir una malla mediante LinearExtrusion
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Construye un perfil CircleShape con radio predeterminado(5). |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload(radius) | Construye un perfil CircleShape con radio especificado. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| radiu | Número | null |
+
+ **Result:**
+
+
+
+---
+
+
+### getRadius{#getRadius}
+
+| Nombre | Descripción |
+| --- | --- |
+| getRadius() | Obtiene o establece el radio del círculo. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRadius{#setRadius}
+
+| Nombre | Descripción |
+| --- | --- |
+| setRadius(value) | Obtiene o establece el radio del círculo. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNodes() | Obtiene todos los nodos padre; una entidad puede estar adjunta a varios nodos padre para la instanciación de geometría. Los nodos. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExcluded() | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExcluded(value) | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNode() | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setParentNode(value) | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Nombre | Descripción |
+| --- | --- |
+| getScene() | Obtiene la escena a la que pertenece este objeto |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtent{#getExtent}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExtent() | Obtiene la extensión en las dimensiones x e y. |
+
+ **Result:**
+Vector2
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEntityRendererKey() | Obtiene la clave del renderizador de entidad registrado en el renderizador |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBoundingBox() | Obtiene el cuadro delimitador de la entidad actual en su sistema de coordenadas de espacio de objeto. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/colladasaveoptions/_index.md
+++ b/spanish/nodejs-java/aspose.threed/colladasaveoptions/_index.md
@@ -1,0 +1,198 @@
+---
+title: "ColladaSaveOptions"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/colladasaveoptions/
+---
+## ColladaSaveOptions class
+
+Opciones de guardado para collada
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Constructor de ColladaSaveOptions |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndented{#getIndented}
+
+| Nombre | Descripción |
+| --- | --- |
+| getIndented() | Obtiene o establece si el documento XML exportado está con sangría. |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndented{#setIndented}
+
+| Nombre | Descripción |
+| --- | --- |
+| setIndented(value) | Obtiene o establece si el documento XML exportado está con sangría. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTransformStyle{#getTransformStyle}
+
+| Nombre | Descripción |
+| --- | --- |
+| getTransformStyle() | Obtiene o establece el estilo de transformación de nodos. El valor de la propiedad es la constante entera ColladaTransformStyle. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTransformStyle{#setTransformStyle}
+
+| Nombre | Descripción |
+| --- | --- |
+| setTransformStyle(value) | Obtiene o establece el estilo de transformación de nodos. El valor de la propiedad es la constante entera ColladaTransformStyle. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportTextures{#getExportTextures}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExportTextures() | Intenta copiar las texturas usadas en la escena al directorio de salida. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextures{#setExportTextures}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExportTextures(value) | Intenta copiar las texturas usadas en la escena al directorio de salida. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileFormat() | Obtiene el formato de archivo especificado en la opción actual de Guardar/Cargar. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEncoding() | Obtiene o establece la codificación predeterminada para archivos basados en texto. El valor predeterminado es null, lo que significa que el importador/exportador decidirá qué codificación usar. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileSystem() | Permite al usuario manejar cómo gestionar las dependencias externas durante la carga/guardado. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFileSystem(value) | Permite al usuario manejar cómo gestionar las dependencias externas durante la carga/guardado. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| Nombre | Descripción |
+| --- | --- |
+| getLookupPaths() | Algunos archivos como OBJ dependen de archivos externos; las rutas de búsqueda permiten que Aspose.3D busque el archivo externo para cargarlo. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileName() | El nombre de archivo de la escena de exportación/importación. Es opcional, pero útil al serializar recursos externos como el material de OBJ. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFileName(value) | El nombre de archivo de la escena de exportación/importación. Es opcional, pero útil al serializar recursos externos como el material de OBJ. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/compositecurve/_index.md
+++ b/spanish/nodejs-java/aspose.threed/compositecurve/_index.md
@@ -1,0 +1,327 @@
+---
+title: "CompositeCurve"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/compositecurve/
+---
+## CompositeCurve class
+
+Un CompositeCurve está compuesto por varios segmentos de curva.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Constructor de CompositeCurve |
+
+ **Result:**
+
+
+
+---
+
+
+### getSegments{#getSegments}
+
+| Nombre | Descripción |
+| --- | --- |
+| getSegments() | Los segmentos de la curva. |
+
+ **Result:**
+
+
+
+---
+
+
+### getColor{#getColor}
+
+| Nombre | Descripción |
+| --- | --- |
+| getColor() | Obtiene o establece el color de la línea, el valor predeterminado es blanco(1, 1, 1) |
+
+ **Result:**
+
+
+
+---
+
+
+### setColor{#setColor}
+
+| Nombre | Descripción |
+| --- | --- |
+| setColor(value) | Obtiene o establece el color de la línea, el valor predeterminado es blanco(1, 1, 1) |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNodes() | Obtiene todos los nodos padre; una entidad puede estar adjunta a varios nodos padre para la instanciación de geometría. Los nodos. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExcluded() | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExcluded(value) | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNode() | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setParentNode(value) | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Nombre | Descripción |
+| --- | --- |
+| getScene() | Obtiene la escena a la que pertenece este objeto |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### addSegment{#addSegment}
+
+| Nombre | Descripción |
+| --- | --- |
+| addSegment(curve, sameDirection) | El |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| curv | Curva | null |
+| sameDirectio | boolean | null |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEntityRendererKey() | Obtiene la clave del renderizador de entidad registrado en el renderizador |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBoundingBox() | Obtiene el cuadro delimitador de la entidad actual en su sistema de coordenadas de espacio de objeto. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/cshape/_index.md
+++ b/spanish/nodejs-java/aspose.threed/cshape/_index.md
@@ -1,0 +1,411 @@
+---
+title: "CShape"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/cshape/
+---
+## CShape class
+
+Perfil en forma de C compatible con IFC definido por parámetros. La posición central del perfil está en el centro del cuadro delimitador.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Constructor de CShape |
+
+ **Result:**
+
+
+
+---
+
+
+### getDepth{#getDepth}
+
+| Nombre | Descripción |
+| --- | --- |
+| getDepth() | Obtiene o establece la profundidad del perfil. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDepth{#setDepth}
+
+| Nombre | Descripción |
+| --- | --- |
+| setDepth(value) | Obtiene o establece la profundidad del perfil. |
+
+ **Result:**
+
+
+
+---
+
+
+### getWidth{#getWidth}
+
+| Nombre | Descripción |
+| --- | --- |
+| getWidth() | Obtiene o establece el ancho del perfil. |
+
+ **Result:**
+
+
+
+---
+
+
+### setWidth{#setWidth}
+
+| Nombre | Descripción |
+| --- | --- |
+| setWidth(value) | Obtiene o establece el ancho del perfil. |
+
+ **Result:**
+
+
+
+---
+
+
+### getGirth{#getGirth}
+
+| Nombre | Descripción |
+| --- | --- |
+| getGirth() | Obtiene o establece la longitud del contorno. |
+
+ **Result:**
+
+
+
+---
+
+
+### setGirth{#setGirth}
+
+| Nombre | Descripción |
+| --- | --- |
+| setGirth(value) | Obtiene o establece la longitud del contorno. |
+
+ **Result:**
+
+
+
+---
+
+
+### getWallThickness{#getWallThickness}
+
+| Nombre | Descripción |
+| --- | --- |
+| getWallThickness() | Obtiene o establece el grosor de la pared. |
+
+ **Result:**
+
+
+
+---
+
+
+### setWallThickness{#setWallThickness}
+
+| Nombre | Descripción |
+| --- | --- |
+| setWallThickness(value) | Obtiene o establece el grosor de la pared. |
+
+ **Result:**
+
+
+
+---
+
+
+### getInternalFilletRadius{#getInternalFilletRadius}
+
+| Nombre | Descripción |
+| --- | --- |
+| getInternalFilletRadius() | Obtiene o establece el radio del filete interno. |
+
+ **Result:**
+
+
+
+---
+
+
+### setInternalFilletRadius{#setInternalFilletRadius}
+
+| Nombre | Descripción |
+| --- | --- |
+| setInternalFilletRadius(value) | Obtiene o establece el radio del filete interno. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNodes() | Obtiene todos los nodos padre; una entidad puede estar adjunta a varios nodos padre para la instanciación de geometría. Los nodos. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExcluded() | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExcluded(value) | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNode() | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setParentNode(value) | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Nombre | Descripción |
+| --- | --- |
+| getScene() | Obtiene la escena a la que pertenece este objeto |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtent{#getExtent}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExtent() | Obtiene la extensión en las dimensiones x e y. |
+
+ **Result:**
+Vector2
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEntityRendererKey() | Obtiene la clave del renderizador de entidad registrado en el renderizador |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBoundingBox() | Obtiene el cuadro delimitador de la entidad actual en su sistema de coordenadas de espacio de objeto. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/cubeface/_index.md
+++ b/spanish/nodejs-java/aspose.threed/cubeface/_index.md
@@ -1,0 +1,13 @@
+---
+title: "CubeFace"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/cubeface/
+---
+## CubeFace class
+
+Clase de utilidad que contiene constantes.  Cada cara de la textura del mapa cúbico  @hideconstructor
+
+

--- a/spanish/nodejs-java/aspose.threed/curve/_index.md
+++ b/spanish/nodejs-java/aspose.threed/curve/_index.md
@@ -1,0 +1,281 @@
+---
+title: "Curva"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/curve/
+---
+## Curve class
+
+La clase base de todas las implementaciones de curvas.  @hideconstructor
+
+
+## Métodos
+
+### getColor{#getColor}
+
+| Nombre | Descripción |
+| --- | --- |
+| getColor() | Obtiene o establece el color de la línea, el valor predeterminado es blanco(1, 1, 1) |
+
+ **Result:**
+
+
+
+---
+
+
+### setColor{#setColor}
+
+| Nombre | Descripción |
+| --- | --- |
+| setColor(value) | Obtiene o establece el color de la línea, el valor predeterminado es blanco(1, 1, 1) |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNodes() | Obtiene todos los nodos padre; una entidad puede estar adjunta a varios nodos padre para la instanciación de geometría. Los nodos. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExcluded() | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExcluded(value) | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNode() | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setParentNode(value) | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Nombre | Descripción |
+| --- | --- |
+| getScene() | Obtiene la escena a la que pertenece este objeto |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEntityRendererKey() | Obtiene la clave del renderizador de entidad registrado en el renderizador |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBoundingBox() | Obtiene el cuadro delimitador de la entidad actual en su sistema de coordenadas de espacio de objeto. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/customobject/_index.md
+++ b/spanish/nodejs-java/aspose.threed/customobject/_index.md
@@ -1,0 +1,183 @@
+---
+title: "CustomObject"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/customobject/
+---
+## CustomObject class
+
+Los metadatos o objetos personalizados utilizados en archivos 3D son gestionados por esta clase. Todas las propiedades personalizadas se guardan como propiedades dinámicas.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Inicializa una nueva instancia de la clase CustomObject. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload(name) | Inicializa una nueva instancia de la clase CustomObject. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| name | Cadena | Nombre |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/cylinder/_index.md
+++ b/spanish/nodejs-java/aspose.threed/cylinder/_index.md
@@ -1,0 +1,763 @@
+---
+title: "Cilindro"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/cylinder/
+---
+## Cylinder class
+
+Cilindro parametrizado. También puede usarse para representar el cono cuando uno de radiusTop/radiusBottom es cero.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Inicializa una nueva instancia de la clase Cylinder. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload(radius, height) | Inicializa una nueva instancia de la clase Cylinder. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| radius | Número | Radio de la tapa superior e inferior. |
+| height | Número | Altura. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload2(radiusTop, radiusBottom, height) | Inicializa una nueva instancia de la clase Cylinder. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| radiusTop | Número | Radio superior. |
+| radiusBottom | Número | Radio inferior. |
+| height | Número | Altura. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload3{#constructor_overload3}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload3(radiusTop, radiusBottom, height, radialSegments, heightSegments, openEnded) | Inicializa una nueva instancia de la clase Cylinder. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| radiusTop | Número | Radio de la tapa superior del cilindro. |
+| radiusBottom | Número | Radio de la tapa inferior del cilindro. |
+| height | Número | Altura del cilindro. |
+| radialSegments | Número | Segmentos radiales de ambos círculos superior e inferior.. |
+| heightSegments | Número | Segmentos de altura. |
+| openEnded | boolean | Si se establece en |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload4{#constructor_overload4}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload4(name, radiusTop, radiusBottom, height, radialSegments, heightSegments, openEnded, thetaStart, thetaLength) | Inicializa una nueva instancia de la clase Cylinder. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| name | Cadena | El nombre de este objeto |
+| radiusTop | Número | Radio de la tapa superior del cilindro. |
+| radiusBottom | Número | Radio de la tapa inferior del cilindro. |
+| height | Número | Altura del cilindro. |
+| radialSegments | Número | Segmentos radiales de ambos círculos superior e inferior.. |
+| heightSegments | Número | Segmentos de altura. |
+| openEnded | boolean | Si se establece en |
+| thetaStart | Número | Inicio de Theta. |
+| thetaLength | Número | Longitud de Theta. |
+
+ **Result:**
+
+
+
+---
+
+
+### getOffsetBottom{#getOffsetBottom}
+
+| Nombre | Descripción |
+| --- | --- |
+| getOffsetBottom() | Obtiene o establece el desplazamiento de transformación de los vértices del lado inferior. |
+
+ **Result:**
+
+
+
+---
+
+
+### setOffsetBottom{#setOffsetBottom}
+
+| Nombre | Descripción |
+| --- | --- |
+| setOffsetBottom(value) | Obtiene o establece el desplazamiento de transformación de los vértices del lado inferior. |
+
+ **Result:**
+
+
+
+---
+
+
+### getOffsetTop{#getOffsetTop}
+
+| Nombre | Descripción |
+| --- | --- |
+| getOffsetTop() | Obtiene o establece el desplazamiento de transformación de los vértices del lado superior. |
+
+ **Result:**
+
+
+
+---
+
+
+### setOffsetTop{#setOffsetTop}
+
+| Nombre | Descripción |
+| --- | --- |
+| setOffsetTop(value) | Obtiene o establece el desplazamiento de transformación de los vértices del lado superior. |
+
+ **Result:**
+
+
+
+---
+
+
+### getGenerateFanCylinder{#getGenerateFanCylinder}
+
+| Nombre | Descripción |
+| --- | --- |
+| getGenerateFanCylinder() | Obtiene o establece si generar el cilindro estilo abanico cuando ThetaLength es menor que 2PI, de lo contrario el modelo no se recortará. |
+
+ **Result:**
+
+
+
+---
+
+
+### setGenerateFanCylinder{#setGenerateFanCylinder}
+
+| Nombre | Descripción |
+| --- | --- |
+| setGenerateFanCylinder(value) | Obtiene o establece si generar el cilindro estilo abanico cuando ThetaLength es menor que 2PI, de lo contrario el modelo no se recortará. |
+
+ **Result:**
+
+
+
+---
+
+
+### getShearBottom{#getShearBottom}
+
+| Nombre | Descripción |
+| --- | --- |
+| getShearBottom() | Obtiene o establece la transformación de cizallamiento del lado inferior, el vector almacena el valor de cizallamiento (x-axis, z-axis) medido en radianes, el valor predeterminado es (0, 0) |
+
+ **Result:**
+
+
+
+---
+
+
+### setShearBottom{#setShearBottom}
+
+| Nombre | Descripción |
+| --- | --- |
+| setShearBottom(value) | Obtiene o establece la transformación de cizallamiento del lado inferior, el vector almacena el valor de cizallamiento (x-axis, z-axis) medido en radianes, el valor predeterminado es (0, 0) |
+
+ **Result:**
+
+
+
+---
+
+
+### getShearTop{#getShearTop}
+
+| Nombre | Descripción |
+| --- | --- |
+| getShearTop() | Obtiene o establece la transformación de cizallamiento del lado superior, el vector almacena el valor de cizallamiento (x-axis, z-axis) medido en radianes, el valor predeterminado es (0, 0) |
+
+ **Result:**
+
+
+
+---
+
+
+### setShearTop{#setShearTop}
+
+| Nombre | Descripción |
+| --- | --- |
+| setShearTop(value) | Obtiene o establece la transformación de cizallamiento del lado superior, el vector almacena el valor de cizallamiento (x-axis, z-axis) medido en radianes, el valor predeterminado es (0, 0) |
+
+ **Result:**
+
+
+
+---
+
+
+### getRadiusTop{#getRadiusTop}
+
+| Nombre | Descripción |
+| --- | --- |
+| getRadiusTop() | Obtiene o establece el radio de la tapa superior del cilindro. El radio de la tapa superior. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRadiusTop{#setRadiusTop}
+
+| Nombre | Descripción |
+| --- | --- |
+| setRadiusTop(value) | Obtiene o establece el radio de la tapa superior del cilindro. El radio de la tapa superior. |
+
+ **Result:**
+
+
+
+---
+
+
+### getRadiusBottom{#getRadiusBottom}
+
+| Nombre | Descripción |
+| --- | --- |
+| getRadiusBottom() | Obtiene o establece el radio de la tapa inferior del cilindro. El radio de la tapa inferior. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRadiusBottom{#setRadiusBottom}
+
+| Nombre | Descripción |
+| --- | --- |
+| setRadiusBottom(value) | Obtiene o establece el radio de la tapa inferior del cilindro. El radio de la tapa inferior. |
+
+ **Result:**
+
+
+
+---
+
+
+### getHeight{#getHeight}
+
+| Nombre | Descripción |
+| --- | --- |
+| getHeight() | Obtiene o establece la altura del cilindro. La altura. |
+
+ **Result:**
+
+
+
+---
+
+
+### setHeight{#setHeight}
+
+| Nombre | Descripción |
+| --- | --- |
+| setHeight(value) | Obtiene o establece la altura del cilindro. La altura. |
+
+ **Result:**
+
+
+
+---
+
+
+### getRadialSegments{#getRadialSegments}
+
+| Nombre | Descripción |
+| --- | --- |
+| getRadialSegments() | Obtiene o establece los segmentos radiales. Los segmentos radiales. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRadialSegments{#setRadialSegments}
+
+| Nombre | Descripción |
+| --- | --- |
+| setRadialSegments(value) | Obtiene o establece los segmentos radiales. Los segmentos radiales. |
+
+ **Result:**
+
+
+
+---
+
+
+### getHeightSegments{#getHeightSegments}
+
+| Nombre | Descripción |
+| --- | --- |
+| getHeightSegments() | Obtiene o establece los segmentos de altura. Los segmentos de altura. |
+
+ **Result:**
+
+
+
+---
+
+
+### setHeightSegments{#setHeightSegments}
+
+| Nombre | Descripción |
+| --- | --- |
+| setHeightSegments(value) | Obtiene o establece los segmentos de altura. Los segmentos de altura. |
+
+ **Result:**
+
+
+
+---
+
+
+### getOpenEnded{#getOpenEnded}
+
+| Nombre | Descripción |
+| --- | --- |
+| getOpenEnded() | Obtiene o establece un valor que indica si este Cylinder está abierto en los extremos. El valor predeterminado es false. true si está abierto; de lo contrario, existen tapas superior/inferior. |
+
+ **Result:**
+
+
+
+---
+
+
+### setOpenEnded{#setOpenEnded}
+
+| Nombre | Descripción |
+| --- | --- |
+| setOpenEnded(value) | Obtiene o establece un valor que indica si este Cylinder está abierto en los extremos. El valor predeterminado es false. true si está abierto; de lo contrario, existen tapas superior/inferior. |
+
+ **Result:**
+
+
+
+---
+
+
+### getThetaStart{#getThetaStart}
+
+| Nombre | Descripción |
+| --- | --- |
+| getThetaStart() | Obtiene o establece el inicio theta. El valor predeterminado es 0. El inicio theta. |
+
+ **Result:**
+
+
+
+---
+
+
+### setThetaStart{#setThetaStart}
+
+| Nombre | Descripción |
+| --- | --- |
+| setThetaStart(value) | Obtiene o establece el inicio theta. El valor predeterminado es 0. El inicio theta. |
+
+ **Result:**
+
+
+
+---
+
+
+### getThetaLength{#getThetaLength}
+
+| Nombre | Descripción |
+| --- | --- |
+| getThetaLength() | Obtiene o establece la longitud de theta. El valor predeterminado es 2π. La longitud de theta. |
+
+ **Result:**
+
+
+
+---
+
+
+### setThetaLength{#setThetaLength}
+
+| Nombre | Descripción |
+| --- | --- |
+| setThetaLength(value) | Obtiene o establece la longitud de theta. El valor predeterminado es 2π. La longitud de theta. |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastShadows{#getCastShadows}
+
+| Nombre | Descripción |
+| --- | --- |
+| getCastShadows() | Obtiene o establece si esta geometría puede proyectar sombra |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastShadows{#setCastShadows}
+
+| Nombre | Descripción |
+| --- | --- |
+| setCastShadows(value) | Obtiene o establece si esta geometría puede proyectar sombra |
+
+ **Result:**
+
+
+
+---
+
+
+### getReceiveShadows{#getReceiveShadows}
+
+| Nombre | Descripción |
+| --- | --- |
+| getReceiveShadows() | Obtiene o establece si esta geometría puede recibir sombra. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReceiveShadows{#setReceiveShadows}
+
+| Nombre | Descripción |
+| --- | --- |
+| setReceiveShadows(value) | Obtiene o establece si esta geometría puede recibir sombra. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNodes() | Obtiene todos los nodos padre; una entidad puede estar adjunta a varios nodos padre para la instanciación de geometría. Los nodos. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExcluded() | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExcluded(value) | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNode() | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setParentNode(value) | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Nombre | Descripción |
+| --- | --- |
+| getScene() | Obtiene la escena a la que pertenece este objeto |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### toMesh{#toMesh}
+
+| Nombre | Descripción |
+| --- | --- |
+| toMesh() | Convertir el objeto actual a malla |
+
+ **Result:**
+Malla
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBoundingBox() | Obtiene el cuadro delimitador de la entidad actual en su sistema de coordenadas de espacio de objeto. |
+
+ **Result:**
+Malla
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEntityRendererKey() | Obtiene la clave del renderizador de entidad registrado en el renderizador |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/deformer/_index.md
+++ b/spanish/nodejs-java/aspose.threed/deformer/_index.md
@@ -1,0 +1,183 @@
+---
+title: "Deformer"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/deformer/
+---
+## Deformer class
+
+Clase base para SkinDeformer y MorphTargetDeformer
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor(name) | Inicializa una nueva instancia de la clase Deformer. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| name | Cadena | Nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getOwner{#getOwner}
+
+| Nombre | Descripción |
+| --- | --- |
+| getOwner() | Obtiene la geometría que posee este deformer |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/descriptorsetupdater/_index.md
+++ b/spanish/nodejs-java/aspose.threed/descriptorsetupdater/_index.md
@@ -1,0 +1,137 @@
+---
+title: "DescriptorSetUpdater"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/descriptorsetupdater/
+---
+## DescriptorSetUpdater class
+
+Esta clase permite actualizar el com.aspose.threed.IDescriptorSet en una operación en cadena.  @hideconstructor
+
+
+## Métodos
+
+### bind{#bind}
+
+| Nombre | Descripción |
+| --- | --- |
+| bind(buffer, offset, size) | Vincula el búfer al conjunto de descriptores actual |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| búfer | IBuffer | Qué búfer vincular |
+| offset | Número | Desplazamiento del búfer a vincular |
+| tamaño | Número | Tamaño del búfer a vincular |
+
+ **Result:**
+DescriptorSetUpdater
+
+
+---
+
+
+### bind{#bind}
+
+| Nombre | Descripción |
+| --- | --- |
+| bind(buffer) | Vincula todo el búfer al descriptor actual |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| búfer | IBuffer | null |
+
+ **Result:**
+DescriptorSetUpdater
+
+
+---
+
+
+### bind{#bind}
+
+| Nombre | Descripción |
+| --- | --- |
+| bind(binding, buffer) | Vincula el búfer al conjunto de descriptores actual en la ubicación de enlace especificada. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| enlace | Número | Ubicación de enlace |
+| búfer | IBuffer | El búfer completo a vincular |
+
+ **Result:**
+DescriptorSetUpdater
+
+
+---
+
+
+### bind{#bind}
+
+| Nombre | Descripción |
+| --- | --- |
+| bind(binding, buffer, offset, size) | Vincula el búfer al conjunto de descriptores actual en la ubicación de enlace especificada. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| enlace | Número | Ubicación de enlace |
+| búfer | IBuffer | El búfer a vincular |
+| offset | Número | Desplazamiento del búfer a vincular |
+| tamaño | Número | Tamaño del búfer a vincular |
+
+ **Result:**
+DescriptorSetUpdater
+
+
+---
+
+
+### bind{#bind}
+
+| Nombre | Descripción |
+| --- | --- |
+| bind(texture) | Vincula la unidad de textura al conjunto de descriptores actual |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| texture | ITextureUnit | La unidad de textura a vincular |
+
+ **Result:**
+DescriptorSetUpdater
+
+
+---
+
+
+### bind{#bind}
+
+| Nombre | Descripción |
+| --- | --- |
+| bind(binding, texture) | Vincula la unidad de textura al conjunto de descriptores actual |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| enlace | Número | La ubicación de enlace |
+| texture | ITextureUnit | La unidad de textura a vincular |
+
+ **Result:**
+DescriptorSetUpdater
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/discreet3dsloadoptions/_index.md
+++ b/spanish/nodejs-java/aspose.threed/discreet3dsloadoptions/_index.md
@@ -1,0 +1,198 @@
+---
+title: "Discreet3dsLoadOptions"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/discreet3dsloadoptions/
+---
+## Discreet3dsLoadOptions class
+
+Opciones de carga para archivo 3DS.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Constructor de Discreet3dsLoadOptions |
+
+ **Result:**
+
+
+
+---
+
+
+### getGammaCorrectedColor{#getGammaCorrectedColor}
+
+| Nombre | Descripción |
+| --- | --- |
+| getGammaCorrectedColor() | Un archivo 3ds puede contener color original y color corregido por gamma para el mismo atributo. Configurarlo en true hará que se use el color corregido por gamma si es posible; de lo contrario, Aspose.3D intentará usar el color original. |
+
+ **Result:**
+
+
+
+---
+
+
+### setGammaCorrectedColor{#setGammaCorrectedColor}
+
+| Nombre | Descripción |
+| --- | --- |
+| setGammaCorrectedColor(value) | Un archivo 3ds puede contener color original y color corregido por gamma para el mismo atributo. Configurarlo en true hará que se use el color corregido por gamma si es posible; de lo contrario, Aspose.3D intentará usar el color original. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlipCoordinateSystem{#getFlipCoordinateSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFlipCoordinateSystem() | Obtiene o establece el sistema de coordenadas invertido de los puntos de control/normal durante la importación/exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlipCoordinateSystem{#setFlipCoordinateSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFlipCoordinateSystem(value) | Obtiene o establece el sistema de coordenadas invertido de los puntos de control/normal durante la importación/exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### getApplyAnimationTransform{#getApplyAnimationTransform}
+
+| Nombre | Descripción |
+| --- | --- |
+| getApplyAnimationTransform() | Obtiene o establece si se debe usar la transformación definida en el primer fotograma de la pista de animación. |
+
+ **Result:**
+
+
+
+---
+
+
+### setApplyAnimationTransform{#setApplyAnimationTransform}
+
+| Nombre | Descripción |
+| --- | --- |
+| setApplyAnimationTransform(value) | Obtiene o establece si se debe usar la transformación definida en el primer fotograma de la pista de animación. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileFormat() | Obtiene el formato de archivo especificado en la opción actual de Guardar/Cargar. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEncoding() | Obtiene o establece la codificación predeterminada para archivos basados en texto. El valor predeterminado es null, lo que significa que el importador/exportador decidirá qué codificación usar. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileSystem() | Permite al usuario manejar cómo gestionar las dependencias externas durante la carga/guardado. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFileSystem(value) | Permite al usuario manejar cómo gestionar las dependencias externas durante la carga/guardado. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| Nombre | Descripción |
+| --- | --- |
+| getLookupPaths() | Algunos archivos como OBJ dependen de archivos externos; las rutas de búsqueda permiten que Aspose.3D busque el archivo externo para cargarlo. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileName() | El nombre de archivo de la escena de exportación/importación. Es opcional, pero útil al serializar recursos externos como el material de OBJ. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFileName(value) | El nombre de archivo de la escena de exportación/importación. Es opcional, pero útil al serializar recursos externos como el material de OBJ. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/discreet3dssaveoptions/_index.md
+++ b/spanish/nodejs-java/aspose.threed/discreet3dssaveoptions/_index.md
@@ -1,0 +1,380 @@
+---
+title: "Discreet3dsSaveOptions"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/discreet3dssaveoptions/
+---
+## Discreet3dsSaveOptions class
+
+Opciones de guardado para archivo 3DS.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Constructor de Discreet3dsSaveOptions |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportLight{#getExportLight}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExportLight() | Obtiene o establece si se exportan todas las luces en la escena. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportLight{#setExportLight}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExportLight(value) | Obtiene o establece si se exportan todas las luces en la escena. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportCamera{#getExportCamera}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExportCamera() | Obtiene o establece si se exportan todas las cámaras en la escena. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportCamera{#setExportCamera}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExportCamera(value) | Obtiene o establece si se exportan todas las cámaras en la escena. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDuplicatedNameSeparator{#getDuplicatedNameSeparator}
+
+| Nombre | Descripción |
+| --- | --- |
+| getDuplicatedNameSeparator() | El separador entre el nombre del objeto y el contador duplicado, el valor predeterminado es "_". Cuando la escena contiene objetos que usan el mismo nombre, el exportador 3DS de Aspose.3D generará un nombre diferente para el objeto. Por ejemplo, hay dos nodos llamados "Box", el primer nodo tendrá el nombre "Box", y el segundo nodo obtendrá un nuevo nombre "Box_2" usando la configuración predeterminada. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDuplicatedNameSeparator{#setDuplicatedNameSeparator}
+
+| Nombre | Descripción |
+| --- | --- |
+| setDuplicatedNameSeparator(value) | El separador entre el nombre del objeto y el contador duplicado, el valor predeterminado es "_". Cuando la escena contiene objetos que usan el mismo nombre, el exportador 3DS de Aspose.3D generará un nombre diferente para el objeto. Por ejemplo, hay dos nodos llamados "Box", el primer nodo tendrá el nombre "Box", y el segundo nodo obtendrá un nuevo nombre "Box_2" usando la configuración predeterminada. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDuplicatedNameCounterBase{#getDuplicatedNameCounterBase}
+
+| Nombre | Descripción |
+| --- | --- |
+| getDuplicatedNameCounterBase() | El contador usado para generar un nuevo nombre para nombres duplicados, el valor predeterminado es 2. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDuplicatedNameCounterBase{#setDuplicatedNameCounterBase}
+
+| Nombre | Descripción |
+| --- | --- |
+| setDuplicatedNameCounterBase(value) | El contador usado para generar un nuevo nombre para nombres duplicados, el valor predeterminado es 2. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDuplicatedNameCounterFormat{#getDuplicatedNameCounterFormat}
+
+| Nombre | Descripción |
+| --- | --- |
+| getDuplicatedNameCounterFormat() | El formato del contador duplicado, el valor predeterminado es una cadena vacía. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDuplicatedNameCounterFormat{#setDuplicatedNameCounterFormat}
+
+| Nombre | Descripción |
+| --- | --- |
+| setDuplicatedNameCounterFormat(value) | El formato del contador duplicado, el valor predeterminado es una cadena vacía. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMasterScale{#getMasterScale}
+
+| Nombre | Descripción |
+| --- | --- |
+| getMasterScale() | Obtiene o establece la escala maestra utilizada en la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMasterScale{#setMasterScale}
+
+| Nombre | Descripción |
+| --- | --- |
+| setMasterScale(value) | Obtiene o establece la escala maestra utilizada en la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### getGammaCorrectedColor{#getGammaCorrectedColor}
+
+| Nombre | Descripción |
+| --- | --- |
+| getGammaCorrectedColor() | Un archivo 3ds puede contener color original y color corregido por gamma para el mismo atributo. Configurarlo en true hará que se use el color corregido por gamma si es posible; de lo contrario, Aspose.3D intentará usar el color original. |
+
+ **Result:**
+
+
+
+---
+
+
+### setGammaCorrectedColor{#setGammaCorrectedColor}
+
+| Nombre | Descripción |
+| --- | --- |
+| setGammaCorrectedColor(value) | Un archivo 3ds puede contener color original y color corregido por gamma para el mismo atributo. Configurarlo en true hará que se use el color corregido por gamma si es posible; de lo contrario, Aspose.3D intentará usar el color original. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlipCoordinateSystem{#getFlipCoordinateSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFlipCoordinateSystem() | Obtiene o establece el sistema de coordenadas invertido de los puntos de control/normal durante la importación/exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlipCoordinateSystem{#setFlipCoordinateSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFlipCoordinateSystem(value) | Obtiene o establece el sistema de coordenadas invertido de los puntos de control/normal durante la importación/exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### getHighPreciseColor{#getHighPreciseColor}
+
+| Nombre | Descripción |
+| --- | --- |
+| getHighPreciseColor() | Si esto es true, el archivo 3ds generado usará color de alta precisión, lo que significa que cada canal de rojo/verde/azul está en punto flotante de 32 bits. De lo contrario, el archivo generado usará color de 24 bits, cada canal usa un byte de 8 bits. El valor predeterminado es false, porque no todas las aplicaciones admiten el color de alta precisión. |
+
+ **Result:**
+
+
+
+---
+
+
+### setHighPreciseColor{#setHighPreciseColor}
+
+| Nombre | Descripción |
+| --- | --- |
+| setHighPreciseColor(value) | Si esto es true, el archivo 3ds generado usará color de alta precisión, lo que significa que cada canal de rojo/verde/azul está en punto flotante de 32 bits. De lo contrario, el archivo generado usará color de 24 bits, cada canal usa un byte de 8 bits. El valor predeterminado es false, porque no todas las aplicaciones admiten el color de alta precisión. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportTextures{#getExportTextures}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExportTextures() | Intenta copiar las texturas usadas en la escena al directorio de salida. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextures{#setExportTextures}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExportTextures(value) | Intenta copiar las texturas usadas en la escena al directorio de salida. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileFormat() | Obtiene el formato de archivo especificado en la opción actual de Guardar/Cargar. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEncoding() | Obtiene o establece la codificación predeterminada para archivos basados en texto. El valor predeterminado es null, lo que significa que el importador/exportador decidirá qué codificación usar. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileSystem() | Permite al usuario manejar cómo gestionar las dependencias externas durante la carga/guardado. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFileSystem(value) | Permite al usuario manejar cómo gestionar las dependencias externas durante la carga/guardado. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| Nombre | Descripción |
+| --- | --- |
+| getLookupPaths() | Algunos archivos como OBJ dependen de archivos externos; las rutas de búsqueda permiten que Aspose.3D busque el archivo externo para cargarlo. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileName() | El nombre de archivo de la escena de exportación/importación. Es opcional, pero útil al serializar recursos externos como el material de OBJ. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFileName(value) | El nombre de archivo de la escena de exportación/importación. Es opcional, pero útil al serializar recursos externos como el material de OBJ. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/dish/_index.md
+++ b/spanish/nodejs-java/aspose.threed/dish/_index.md
@@ -1,0 +1,480 @@
+---
+title: "Dish"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/dish/
+---
+## Dish class
+
+Plato parametrizado.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Cree una nueva instancia de Dish con radio predeterminado (10) y altura predeterminada (5) |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload(radius, height) | Cree una nueva instancia de Dish con radio y altura especificados |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| radius | Número | El radio del dish |
+| height | Número | La altura del dish |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload2(name, radius, height, widthSegments, heightSegments) | Cree una nueva instancia de Dish con radio y altura especificados |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| name | Cadena | El nombre del dish |
+| radius | Número | El radio del dish |
+| height | Número | La altura del dish |
+| widthSegments | Número | El segmento de ancho del dish |
+| heightSegments | Número | El segmento de altura del plato |
+
+ **Result:**
+
+
+
+---
+
+
+### getHeight{#getHeight}
+
+| Nombre | Descripción |
+| --- | --- |
+| getHeight() | Altura del plato |
+
+ **Result:**
+
+
+
+---
+
+
+### setHeight{#setHeight}
+
+| Nombre | Descripción |
+| --- | --- |
+| setHeight(value) | Altura del plato |
+
+ **Result:**
+
+
+
+---
+
+
+### getRadius{#getRadius}
+
+| Nombre | Descripción |
+| --- | --- |
+| getRadius() | Radio del plato |
+
+ **Result:**
+
+
+
+---
+
+
+### setRadius{#setRadius}
+
+| Nombre | Descripción |
+| --- | --- |
+| setRadius(value) | Radio del plato |
+
+ **Result:**
+
+
+
+---
+
+
+### getWidthSegments{#getWidthSegments}
+
+| Nombre | Descripción |
+| --- | --- |
+| getWidthSegments() | Obtiene o establece los segmentos de ancho |
+
+ **Result:**
+
+
+
+---
+
+
+### setWidthSegments{#setWidthSegments}
+
+| Nombre | Descripción |
+| --- | --- |
+| setWidthSegments(value) | Obtiene o establece los segmentos de ancho |
+
+ **Result:**
+
+
+
+---
+
+
+### getHeightSegments{#getHeightSegments}
+
+| Nombre | Descripción |
+| --- | --- |
+| getHeightSegments() | Obtiene o establece los segmentos de altura |
+
+ **Result:**
+
+
+
+---
+
+
+### setHeightSegments{#setHeightSegments}
+
+| Nombre | Descripción |
+| --- | --- |
+| setHeightSegments(value) | Obtiene o establece los segmentos de altura |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastShadows{#getCastShadows}
+
+| Nombre | Descripción |
+| --- | --- |
+| getCastShadows() | Obtiene o establece si esta geometría puede proyectar sombra |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastShadows{#setCastShadows}
+
+| Nombre | Descripción |
+| --- | --- |
+| setCastShadows(value) | Obtiene o establece si esta geometría puede proyectar sombra |
+
+ **Result:**
+
+
+
+---
+
+
+### getReceiveShadows{#getReceiveShadows}
+
+| Nombre | Descripción |
+| --- | --- |
+| getReceiveShadows() | Obtiene o establece si esta geometría puede recibir sombra. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReceiveShadows{#setReceiveShadows}
+
+| Nombre | Descripción |
+| --- | --- |
+| setReceiveShadows(value) | Obtiene o establece si esta geometría puede recibir sombra. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNodes() | Obtiene todos los nodos padre; una entidad puede estar adjunta a varios nodos padre para la instanciación de geometría. Los nodos. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExcluded() | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExcluded(value) | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNode() | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setParentNode(value) | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Nombre | Descripción |
+| --- | --- |
+| getScene() | Obtiene la escena a la que pertenece este objeto |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### toMesh{#toMesh}
+
+| Nombre | Descripción |
+| --- | --- |
+| toMesh() | Convertir el objeto actual a malla |
+
+ **Result:**
+Malla
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBoundingBox() | Obtiene el cuadro delimitador de la entidad actual en su sistema de coordenadas de espacio de objeto. |
+
+ **Result:**
+Malla
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEntityRendererKey() | Obtiene la clave del renderizador de entidad registrado en el renderizador |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/dracoformat/_index.md
+++ b/spanish/nodejs-java/aspose.threed/dracoformat/_index.md
@@ -1,0 +1,199 @@
+---
+title: "DracoFormat"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/dracoformat/
+---
+## DracoFormat class
+
+Formato Google Draco  @hideconstructor
+
+
+## Métodos
+
+### getVersion{#getVersion}
+
+| Nombre | Descripción |
+| --- | --- |
+| getVersion() | Obtiene la versión del formato de archivo |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtension{#getExtension}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExtension() | Obtiene el nombre de la extensión de este tipo. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtensions{#getExtensions}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExtensions() | Obtiene los nombres de las extensiones de este tipo. |
+
+ **Result:**
+
+
+
+---
+
+
+### getContentType{#getContentType}
+
+| Nombre | Descripción |
+| --- | --- |
+| getContentType() | Obtiene el tipo de contenido del formato de archivo. El valor de la propiedad es la constante entera FileContentType. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormatType{#getFileFormatType}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileFormatType() | Obtiene el tipo de formato de archivo |
+
+ **Result:**
+
+
+
+---
+
+
+### decode{#decode}
+
+| Nombre | Descripción |
+| --- | --- |
+| decode(fileName) | Decodificar la nube de puntos o malla del nombre de archivo especificado |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| fileName | Cadena | El nombre del archivo contiene el archivo drc |
+
+ **Result:**
+Geometría
+
+
+---
+
+
+### decode{#decode}
+
+| Nombre | Descripción |
+| --- | --- |
+| decode(data) | Decodificar la nube de puntos o malla de los datos en memoria |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| data | byte[] | Los bytes crudos drc |
+
+ **Result:**
+Geometría
+
+
+---
+
+
+### encode{#encode}
+
+| Nombre | Descripción |
+| --- | --- |
+| encode(entity, fileName, options) | Codificar la entidad al archivo especificado |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| entidad | Entidad | La entidad a codificar |
+| fileName | Cadena | El nombre del archivo a escribir |
+| opciones | DracoSaveOptions | Opciones extra para codificar la nube de puntos |
+
+ **Result:**
+Geometría
+
+
+---
+
+
+### encode{#encode}
+
+| Nombre | Descripción |
+| --- | --- |
+| encode(entity, options) | Codificar la entidad a datos crudos Draco |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| entidad | Entidad | La entidad a codificar |
+| opciones | DracoSaveOptions | Opciones extra para codificar la nube de puntos |
+
+ **Result:**
+byte[]
+
+
+---
+
+
+### createLoadOptions{#createLoadOptions}
+
+| Nombre | Descripción |
+| --- | --- |
+| createLoadOptions() | Crea opciones de carga predeterminadas para este formato de archivo |
+
+ **Result:**
+LoadOptions
+
+
+---
+
+
+### createSaveOptions{#createSaveOptions}
+
+| Nombre | Descripción |
+| --- | --- |
+| createSaveOptions() | Crea opciones de guardado predeterminadas para este formato de archivo |
+
+ **Result:**
+SaveOptions
+
+
+---
+
+
+### toString{#toString}
+
+| Nombre | Descripción |
+| --- | --- |
+| toString() | Formatos a cadena |
+
+ **Result:**
+Cadena
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/dracosaveoptions/_index.md
+++ b/spanish/nodejs-java/aspose.threed/dracosaveoptions/_index.md
@@ -1,0 +1,328 @@
+---
+title: "DracoSaveOptions"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/dracosaveoptions/
+---
+## DracoSaveOptions class
+
+Opciones de guardado para archivos Google draco
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Construir una configuración predeterminada para guardar archivos draco. |
+
+ **Result:**
+
+
+
+---
+
+
+### getPositionBits{#getPositionBits}
+
+| Nombre | Descripción |
+| --- | --- |
+| getPositionBits() | Bits de cuantización para la posición, el valor predeterminado es 14. |
+
+ **Result:**
+
+
+
+---
+
+
+### setPositionBits{#setPositionBits}
+
+| Nombre | Descripción |
+| --- | --- |
+| setPositionBits(value) | Bits de cuantización para la posición, el valor predeterminado es 14. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTextureCoordinateBits{#getTextureCoordinateBits}
+
+| Nombre | Descripción |
+| --- | --- |
+| getTextureCoordinateBits() | Bits de cuantización para la coordenada de textura, el valor predeterminado es 12. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTextureCoordinateBits{#setTextureCoordinateBits}
+
+| Nombre | Descripción |
+| --- | --- |
+| setTextureCoordinateBits(value) | Bits de cuantización para la coordenada de textura, el valor predeterminado es 12. |
+
+ **Result:**
+
+
+
+---
+
+
+### getColorBits{#getColorBits}
+
+| Nombre | Descripción |
+| --- | --- |
+| getColorBits() | Bits de cuantización para el color del vértice, el valor predeterminado es 10. |
+
+ **Result:**
+
+
+
+---
+
+
+### setColorBits{#setColorBits}
+
+| Nombre | Descripción |
+| --- | --- |
+| setColorBits(value) | Bits de cuantización para el color del vértice, el valor predeterminado es 10. |
+
+ **Result:**
+
+
+
+---
+
+
+### getNormalBits{#getNormalBits}
+
+| Nombre | Descripción |
+| --- | --- |
+| getNormalBits() | Bits de cuantización para vectores normales, el valor predeterminado es 10. |
+
+ **Result:**
+
+
+
+---
+
+
+### setNormalBits{#setNormalBits}
+
+| Nombre | Descripción |
+| --- | --- |
+| setNormalBits(value) | Bits de cuantización para vectores normales, el valor predeterminado es 10. |
+
+ **Result:**
+
+
+
+---
+
+
+### getCompressionLevel{#getCompressionLevel}
+
+| Nombre | Descripción |
+| --- | --- |
+| getCompressionLevel() | Nivel de compresión, el valor predeterminado es DracoCompressionLevel.STANDARD. El valor de la propiedad es una constante entera DracoCompressionLevel. |
+
+ **Result:**
+
+
+
+---
+
+
+### setCompressionLevel{#setCompressionLevel}
+
+| Nombre | Descripción |
+| --- | --- |
+| setCompressionLevel(value) | Nivel de compresión, el valor predeterminado es DracoCompressionLevel.STANDARD. El valor de la propiedad es una constante entera DracoCompressionLevel. |
+
+ **Result:**
+
+
+
+---
+
+
+### getApplyUnitScale{#getApplyUnitScale}
+
+| Nombre | Descripción |
+| --- | --- |
+| getApplyUnitScale() | Aplicar AssetInfo.UnitScaleFactor a la malla. El valor predeterminado es false. |
+
+ **Result:**
+
+
+
+---
+
+
+### setApplyUnitScale{#setApplyUnitScale}
+
+| Nombre | Descripción |
+| --- | --- |
+| setApplyUnitScale(value) | Aplicar AssetInfo.UnitScaleFactor a la malla. El valor predeterminado es false. |
+
+ **Result:**
+
+
+
+---
+
+
+### getPointCloud{#getPointCloud}
+
+| Nombre | Descripción |
+| --- | --- |
+| getPointCloud() | Exporta la escena como nube de puntos, el valor predeterminado es false. |
+
+ **Result:**
+
+
+
+---
+
+
+### setPointCloud{#setPointCloud}
+
+| Nombre | Descripción |
+| --- | --- |
+| setPointCloud(value) | Exporta la escena como nube de puntos, el valor predeterminado es false. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportTextures{#getExportTextures}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExportTextures() | Intenta copiar las texturas usadas en la escena al directorio de salida. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextures{#setExportTextures}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExportTextures(value) | Intenta copiar las texturas usadas en la escena al directorio de salida. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileFormat() | Obtiene el formato de archivo especificado en la opción actual de Guardar/Cargar. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEncoding() | Obtiene o establece la codificación predeterminada para archivos basados en texto. El valor predeterminado es null, lo que significa que el importador/exportador decidirá qué codificación usar. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileSystem() | Permite al usuario manejar cómo gestionar las dependencias externas durante la carga/guardado. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFileSystem(value) | Permite al usuario manejar cómo gestionar las dependencias externas durante la carga/guardado. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| Nombre | Descripción |
+| --- | --- |
+| getLookupPaths() | Algunos archivos como OBJ dependen de archivos externos; las rutas de búsqueda permiten que Aspose.3D busque el archivo externo para cargarlo. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileName() | El nombre de archivo de la escena de exportación/importación. Es opcional, pero útil al serializar recursos externos como el material de OBJ. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFileName(value) | El nombre de archivo de la escena de exportación/importación. Es opcional, pero útil al serializar recursos externos como el material de OBJ. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/driverexception/_index.md
+++ b/spanish/nodejs-java/aspose.threed/driverexception/_index.md
@@ -1,0 +1,29 @@
+---
+title: "DriverException"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/driverexception/
+---
+## DriverException class
+
+La excepción generada por los controladores internos de renderizado.  @hideconstructor
+
+
+## Métodos
+
+### getErrorCode{#getErrorCode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getErrorCode() | Obtiene el código de error nativo. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/dummyfilesystem/_index.md
+++ b/spanish/nodejs-java/aspose.threed/dummyfilesystem/_index.md
@@ -1,0 +1,69 @@
+---
+title: "DummyFileSystem"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/dummyfilesystem/
+---
+## DummyFileSystem class
+
+Las operaciones de lectura/escritura son operaciones ficticias.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### readFile{#readFile}
+
+| Nombre | Descripción |
+| --- | --- |
+| readFile(fileName, options) | Crea un flujo para leer dependencias. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| fileNam | Cadena | null |
+| opción | IOConfig | null |
+
+ **Result:**
+Stream
+
+
+---
+
+
+### writeFile{#writeFile}
+
+| Nombre | Descripción |
+| --- | --- |
+| writeFile(fileName, options) | Crea un flujo para escribir dependencias. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| fileNam | Cadena | null |
+| opción | IOConfig | null |
+
+ **Result:**
+Stream
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/ellipse/_index.md
+++ b/spanish/nodejs-java/aspose.threed/ellipse/_index.md
@@ -1,0 +1,359 @@
+---
+title: "Elipse"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/ellipse/
+---
+## Ellipse class
+
+Una Elipse define un conjunto de puntos que forman la forma de una elipse.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Constructor de Ellipse |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload(semiAxis1, semiAxis2) | Constructor de Ellipse |
+
+ **Result:**
+
+
+
+---
+
+
+### getSemiAxis1{#getSemiAxis1}
+
+| Nombre | Descripción |
+| --- | --- |
+| getSemiAxis1() | Radio en el eje X |
+
+ **Result:**
+
+
+
+---
+
+
+### setSemiAxis1{#setSemiAxis1}
+
+| Nombre | Descripción |
+| --- | --- |
+| setSemiAxis1(value) | Radio en el eje X |
+
+ **Result:**
+
+
+
+---
+
+
+### getSemiAxis2{#getSemiAxis2}
+
+| Nombre | Descripción |
+| --- | --- |
+| getSemiAxis2() | Radio en el eje Y |
+
+ **Result:**
+
+
+
+---
+
+
+### setSemiAxis2{#setSemiAxis2}
+
+| Nombre | Descripción |
+| --- | --- |
+| setSemiAxis2(value) | Radio en el eje Y |
+
+ **Result:**
+
+
+
+---
+
+
+### getColor{#getColor}
+
+| Nombre | Descripción |
+| --- | --- |
+| getColor() | Obtiene o establece el color de la línea, el valor predeterminado es blanco(1, 1, 1) |
+
+ **Result:**
+
+
+
+---
+
+
+### setColor{#setColor}
+
+| Nombre | Descripción |
+| --- | --- |
+| setColor(value) | Obtiene o establece el color de la línea, el valor predeterminado es blanco(1, 1, 1) |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNodes() | Obtiene todos los nodos padre; una entidad puede estar adjunta a varios nodos padre para la instanciación de geometría. Los nodos. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExcluded() | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExcluded(value) | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNode() | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setParentNode(value) | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Nombre | Descripción |
+| --- | --- |
+| getScene() | Obtiene la escena a la que pertenece este objeto |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEntityRendererKey() | Obtiene la clave del renderizador de entidad registrado en el renderizador |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBoundingBox() | Obtiene el cuadro delimitador de la entidad actual en su sistema de coordenadas de espacio de objeto. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/ellipseshape/_index.md
+++ b/spanish/nodejs-java/aspose.threed/ellipseshape/_index.md
@@ -1,0 +1,333 @@
+---
+title: "EllipseShape"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/ellipseshape/
+---
+## EllipseShape class
+
+Forma de elipse compatible con IFC definida por parámetros. La posición central del perfil está en el centro del cuadro delimitador.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getSemiAxis1{#getSemiAxis1}
+
+| Nombre | Descripción |
+| --- | --- |
+| getSemiAxis1() | Obtiene o establece el primer radio de la elipse que se mide en la dirección del eje x. |
+
+ **Result:**
+
+
+
+---
+
+
+### setSemiAxis1{#setSemiAxis1}
+
+| Nombre | Descripción |
+| --- | --- |
+| setSemiAxis1(value) | Obtiene o establece el primer radio de la elipse que se mide en la dirección del eje x. |
+
+ **Result:**
+
+
+
+---
+
+
+### getSemiAxis2{#getSemiAxis2}
+
+| Nombre | Descripción |
+| --- | --- |
+| getSemiAxis2() | Obtiene o establece el segundo radio de la elipse que se mide en la dirección del eje y. |
+
+ **Result:**
+
+
+
+---
+
+
+### setSemiAxis2{#setSemiAxis2}
+
+| Nombre | Descripción |
+| --- | --- |
+| setSemiAxis2(value) | Obtiene o establece el segundo radio de la elipse que se mide en la dirección del eje y. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNodes() | Obtiene todos los nodos padre; una entidad puede estar adjunta a varios nodos padre para la instanciación de geometría. Los nodos. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExcluded() | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExcluded(value) | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNode() | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setParentNode(value) | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Nombre | Descripción |
+| --- | --- |
+| getScene() | Obtiene la escena a la que pertenece este objeto |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtent{#getExtent}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExtent() | Obtiene la extensión en las dimensiones x e y. |
+
+ **Result:**
+Vector2
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEntityRendererKey() | Obtiene la clave del renderizador de entidad registrado en el renderizador |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBoundingBox() | Obtiene el cuadro delimitador de la entidad actual en su sistema de coordenadas de espacio de objeto. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/endpoint/_index.md
+++ b/spanish/nodejs-java/aspose.threed/endpoint/_index.md
@@ -1,0 +1,157 @@
+---
+title: "EndPoint"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/endpoint/
+---
+## EndPoint class
+
+El punto final para recortar la curva, puede ser un valor de parámetro o un punto cartesiano.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload(point) | Construye un EndPoint a partir de un punto cartesiano. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| poin | Vector3 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload2(v) | Construye un EndPoint a partir de un parámetro real. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+|  | Número | null |
+
+ **Result:**
+
+
+
+---
+
+
+### isCartesianPoint{#isCartesianPoint}
+
+| Nombre | Descripción |
+| --- | --- |
+| isCartesianPoint() | ¿Es el punto final un punto cartesiano? |
+
+ **Result:**
+
+
+
+---
+
+
+### getAsPoint{#getAsPoint}
+
+| Nombre | Descripción |
+| --- | --- |
+| getAsPoint() | Obtiene el punto final como punto cartesiano, o lanza una excepción. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAsValue{#getAsValue}
+
+| Nombre | Descripción |
+| --- | --- |
+| getAsValue() | Obtiene el punto final como un parámetro real, o lanza una excepción. |
+
+ **Result:**
+
+
+
+---
+
+
+### fromDegree{#fromDegree}
+
+| Nombre | Descripción |
+| --- | --- |
+| fromDegree(degree) | Crea un punto final medido en grados. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| grado | Número | null |
+
+ **Result:**
+EndPoint
+
+
+---
+
+
+### fromRadian{#fromRadian}
+
+| Nombre | Descripción |
+| --- | --- |
+| fromRadian(degree) | Crea un punto final medido en radianes. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| grado | Número | null |
+
+ **Result:**
+EndPoint
+
+
+---
+
+
+### toString{#toString}
+
+| Nombre | Descripción |
+| --- | --- |
+| toString() | Devuelve una representación en cadena del punto final actual. |
+
+ **Result:**
+Cadena
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/entity/_index.md
+++ b/spanish/nodejs-java/aspose.threed/entity/_index.md
@@ -1,0 +1,274 @@
+---
+title: "Entidad"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/entity/
+---
+## Entity class
+
+La clase base de todas las entidades.  Entity representa un objeto concreto que está adjunto bajo un nodo como Light/Geometry.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor(name) | Inicializa una nueva instancia de la clase Entity. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| name | Cadena | Nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNodes() | Obtiene todos los nodos padre; una entidad puede estar adjunta a varios nodos padre para la instanciación de geometría. Los nodos. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExcluded() | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExcluded(value) | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNode() | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setParentNode(value) | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Nombre | Descripción |
+| --- | --- |
+| getScene() | Obtiene la escena a la que pertenece este objeto |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBoundingBox() | Obtiene el cuadro delimitador de la entidad actual en su sistema de coordenadas de espacio de objeto. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEntityRendererKey() | Obtiene la clave del renderizador de entidad registrado en el renderizador |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/entityrenderer/_index.md
+++ b/spanish/nodejs-java/aspose.threed/entityrenderer/_index.md
@@ -1,0 +1,185 @@
+---
+title: "EntityRenderer"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/entityrenderer/
+---
+## EntityRenderer class
+
+Subclase esto para implementar renderizado para diferentes tipos de entidades.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor(key, features) | Constructor de EntityRenderer |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| key | Cadena | La clave del renderizador de entidad |
+| features | byte | EntityRendererFeatures |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload(key) | Constructor de EntityRenderer |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| key | Cadena | La clave del renderizador de entidad |
+
+ **Result:**
+
+
+
+---
+
+
+### initialize{#initialize}
+
+| Nombre | Descripción |
+| --- | --- |
+| initialize(renderer) | Inicializar el renderizador de entidad |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| rendere | Renderizador | null |
+
+ **Result:**
+
+
+
+---
+
+
+### resetSceneCache{#resetSceneCache}
+
+| Nombre | Descripción |
+| --- | --- |
+| resetSceneCache() | La escena ha cambiado o se ha eliminado, es necesario liberar los recursos de renderizado a nivel de escena en esto |
+
+ **Result:**
+
+
+
+---
+
+
+### frameBegin{#frameBegin}
+
+| Nombre | Descripción |
+| --- | --- |
+| frameBegin(renderer, renderQueue) | Iniciar el renderizado de un fotograma |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| renderizador | Renderizador | Renderizador actual |
+| renderQueue | IRenderQueue | Cola de renderizado |
+
+ **Result:**
+
+
+
+---
+
+
+### frameEnd{#frameEnd}
+
+| Nombre | Descripción |
+| --- | --- |
+| frameEnd(renderer, renderQueue) | Finaliza el renderizado de un fotograma |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| renderizador | Renderizador | Renderizador actual |
+| renderQueue | IRenderQueue | Cola de renderizado |
+
+ **Result:**
+
+
+
+---
+
+
+### prepareRenderQueue{#prepareRenderQueue}
+
+| Nombre | Descripción |
+| --- | --- |
+| prepareRenderQueue(renderer, queue, node, entity) | Preparar comandos de renderizado para el par nodo/entidad especificado. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| renderizador | Renderizador | La instancia del renderizador actual |
+| cola | IRenderQueue | La cola de renderizado utilizada para gestionar tareas de renderizado |
+| nodo | Nodo | Nodo actual |
+| entidad | Entidad | La entidad que necesita ser renderizada |
+
+ **Result:**
+
+
+
+---
+
+
+### renderEntity{#renderEntity}
+
+| Nombre | Descripción |
+| --- | --- |
+| renderEntity(renderer, commandList, node, renderableResource, subEntity) | Cada tarea de renderizado enviada a com.aspose.threed.IRenderQueue tendrá una llamada correspondiente a RenderEntity para ejecutar el trabajo de renderizado concreto. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| renderizador | Renderizador | El renderizador |
+| commandList | ICommandList | La commandList utilizada para registrar los comandos de renderizado |
+| nodo | Nodo | El mismo nodo que se pasó a PrepareRenderQueue de la entidad que será renderizada |
+| renderableResource | Objeto | El objeto personalizado que se pasó a IRenderQueue durante el PrepareRenderQueue |
+| subEntity | Número | El índice del sub entity que se pasó a IRenderQueue |
+
+ **Result:**
+
+
+
+---
+
+
+### dispose{#dispose}
+
+| Nombre | Descripción |
+| --- | --- |
+| dispose() | El renderizador de entidad se está disponiendo, libere los recursos compartidos. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/entityrendererkey/_index.md
+++ b/spanish/nodejs-java/aspose.threed/entityrendererkey/_index.md
@@ -1,0 +1,48 @@
+---
+title: "EntityRendererKey"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/entityrendererkey/
+---
+## EntityRendererKey class
+
+La clave del renderizador de entidad registrado
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor(name) | Constructor de EntityRendererKey |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| nam | Cadena | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| Nombre | Descripción |
+| --- | --- |
+| toString() |  |
+
+ **Result:**
+Cadena
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/exportexception/_index.md
+++ b/spanish/nodejs-java/aspose.threed/exportexception/_index.md
@@ -1,0 +1,35 @@
+---
+title: "ExportException"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/exportexception/
+---
+## ExportException class
+
+Excepciones cuando Aspose.3D no pudo exportar la escena a un archivo
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor(msg) | Inicializa una nueva instancia |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| msg | Cadena | Mensaje de error |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/extrapolation/_index.md
+++ b/spanish/nodejs-java/aspose.threed/extrapolation/_index.md
@@ -1,0 +1,68 @@
+---
+title: "Extrapolation"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/extrapolation/
+---
+## Extrapolation class
+
+La extrapolación define qué hacer cuando el valor muestreado está fuera del rango definido por los primeros y últimos fotogramas clave.  @hideconstructor
+
+
+## Métodos
+
+### getType{#getType}
+
+| Nombre | Descripción |
+| --- | --- |
+| getType() | Obtiene y establece el patrón de muestreo de la extrapolación. El valor de la propiedad es una constante entera ExtrapolationType. El tipo. |
+
+ **Result:**
+
+
+
+---
+
+
+### setType{#setType}
+
+| Nombre | Descripción |
+| --- | --- |
+| setType(value) | Obtiene y establece el patrón de muestreo de la extrapolación. El valor de la propiedad es una constante entera ExtrapolationType. El tipo. |
+
+ **Result:**
+
+
+
+---
+
+
+### getRepeatCount{#getRepeatCount}
+
+| Nombre | Descripción |
+| --- | --- |
+| getRepeatCount() | Obtiene y establece la cantidad de repeticiones del patrón de extrapolación. El recuento. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRepeatCount{#setRepeatCount}
+
+| Nombre | Descripción |
+| --- | --- |
+| setRepeatCount(value) | Obtiene y establece la cantidad de repeticiones del patrón de extrapolación. El recuento. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/fbxloadoptions/_index.md
+++ b/spanish/nodejs-java/aspose.threed/fbxloadoptions/_index.md
@@ -1,0 +1,165 @@
+---
+title: "FbxLoadOptions"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/fbxloadoptions/
+---
+## FbxLoadOptions class
+
+Opciones de carga para formato Fbx.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor(format) | Constructor de FbxLoadOptions |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| forma | FileFormat | null |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload() | Constructor de FbxLoadOptions |
+
+ **Result:**
+
+
+
+---
+
+
+### getKeepBuiltinGlobalSettings{#getKeepBuiltinGlobalSettings}
+
+| Nombre | Descripción |
+| --- | --- |
+| getKeepBuiltinGlobalSettings() | Obtiene o establece si se deben mantener las propiedades incorporadas en GlobalSettings que tienen un reemplazo de propiedad nativa en AssetInfo. Establezca esto en true si desea todas las propiedades en GlobalSettings. El valor predeterminado es false |
+
+ **Result:**
+
+
+
+---
+
+
+### setKeepBuiltinGlobalSettings{#setKeepBuiltinGlobalSettings}
+
+| Nombre | Descripción |
+| --- | --- |
+| setKeepBuiltinGlobalSettings(value) | Obtiene o establece si se deben mantener las propiedades incorporadas en GlobalSettings que tienen un reemplazo de propiedad nativa en AssetInfo. Establezca esto en true si desea todas las propiedades en GlobalSettings. El valor predeterminado es false |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileFormat() | Obtiene el formato de archivo especificado en la opción actual de Guardar/Cargar. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEncoding() | Obtiene o establece la codificación predeterminada para archivos basados en texto. El valor predeterminado es null, lo que significa que el importador/exportador decidirá qué codificación usar. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileSystem() | Permite al usuario manejar cómo gestionar las dependencias externas durante la carga/guardado. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFileSystem(value) | Permite al usuario manejar cómo gestionar las dependencias externas durante la carga/guardado. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| Nombre | Descripción |
+| --- | --- |
+| getLookupPaths() | Algunos archivos como OBJ dependen de archivos externos; las rutas de búsqueda permiten que Aspose.3D busque el archivo externo para cargarlo. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileName() | El nombre de archivo de la escena de exportación/importación. Es opcional, pero útil al serializar recursos externos como el material de OBJ. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFileName(value) | El nombre de archivo de la escena de exportación/importación. Es opcional, pero útil al serializar recursos externos como el material de OBJ. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/fbxsaveoptions/_index.md
+++ b/spanish/nodejs-java/aspose.threed/fbxsaveoptions/_index.md
@@ -1,0 +1,340 @@
+---
+title: "FbxSaveOptions"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/fbxsaveoptions/
+---
+## FbxSaveOptions class
+
+Opciones de guardado para archivo Fbx.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor(format) | Inicializa un FbxSaveOptions |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| forma | FileFormat | null |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload(contentType) | Inicializa un FbxSaveOptions usando la última versión compatible. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| contentType | FileContentType | FileContentType |
+
+ **Result:**
+
+
+
+---
+
+
+### getReusePrimitiveMesh{#getReusePrimitiveMesh}
+
+| Nombre | Descripción |
+| --- | --- |
+| getReusePrimitiveMesh() | Reutiliza la malla para los primitivas con los mismos parámetros, lo que reducirá significativamente el tamaño del archivo FBX cuando la escena se haya construido con un gran conjunto de formas primitivas (como importadas de archivos CAD). El valor predeterminado es false. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReusePrimitiveMesh{#setReusePrimitiveMesh}
+
+| Nombre | Descripción |
+| --- | --- |
+| setReusePrimitiveMesh(value) | Reutiliza la malla para los primitivas con los mismos parámetros, lo que reducirá significativamente el tamaño del archivo FBX cuando la escena se haya construido con un gran conjunto de formas primitivas (como importadas de archivos CAD). El valor predeterminado es false. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEnableCompression{#getEnableCompression}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEnableCompression() | Compresión de datos binarios grandes en el archivo FBX (p. ej., datos de animación, puntos de control, datos de elementos de vértice, índices), el valor predeterminado es true. |
+
+ **Result:**
+
+
+
+---
+
+
+### setEnableCompression{#setEnableCompression}
+
+| Nombre | Descripción |
+| --- | --- |
+| setEnableCompression(value) | Compresión de datos binarios grandes en el archivo FBX (p. ej., datos de animación, puntos de control, datos de elementos de vértice, índices), el valor predeterminado es true. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFoldRepeatedCurveData{#getFoldRepeatedCurveData}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFoldRepeatedCurveData() | Obtiene o establece si reutiliza datos de curvas repetidas incrementando el recuento de referencias del último dato; true si se pliegan los datos de curvas repetidas; de lo contrario, false. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportLegacyMaterialProperties{#getExportLegacyMaterialProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExportLegacyMaterialProperties() | Obtiene o establece si exporta propiedades de material heredadas, usadas para compatibilidad retroactiva. Esta opción está activada por defecto. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportLegacyMaterialProperties{#setExportLegacyMaterialProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExportLegacyMaterialProperties(value) | Obtiene o establece si exporta propiedades de material heredadas, usadas para compatibilidad retroactiva. Esta opción está activada por defecto. |
+
+ **Result:**
+
+
+
+---
+
+
+### getVideoForTexture{#getVideoForTexture}
+
+| Nombre | Descripción |
+| --- | --- |
+| getVideoForTexture() | Obtiene o establece si genera una instancia de Video para la Textura al exportar como FBX. |
+
+ **Result:**
+
+
+
+---
+
+
+### setVideoForTexture{#setVideoForTexture}
+
+| Nombre | Descripción |
+| --- | --- |
+| setVideoForTexture(value) | Obtiene o establece si genera una instancia de Video para la Textura al exportar como FBX. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEmbedTextures{#getEmbedTextures}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEmbedTextures() | Obtiene o establece si incrusta la textura en el archivo de salida final. El exportador FBX intentará encontrar los datos sin procesar de la textura en el sistema de archivos y incrustará el archivo en el FBX final. El valor predeterminado es false. |
+
+ **Result:**
+
+
+
+---
+
+
+### setEmbedTextures{#setEmbedTextures}
+
+| Nombre | Descripción |
+| --- | --- |
+| setEmbedTextures(value) | Obtiene o establece si incrusta la textura en el archivo de salida final. El exportador FBX intentará encontrar los datos sin procesar de la textura en el sistema de archivos y incrustará el archivo en el FBX final. El valor predeterminado es false. |
+
+ **Result:**
+
+
+
+---
+
+
+### getGenerateVertexElementMaterial{#getGenerateVertexElementMaterial}
+
+| Nombre | Descripción |
+| --- | --- |
+| getGenerateVertexElementMaterial() | Obtiene o establece si siempre genera un VertexElementMaterial para geometrías cuando el nodo adjunto contiene materiales. Esta opción está desactivada por defecto. |
+
+ **Result:**
+
+
+
+---
+
+
+### setGenerateVertexElementMaterial{#setGenerateVertexElementMaterial}
+
+| Nombre | Descripción |
+| --- | --- |
+| setGenerateVertexElementMaterial(value) | Obtiene o establece si siempre genera un VertexElementMaterial para geometrías cuando el nodo adjunto contiene materiales. Esta opción está desactivada por defecto. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportTextures{#getExportTextures}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExportTextures() | Intenta copiar las texturas usadas en la escena al directorio de salida. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextures{#setExportTextures}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExportTextures(value) | Intenta copiar las texturas usadas en la escena al directorio de salida. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileFormat() | Obtiene el formato de archivo especificado en la opción actual de Guardar/Cargar. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEncoding() | Obtiene o establece la codificación predeterminada para archivos basados en texto. El valor predeterminado es null, lo que significa que el importador/exportador decidirá qué codificación usar. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileSystem() | Permite al usuario manejar cómo gestionar las dependencias externas durante la carga/guardado. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFileSystem(value) | Permite al usuario manejar cómo gestionar las dependencias externas durante la carga/guardado. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| Nombre | Descripción |
+| --- | --- |
+| getLookupPaths() | Algunos archivos como OBJ dependen de archivos externos; las rutas de búsqueda permiten que Aspose.3D busque el archivo externo para cargarlo. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileName() | El nombre de archivo de la escena de exportación/importación. Es opcional, pero útil al serializar recursos externos como el material de OBJ. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFileName(value) | El nombre de archivo de la escena de exportación/importación. Es opcional, pero útil al serializar recursos externos como el material de OBJ. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/fileformat/_index.md
+++ b/spanish/nodejs-java/aspose.threed/fileformat/_index.md
@@ -1,0 +1,187 @@
+---
+title: "FileFormat"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/fileformat/
+---
+## FileFormat class
+
+Definición del formato de archivo  @hideconstructor
+
+
+## Propiedades
+
+| Nombre | Descripción |
+| --- | --- |
+| MAYA_BINARY | Autodesk Maya en formato binario |
+| STL_BINARY | Formato de archivo STL binario |
+| STLASCII | Formato de archivo STL ASCII |
+| COLLADA | Formato de archivo Collada |
+| GLTF | glTF de Khronos Group |
+| GLTF_BINARY | glTF de Khronos Group en formato binario |
+| PDF | Formato de Documento Portátil de Adobe |
+| DXF | AutoCAD DXF |
+| PLY | Formato de Archivo de Polígonos o Formato de Triángulo de Stanford |
+| X_BINARY | Archivo X de DirectX en formato binario |
+| X_TEXT | Archivo X de DirectX en formato binario |
+| DRACO | Malla Draco de Google |
+| RVM_TEXT | Modelo del Sistema de Gestión de Diseño de Planta AVEVA en formato de texto |
+| RVM_BINARY | Modelo del Sistema de Gestión de Diseño de Planta AVEVA en formato binario |
+| ASE | Formato del exportador de escena ASCII de 3D Studio Max. |
+| IFC | Modelo de datos de Industry Foundation Classes ISO 16739-1. |
+| AMF | Formato de archivo de fabricación aditiva |
+| VRML | El Lenguaje de Modelado de Realidad Virtual |
+| ZIP | Archivo Zip que contiene otros formatos de archivo 3d. |
+| USD | Descripción de escena universal |
+| USDZ | Descripción de escena universal comprimida |
+| XYZ | Archivo de nube de puntos Xyz |
+| PCD | Archivo de datos de nube de puntos PCL en modo ASCII |
+| PCD_BINARY | Archivo de datos de nube de puntos PCL en modo binario |
+
+## Métodos
+
+### getVersion{#getVersion}
+
+| Nombre | Descripción |
+| --- | --- |
+| getVersion() | Obtiene la versión del formato de archivo |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtension{#getExtension}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExtension() | Obtiene el nombre de la extensión de este tipo. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtensions{#getExtensions}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExtensions() | Obtiene los nombres de las extensiones de este tipo. |
+
+ **Result:**
+
+
+
+---
+
+
+### getContentType{#getContentType}
+
+| Nombre | Descripción |
+| --- | --- |
+| getContentType() | Obtiene el tipo de contenido del formato de archivo. El valor de la propiedad es la constante entera FileContentType. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormatType{#getFileFormatType}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileFormatType() | Obtiene el tipo de formato de archivo |
+
+ **Result:**
+
+
+
+---
+
+
+### getFormatByExtension{#getFormatByExtension}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFormatByExtension(extensionName) | Obtiene el formato de archivo preferido a partir del nombre de la extensión del archivo. El nombre de la extensión debe comenzar con un punto ('.'). |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| extensionNam | Cadena | null |
+
+ **Result:**
+FileFormat
+
+
+---
+
+
+### detect{#detect}
+
+| Nombre | Descripción |
+| --- | --- |
+| detect(fileName) | Detecta el formato de archivo a partir del nombre del archivo; el archivo debe ser legible para que Aspose.3D pueda detectar el formato de archivo mediante el encabezado del archivo. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| fileNam | Cadena | null |
+
+ **Result:**
+FileFormat
+
+
+---
+
+
+### createLoadOptions{#createLoadOptions}
+
+| Nombre | Descripción |
+| --- | --- |
+| createLoadOptions() | Crea opciones de carga predeterminadas para este formato de archivo |
+
+ **Result:**
+LoadOptions
+
+
+---
+
+
+### createSaveOptions{#createSaveOptions}
+
+| Nombre | Descripción |
+| --- | --- |
+| createSaveOptions() | Crea opciones de guardado predeterminadas para este formato de archivo |
+
+ **Result:**
+SaveOptions
+
+
+---
+
+
+### toString{#toString}
+
+| Nombre | Descripción |
+| --- | --- |
+| toString() | Formatos a cadena |
+
+ **Result:**
+Cadena
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/fileformattype/_index.md
+++ b/spanish/nodejs-java/aspose.threed/fileformattype/_index.md
@@ -1,0 +1,66 @@
+---
+title: "FileFormatType"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/fileformattype/
+---
+## FileFormatType class
+
+Tipo de formato de archivo  @hideconstructor
+
+
+## Propiedades
+
+| Nombre | Descripción |
+| --- | --- |
+| MAYA | Tipo de formato Autodesk Maya |
+| FBX | Tipo de formato de archivo FBX |
+| STL | Tipo de formato de archivo STL |
+| COLLADA | Formato de archivo Collada del Khronos Group. |
+| PDF | Formato de Documento Portátil |
+| GLTF | glTF de Khronos Group |
+| DXF | AutoCAD DXF |
+| PLY | Formato de Archivo de Polígonos o Formato de Triángulo de Stanford |
+| X | Archivo X de DirectX |
+| DRACO | Malla Draco de Google |
+| RVM | Modelo del Sistema de Gestión de Diseño de Planta AVEVA. |
+| ASE | Formato del exportador de escena ASCII de 3D Studio Max. |
+| ZIP | Archivo Zip que contiene otros formatos de archivo 3d. |
+| USD | Descripción de escena universal |
+| PCD | Datos de Nube de Puntos usados por Point Cloud Library |
+| XYZ | Archivo de nube de puntos Xyz |
+| IFC | Modelo de datos de Industry Foundation Classes ISO 16739-1. |
+| AMF | Formato de archivo de fabricación aditiva |
+| VRML | El Lenguaje de Modelado de Realidad Virtual |
+
+## Métodos
+
+### getExtension{#getExtension}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExtension() | El nombre de extensión de este formato de archivo, comienza con . |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| Nombre | Descripción |
+| --- | --- |
+| toString() | Obtener el nombre de este tipo de formato de archivo |
+
+ **Result:**
+Cadena
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/filesystem/_index.md
+++ b/spanish/nodejs-java/aspose.threed/filesystem/_index.md
@@ -1,0 +1,56 @@
+---
+title: "FileSystem"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/filesystem/
+---
+## FileSystem class
+
+Encapsulación del sistema de archivos.  Aspose.3D usará esto para leer/escribir dependencias.  @hideconstructor
+
+
+## Métodos
+
+### readFile{#readFile}
+
+| Nombre | Descripción |
+| --- | --- |
+| readFile(fileName, options) | Crea un flujo para leer dependencias. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| fileNam | Cadena | null |
+| opción | IOConfig | null |
+
+ **Result:**
+Stream
+
+
+---
+
+
+### writeFile{#writeFile}
+
+| Nombre | Descripción |
+| --- | --- |
+| writeFile(fileName, options) | Crea un flujo para escribir dependencias. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| fileNam | Cadena | null |
+| opción | IOConfig | null |
+
+ **Result:**
+Stream
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/fmatrix4/_index.md
+++ b/spanish/nodejs-java/aspose.threed/fmatrix4/_index.md
@@ -1,0 +1,190 @@
+---
+title: "FMatrix4"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/fmatrix4/
+---
+## FMatrix4 class
+
+Matriz 4x4 con todos los componentes en tipo flotante
+
+
+## Propiedades
+
+| Nombre | Descripción |
+| --- | --- |
+| m00 | El m00. |
+| m01 | El m01. |
+| m02 | El m02. |
+| m03 | El m03. |
+| m10 | El m10. |
+| m11 | El m11. |
+| m12 | El m12. |
+| m13 | El m13. |
+| m20 | El m20. |
+| m21 | El m21. |
+| m22 | El m22. |
+| m23 | El m23. |
+| m30 | El m30. |
+| m31 | El m31. |
+| m32 | El m32. |
+| m33 | El m33. |
+| IDENTITY | La matriz identidad |
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload(m00, m01, m02, m03, m10, m11, m12, m13, m20, m21, m22, m23, m30, m31, m32, m33) | Inicializar la instancia de FMatrix4 |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| m0 | Número | null |
+| m0 | Número | null |
+| m0 | Número | null |
+| m0 | Número | null |
+| m1 | Número | null |
+| m1 | Número | null |
+| m1 | Número | null |
+| m1 | Número | null |
+| m2 | Número | null |
+| m2 | Número | null |
+| m2 | Número | null |
+| m2 | Número | null |
+| m3 | Número | null |
+| m3 | Número | null |
+| m3 | Número | null |
+| m3 | Número | null |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload2(mat) | Inicializa la instancia de FMatrix4 a partir de una instancia de Matrix4. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| ma | Matrix4 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload3{#constructor_overload3}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload3(r0, r1, r2, r3) | Construye la matriz a partir de 4 filas. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| r0 | FVector4 | R0. |
+| r1 | FVector4 | R1. |
+| r2 | FVector4 | R2. |
+| r3 | FVector4 | R3. |
+
+ **Result:**
+
+
+
+---
+
+
+### concatenate{#concatenate}
+
+| Nombre | Descripción |
+| --- | --- |
+| concatenate(m2) | Concatena las dos matrices |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| m2 | FMatrix4 | M2. |
+
+ **Result:**
+FMatrix4
+
+
+---
+
+
+### concatenate{#concatenate}
+
+| Nombre | Descripción |
+| --- | --- |
+| concatenate(m2) | Concatena las dos matrices |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| m2 | Matrix4 | M2. |
+
+ **Result:**
+FMatrix4
+
+
+---
+
+
+### transpose{#transpose}
+
+| Nombre | Descripción |
+| --- | --- |
+| transpose() | Transpone esta instancia. |
+
+ **Result:**
+FMatrix4
+
+
+---
+
+
+### inverse{#inverse}
+
+| Nombre | Descripción |
+| --- | --- |
+| inverse() | Calcula la matriz inversa de la instancia actual. |
+
+ **Result:**
+FMatrix4
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/fontfile/_index.md
+++ b/spanish/nodejs-java/aspose.threed/fontfile/_index.md
@@ -1,0 +1,189 @@
+---
+title: "FontFile"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/fontfile/
+---
+## FontFile class
+
+El archivo de fuente contiene definiciones de glifos, se usa para crear el perfil de texto.  @hideconstructor
+
+
+## Métodos
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### fromFile{#fromFile}
+
+| Nombre | Descripción |
+| --- | --- |
+| fromFile(fileName) | Cargar FontFile desde el nombre de archivo |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| fileName | Cadena | Ruta al archivo de fuente |
+
+ **Result:**
+FontFile
+
+
+---
+
+
+### parse{#parse}
+
+| Nombre | Descripción |
+| --- | --- |
+| parse(bytes) | Analizar FontFile desde bytes |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| bytes | byte[] | Contenido sin procesar del archivo de fuente OTF |
+
+ **Result:**
+FontFile
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/frustum/_index.md
+++ b/spanish/nodejs-java/aspose.threed/frustum/_index.md
@@ -1,0 +1,489 @@
+---
+title: "Frustum"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/frustum/
+---
+## Frustum class
+
+La clase base de Cámara y Luz  @hideconstructor
+
+
+## Métodos
+
+### getRotationMode{#getRotationMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getRotationMode() | Obtiene o establece el modo de orientación del frustum. Esta propiedad solo funciona cuando Target es nulo. Si el valor es RotationMode.FIXED_TARGET, la dirección siempre se calcula mediante la propiedad LookAt. De lo contrario, LookAt siempre se calcula mediante Direction. El valor de la propiedad es la constante entera RotationMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRotationMode{#setRotationMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setRotationMode(value) | Obtiene o establece el modo de orientación del frustum. Esta propiedad solo funciona cuando Target es nulo. Si el valor es RotationMode.FIXED_TARGET, la dirección siempre se calcula mediante la propiedad LookAt. De lo contrario, LookAt siempre se calcula mediante Direction. El valor de la propiedad es la constante entera RotationMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getNearPlane{#getNearPlane}
+
+| Nombre | Descripción |
+| --- | --- |
+| getNearPlane() | Obtiene o establece la distancia del plano cercano del frustum. |
+
+ **Result:**
+
+
+
+---
+
+
+### setNearPlane{#setNearPlane}
+
+| Nombre | Descripción |
+| --- | --- |
+| setNearPlane(value) | Obtiene o establece la distancia del plano cercano del frustum. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFarPlane{#getFarPlane}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFarPlane() | Obtiene o establece la distancia del plano lejano del frustum. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFarPlane{#setFarPlane}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFarPlane(value) | Obtiene o establece la distancia del plano lejano del frustum. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAspect{#getAspect}
+
+| Nombre | Descripción |
+| --- | --- |
+| getAspect() | Obtiene o establece la relación de aspecto del frustum |
+
+ **Result:**
+
+
+
+---
+
+
+### setAspect{#setAspect}
+
+| Nombre | Descripción |
+| --- | --- |
+| setAspect(value) | Obtiene o establece la relación de aspecto del frustum |
+
+ **Result:**
+
+
+
+---
+
+
+### getOrthoHeight{#getOrthoHeight}
+
+| Nombre | Descripción |
+| --- | --- |
+| getOrthoHeight() | Obtiene o establece la altura cuando el frustum está en proyección ortográfica. |
+
+ **Result:**
+
+
+
+---
+
+
+### setOrthoHeight{#setOrthoHeight}
+
+| Nombre | Descripción |
+| --- | --- |
+| setOrthoHeight(value) | Obtiene o establece la altura cuando el frustum está en proyección ortográfica. |
+
+ **Result:**
+
+
+
+---
+
+
+### getUp{#getUp}
+
+| Nombre | Descripción |
+| --- | --- |
+| getUp() | Obtiene o establece la dirección ascendente de la cámara |
+
+ **Result:**
+
+
+
+---
+
+
+### setUp{#setUp}
+
+| Nombre | Descripción |
+| --- | --- |
+| setUp(value) | Obtiene o establece la dirección ascendente de la cámara |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookAt{#getLookAt}
+
+| Nombre | Descripción |
+| --- | --- |
+| getLookAt() | Obtiene o establece la posición de interés a la que la cámara está mirando. |
+
+ **Result:**
+
+
+
+---
+
+
+### setLookAt{#setLookAt}
+
+| Nombre | Descripción |
+| --- | --- |
+| setLookAt(value) | Obtiene o establece la posición de interés a la que la cámara está mirando. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDirection{#getDirection}
+
+| Nombre | Descripción |
+| --- | --- |
+| getDirection() | Obtiene o establece la dirección a la que la cámara está mirando. Los cambios en esta propiedad también afectarán a LookAt y Target. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDirection{#setDirection}
+
+| Nombre | Descripción |
+| --- | --- |
+| setDirection(value) | Obtiene o establece la dirección a la que la cámara está mirando. Los cambios en esta propiedad también afectarán a LookAt y Target. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTarget{#getTarget}
+
+| Nombre | Descripción |
+| --- | --- |
+| getTarget() | Obtiene o establece el objetivo al que la cámara está mirando. Si el usuario admite esta propiedad, debe ser anterior a la propiedad LookAt. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTarget{#setTarget}
+
+| Nombre | Descripción |
+| --- | --- |
+| setTarget(value) | Obtiene o establece el objetivo al que la cámara está mirando. Si el usuario admite esta propiedad, debe ser anterior a la propiedad LookAt. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNodes() | Obtiene todos los nodos padre; una entidad puede estar adjunta a varios nodos padre para la instanciación de geometría. Los nodos. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExcluded() | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExcluded(value) | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNode() | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setParentNode(value) | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Nombre | Descripción |
+| --- | --- |
+| getScene() | Obtiene la escena a la que pertenece este objeto |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBoundingBox() | Obtiene el cuadro delimitador de la entidad actual en su sistema de coordenadas de espacio de objeto. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEntityRendererKey() | Obtiene la clave del renderizador de entidad registrado en el renderizador |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/fvector2/_index.md
+++ b/spanish/nodejs-java/aspose.threed/fvector2/_index.md
@@ -1,0 +1,126 @@
+---
+title: "FVector2"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/fvector2/
+---
+## FVector2 class
+
+Un vector flotante con dos componentes.
+
+
+## Propiedades
+
+| Nombre | Descripción |
+| --- | --- |
+| x | El componente x. |
+| y | El componente y. |
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload(x, y) | Inicializa una nueva instancia de FVector2. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload2(vec) | Inicializa una nueva instancia de FVector2. |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| Nombre | Descripción |
+| --- | --- |
+| toString() |  |
+
+ **Result:**
+Cadena
+
+
+---
+
+
+### equals{#equals}
+
+| Nombre | Descripción |
+| --- | --- |
+| equals(rhs) | Comprueba si dos vectores son iguales |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| rh | FVector2 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### equals{#equals}
+
+| Nombre | Descripción |
+| --- | --- |
+| equals(obj) | Comprueba si dos vectores son iguales |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| ob | Objeto | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### hashCode{#hashCode}
+
+| Nombre | Descripción |
+| --- | --- |
+| hashCode() | Obtiene el código hash de esta instancia |
+
+ **Result:**
+Número
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/fvector3/_index.md
+++ b/spanish/nodejs-java/aspose.threed/fvector3/_index.md
@@ -1,0 +1,123 @@
+---
+title: "FVector3"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/fvector3/
+---
+## FVector3 class
+
+Un vector flotante con tres componentes.
+
+
+## Propiedades
+
+| Nombre | Descripción |
+| --- | --- |
+| x | El componente x. |
+| y | El componente y. |
+| z | El componente y. |
+| CERO | El vector Cero. |
+| UNIT_SCALE | El vector de escala unitaria con todos los componentes iguales a 1 |
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload(x, y, z) | Inicializa una nueva instancia de FVector3. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload2(vec) | Inicializa una nueva instancia de FVector3. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload3{#constructor_overload3}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload3(vec) | Inicializa una nueva instancia de FVector4. |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| Nombre | Descripción |
+| --- | --- |
+| toString() |  |
+
+ **Result:**
+Cadena
+
+
+---
+
+
+### normalize{#normalize}
+
+| Nombre | Descripción |
+| --- | --- |
+| normalize() | Normaliza esta instancia. |
+
+ **Result:**
+FVector3
+
+
+---
+
+
+### cross{#cross}
+
+| Nombre | Descripción |
+| --- | --- |
+| cross(rhs) | Producto cruz de dos vectores |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| rhs | FVector3 | Valor del lado derecho. |
+
+ **Result:**
+FVector3
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/fvector4/_index.md
+++ b/spanish/nodejs-java/aspose.threed/fvector4/_index.md
@@ -1,0 +1,116 @@
+---
+title: "FVector4"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/fvector4/
+---
+## FVector4 class
+
+Un vector flotante con cuatro componentes.
+
+
+## Propiedades
+
+| Nombre | Descripción |
+| --- | --- |
+| x | El componente x. |
+| y | El componente y. |
+| z | El componente z. |
+| w | El componente w. |
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload(x, y, z, w) | Inicializa una nueva instancia de FVector4. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload2(x, y, z) | Inicializa una nueva instancia de FVector4. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload3{#constructor_overload3}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload3(vec) | Inicializa una nueva instancia de FVector4. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload4{#constructor_overload4}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload4(vec) | Inicializa una nueva instancia de FVector4. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload5{#constructor_overload5}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload5(vec, w) | Inicializa una nueva instancia de FVector4. |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| Nombre | Descripción |
+| --- | --- |
+| toString() |  |
+
+ **Result:**
+Cadena
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/geometry/_index.md
+++ b/spanish/nodejs-java/aspose.threed/geometry/_index.md
@@ -1,0 +1,528 @@
+---
+title: "Geometría"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/geometry/
+---
+## Geometry class
+
+La clase base de todos los objetos geométricos renderizables (como Mesh, NurbsSurface, Patch, etc.).  La clase base Geometry admite:  Gestión de puntos de control, los puntos de control definen la estructura espacial 3D base de la geometría; los diferentes tipos geométricos tienen diferentes formas de definir modelos 3D concretos. Definición de elementos de vértice, los elementos de vértice aplican información adicional como normales, coordenadas uv o colores de vértice a la geometría; vea VertexElement para más detalles. Deformación de objetos, Deformer puede enlazarse para animar la forma de la geometría.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor(name) | Inicializa una nueva instancia de la clase Geometry. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| name | Cadena | Nombre |
+
+ **Result:**
+
+
+
+---
+
+
+### getVisible{#getVisible}
+
+| Nombre | Descripción |
+| --- | --- |
+| getVisible() | Obtiene o establece si la geometría es visible |
+
+ **Result:**
+
+
+
+---
+
+
+### setVisible{#setVisible}
+
+| Nombre | Descripción |
+| --- | --- |
+| setVisible(value) | Obtiene o establece si la geometría es visible |
+
+ **Result:**
+
+
+
+---
+
+
+### getDeformers{#getDeformers}
+
+| Nombre | Descripción |
+| --- | --- |
+| getDeformers() | Obtiene todos los deformadores asociados con esta geometría. Los deformadores. |
+
+ **Result:**
+
+
+
+---
+
+
+### getControlPoints{#getControlPoints}
+
+| Nombre | Descripción |
+| --- | --- |
+| getControlPoints() | Obtiene todos los puntos de control |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastShadows{#getCastShadows}
+
+| Nombre | Descripción |
+| --- | --- |
+| getCastShadows() | Obtiene o establece si esta geometría puede proyectar sombra |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastShadows{#setCastShadows}
+
+| Nombre | Descripción |
+| --- | --- |
+| setCastShadows(value) | Obtiene o establece si esta geometría puede proyectar sombra |
+
+ **Result:**
+
+
+
+---
+
+
+### getReceiveShadows{#getReceiveShadows}
+
+| Nombre | Descripción |
+| --- | --- |
+| getReceiveShadows() | Obtiene o establece si esta geometría puede recibir sombra. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReceiveShadows{#setReceiveShadows}
+
+| Nombre | Descripción |
+| --- | --- |
+| setReceiveShadows(value) | Obtiene o establece si esta geometría puede recibir sombra. |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElements{#getVertexElements}
+
+| Nombre | Descripción |
+| --- | --- |
+| getVertexElements() | Obtiene todos los elementos de vértice |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNodes() | Obtiene todos los nodos padre; una entidad puede estar adjunta a varios nodos padre para la instanciación de geometría. Los nodos. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExcluded() | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExcluded(value) | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNode() | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setParentNode(value) | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Nombre | Descripción |
+| --- | --- |
+| getScene() | Obtiene la escena a la que pertenece este objeto |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### getElement{#getElement}
+
+| Nombre | Descripción |
+| --- | --- |
+| getElement(type) | Obtiene un elemento de vértice con el tipo especificado |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| type | VertexElementType | VertexElementType |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### getVertexElementOfUV{#getVertexElementOfUV}
+
+| Nombre | Descripción |
+| --- | --- |
+| getVertexElementOfUV(textureMapping) | Obtiene una instancia de VertexElementUV con el tipo de TextureMapping dado |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| textureMapping | TextureMapping | TextureMapping |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### createElement{#createElement}
+
+| Nombre | Descripción |
+| --- | --- |
+| createElement(type) | Crea un elemento de vértice con el tipo especificado y lo agrega a la geometría. Si el tipo es VertexElementType.UV, se creará un VertexElementUV con el tipo de mapeo de textura a TextureMapping.DIFFUSE. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| type | VertexElementType | VertexElementType |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### addElement{#addElement}
+
+| Nombre | Descripción |
+| --- | --- |
+| addElement(element) | Agrega un elemento de vértice existente a la geometría actual |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| element | VertexElement | El elemento de vértice a agregar |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### createElement{#createElement}
+
+| Nombre | Descripción |
+| --- | --- |
+| createElement(type, mappingMode, referenceMode) | Crea un elemento de vértice con el tipo especificado y lo agrega a la geometría. Si el tipo es VertexElementType.UV, se creará un VertexElementUV con el tipo de mapeo de textura a TextureMapping.DIFFUSE. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| type | VertexElementType | VertexElementType |
+| mappingMode | MappingMode | MappingMode |
+| referenceMode | ReferenceMode | ReferenceMode |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### createElementUV{#createElementUV}
+
+| Nombre | Descripción |
+| --- | --- |
+| createElementUV(uvMapping) | Crea un VertexElementUV con el tipo de mapeo de textura dado. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| uvMapping | TextureMapping | TextureMapping |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### createElementUV{#createElementUV}
+
+| Nombre | Descripción |
+| --- | --- |
+| createElementUV(uvMapping, mappingMode, referenceMode) | Crea un VertexElementUV con el tipo de mapeo de textura dado. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| uvMapping | TextureMapping | TextureMapping |
+| mappingMode | MappingMode | MappingMode |
+| referenceMode | ReferenceMode | ReferenceMode |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBoundingBox() | Obtiene el cuadro delimitador de la entidad actual en su sistema de coordenadas de espacio de objeto. |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEntityRendererKey() | Obtiene la clave del renderizador de entidad registrado en el renderizador |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/globaltransform/_index.md
+++ b/spanish/nodejs-java/aspose.threed/globaltransform/_index.md
@@ -1,0 +1,81 @@
+---
+title: "GlobalTransform"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/globaltransform/
+---
+## GlobalTransform class
+
+La transformación global es similar a Transform pero es inmutable mientras representa la transformación final evaluada.  Se utiliza un sistema de coordenadas de mano derecha al evaluar la transformación global  @hideconstructor
+
+
+## Métodos
+
+### getTranslation{#getTranslation}
+
+| Nombre | Descripción |
+| --- | --- |
+| getTranslation() | Obtiene la traslación |
+
+ **Result:**
+
+
+
+---
+
+
+### getScale{#getScale}
+
+| Nombre | Descripción |
+| --- | --- |
+| getScale() | Obtiene la escala |
+
+ **Result:**
+
+
+
+---
+
+
+### getEulerAngles{#getEulerAngles}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEulerAngles() | Obtiene la rotación representada en ángulos de Euler, medida en grados |
+
+ **Result:**
+
+
+
+---
+
+
+### getRotation{#getRotation}
+
+| Nombre | Descripción |
+| --- | --- |
+| getRotation() | Obtiene la rotación representada en cuaternión. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTransformMatrix{#getTransformMatrix}
+
+| Nombre | Descripción |
+| --- | --- |
+| getTransformMatrix() | Obtiene la matriz de transformación. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/glslsource/_index.md
+++ b/spanish/nodejs-java/aspose.threed/glslsource/_index.md
@@ -1,0 +1,153 @@
+---
+title: "GLSLSource"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/glslsource/
+---
+## GLSLSource class
+
+El código fuente de los shaders en GLSL
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getComputeShader{#getComputeShader}
+
+| Nombre | Descripción |
+| --- | --- |
+| getComputeShader() | Obtiene o establece el código fuente del sombreador de cómputo. |
+
+ **Result:**
+
+
+
+---
+
+
+### setComputeShader{#setComputeShader}
+
+| Nombre | Descripción |
+| --- | --- |
+| setComputeShader(value) | Obtiene o establece el código fuente del sombreador de cómputo. |
+
+ **Result:**
+
+
+
+---
+
+
+### getGeometryShader{#getGeometryShader}
+
+| Nombre | Descripción |
+| --- | --- |
+| getGeometryShader() | Obtiene o establece el código fuente del sombreador de geometría. |
+
+ **Result:**
+
+
+
+---
+
+
+### setGeometryShader{#setGeometryShader}
+
+| Nombre | Descripción |
+| --- | --- |
+| setGeometryShader(value) | Obtiene o establece el código fuente del sombreador de geometría. |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexShader{#getVertexShader}
+
+| Nombre | Descripción |
+| --- | --- |
+| getVertexShader() | Obtiene o establece el código fuente del sombreador de vértice |
+
+ **Result:**
+
+
+
+---
+
+
+### setVertexShader{#setVertexShader}
+
+| Nombre | Descripción |
+| --- | --- |
+| setVertexShader(value) | Obtiene o establece el código fuente del sombreador de vértice |
+
+ **Result:**
+
+
+
+---
+
+
+### getFragmentShader{#getFragmentShader}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFragmentShader() | Obtiene o establece el código fuente del shader de fragmento. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFragmentShader{#setFragmentShader}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFragmentShader(value) | Obtiene o establece el código fuente del shader de fragmento. |
+
+ **Result:**
+
+
+
+---
+
+
+### defineInclude{#defineInclude}
+
+| Nombre | Descripción |
+| --- | --- |
+| defineInclude(fileName, content) | Define un archivo virtual para #include en el código fuente GLSL |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| fileName | Cadena | Nombre del archivo virtual |
+| contenido | Cadena | null |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/gltfloadoptions/_index.md
+++ b/spanish/nodejs-java/aspose.threed/gltfloadoptions/_index.md
@@ -1,0 +1,146 @@
+---
+title: "GltfLoadOptions"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/gltfloadoptions/
+---
+## GltfLoadOptions class
+
+Opciones de carga para el formato glTF
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Constructor de GltfLoadOptions |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlipTexCoordV{#getFlipTexCoordV}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFlipTexCoordV() | Invierte la coordenada v(t) en la coordenada de textura de la malla, el valor predeterminado es true. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlipTexCoordV{#setFlipTexCoordV}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFlipTexCoordV(value) | Invierte la coordenada v(t) en la coordenada de textura de la malla, el valor predeterminado es true. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileFormat() | Obtiene el formato de archivo especificado en la opción actual de Guardar/Cargar. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEncoding() | Obtiene o establece la codificación predeterminada para archivos basados en texto. El valor predeterminado es null, lo que significa que el importador/exportador decidirá qué codificación usar. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileSystem() | Permite al usuario manejar cómo gestionar las dependencias externas durante la carga/guardado. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFileSystem(value) | Permite al usuario manejar cómo gestionar las dependencias externas durante la carga/guardado. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| Nombre | Descripción |
+| --- | --- |
+| getLookupPaths() | Algunos archivos como OBJ dependen de archivos externos; las rutas de búsqueda permiten que Aspose.3D busque el archivo externo para cargarlo. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileName() | El nombre de archivo de la escena de exportación/importación. Es opcional, pero útil al serializar recursos externos como el material de OBJ. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFileName(value) | El nombre de archivo de la escena de exportación/importación. Es opcional, pero útil al serializar recursos externos como el material de OBJ. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/gltfsaveoptions/_index.md
+++ b/spanish/nodejs-java/aspose.threed/gltfsaveoptions/_index.md
@@ -1,0 +1,470 @@
+---
+title: "GltfSaveOptions"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/gltfsaveoptions/
+---
+## GltfSaveOptions class
+
+Opciones de guardado para el formato glTF.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor(contentType) | Constructor de GltfSaveOptions |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| contentType | FileContentType | FileContentType |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload(format) | Constructor de GltfSaveOptions |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| forma | FileFormat | null |
+
+ **Result:**
+
+
+
+---
+
+
+### getPrettyPrint{#getPrettyPrint}
+
+| Nombre | Descripción |
+| --- | --- |
+| getPrettyPrint() | El contenido JSON del archivo GLTF está indentado para la lectura humana, el valor predeterminado es false |
+
+ **Result:**
+
+
+
+---
+
+
+### setPrettyPrint{#setPrettyPrint}
+
+| Nombre | Descripción |
+| --- | --- |
+| setPrettyPrint(value) | El contenido JSON del archivo GLTF está indentado para la lectura humana, el valor predeterminado es false |
+
+ **Result:**
+
+
+
+---
+
+
+### getFallbackNormal{#getFallbackNormal}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFallbackNormal() | Cuando el exportador GLTF2 detecta una normal inválida, esto se usará en lugar de su valor original para eludir la validación. El valor predeterminado es (0, 1, 0) |
+
+ **Result:**
+
+
+
+---
+
+
+### getEmbedAssets{#getEmbedAssets}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEmbedAssets() | Incrusta todos los recursos externos como base64 en un solo archivo en modo ASCII, el valor predeterminado es false. |
+
+ **Result:**
+
+
+
+---
+
+
+### setEmbedAssets{#setEmbedAssets}
+
+| Nombre | Descripción |
+| --- | --- |
+| setEmbedAssets(value) | Incrusta todos los recursos externos como base64 en un solo archivo en modo ASCII, el valor predeterminado es false. |
+
+ **Result:**
+
+
+
+---
+
+
+### getImageFormat{#getImageFormat}
+
+| Nombre | Descripción |
+| --- | --- |
+| getImageFormat() | El glTF estándar solo admite PNG/JPG como su formato de textura, esta opción guiará cómo Aspose.3D convierte las imágenes no estándar al formato compatible durante la exportación. El valor predeterminado es GltfEmbeddedImageFormat.PNG. El valor de la propiedad es la constante entera GltfEmbeddedImageFormat. |
+
+ **Result:**
+
+
+
+---
+
+
+### setImageFormat{#setImageFormat}
+
+| Nombre | Descripción |
+| --- | --- |
+| setImageFormat(value) | El glTF estándar solo admite PNG/JPG como su formato de textura, esta opción guiará cómo Aspose.3D convierte las imágenes no estándar al formato compatible durante la exportación. El valor predeterminado es GltfEmbeddedImageFormat.PNG. El valor de la propiedad es la constante entera GltfEmbeddedImageFormat. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMaterialConverter{#getMaterialConverter}
+
+| Nombre | Descripción |
+| --- | --- |
+| getMaterialConverter() | Convertidor personalizado para convertir el material de la geometría a material PBR. Si no está asignado, el exportador glTF 2.0 convertirá automáticamente el material estándar a material PBR. El valor predeterminado es null. Esta propiedad se usa al exportar una escena a un archivo glTF 2.0. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMaterialConverter{#setMaterialConverter}
+
+| Nombre | Descripción |
+| --- | --- |
+| setMaterialConverter(value) | Convertidor personalizado para convertir el material de la geometría a material PBR. Si no está asignado, el exportador glTF 2.0 convertirá automáticamente el material estándar a material PBR. El valor predeterminado es null. Esta propiedad se usa al exportar una escena a un archivo glTF 2.0. |
+
+ **Result:**
+
+
+
+---
+
+
+### getUseCommonMaterials{#getUseCommonMaterials}
+
+| Nombre | Descripción |
+| --- | --- |
+| getUseCommonMaterials() | Serializar materiales usando extensiones de material común KHR, el valor predeterminado es false. Establecer esto en false hará que Aspose.3D exporte un conjunto de shaders de vértice/fragmento si #Error Cref: P:Aspose.ThreeD.Formats.GltfSaveOptions.ExportShaders |
+
+ **Result:**
+
+
+
+---
+
+
+### setUseCommonMaterials{#setUseCommonMaterials}
+
+| Nombre | Descripción |
+| --- | --- |
+| setUseCommonMaterials(value) | Serializar materiales usando extensiones de material común KHR, el valor predeterminado es false. Establecer esto en false hará que Aspose.3D exporte un conjunto de shaders de vértice/fragmento si #Error Cref: P:Aspose.ThreeD.Formats.GltfSaveOptions.ExportShaders |
+
+ **Result:**
+
+
+
+---
+
+
+### getExternalDracoEncoder{#getExternalDracoEncoder}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExternalDracoEncoder() | Utilizar un codificador draco externo para acelerar la velocidad de compresión draco. Aspose.3D creará un nuevo subproceso para codificar la malla al formato draco, úselo bajo su propio riesgo. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExternalDracoEncoder{#setExternalDracoEncoder}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExternalDracoEncoder(value) | Utilizar un codificador draco externo para acelerar la velocidad de compresión draco. Aspose.3D creará un nuevo subproceso para codificar la malla al formato draco, úselo bajo su propio riesgo. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlipTexCoordV{#getFlipTexCoordV}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFlipTexCoordV() | Invertir el componente v(t) de la coordenada de textura, el valor predeterminado es true. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlipTexCoordV{#setFlipTexCoordV}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFlipTexCoordV(value) | Invertir el componente v(t) de la coordenada de textura, el valor predeterminado es true. |
+
+ **Result:**
+
+
+
+---
+
+
+### getBufferFile{#getBufferFile}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBufferFile() | El nombre de archivo del buffer externo utilizado para almacenar datos binarios. Si este archivo no se especifica, Aspose.3D generará un nombre para usted. Esto se ignora al exportar glTF en modo binario. |
+
+ **Result:**
+
+
+
+---
+
+
+### setBufferFile{#setBufferFile}
+
+| Nombre | Descripción |
+| --- | --- |
+| setBufferFile(value) | El nombre de archivo del buffer externo utilizado para almacenar datos binarios. Si este archivo no se especifica, Aspose.3D generará un nombre para usted. Esto se ignora al exportar glTF en modo binario. |
+
+ **Result:**
+
+
+
+---
+
+
+### getSaveExtras{#getSaveExtras}
+
+| Nombre | Descripción |
+| --- | --- |
+| getSaveExtras() | Guardar las propiedades dinámicas del objeto de escena en campos 'extra' en el archivo glTF generado. Esto es útil para proporcionar datos específicos de la aplicación. El valor predeterminado es false. |
+
+ **Result:**
+
+
+
+---
+
+
+### setSaveExtras{#setSaveExtras}
+
+| Nombre | Descripción |
+| --- | --- |
+| setSaveExtras(value) | Guardar las propiedades dinámicas del objeto de escena en campos 'extra' en el archivo glTF generado. Esto es útil para proporcionar datos específicos de la aplicación. El valor predeterminado es false. |
+
+ **Result:**
+
+
+
+---
+
+
+### getApplyUnitScale{#getApplyUnitScale}
+
+| Nombre | Descripción |
+| --- | --- |
+| getApplyUnitScale() | Aplicar AssetInfo.UnitScaleFactor a la malla. El valor predeterminado es false. |
+
+ **Result:**
+
+
+
+---
+
+
+### setApplyUnitScale{#setApplyUnitScale}
+
+| Nombre | Descripción |
+| --- | --- |
+| setApplyUnitScale(value) | Aplicar AssetInfo.UnitScaleFactor a la malla. El valor predeterminado es false. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDracoCompression{#getDracoCompression}
+
+| Nombre | Descripción |
+| --- | --- |
+| getDracoCompression() | Obtiene o establece si se habilita la compresión draco |
+
+ **Result:**
+
+
+
+---
+
+
+### setDracoCompression{#setDracoCompression}
+
+| Nombre | Descripción |
+| --- | --- |
+| setDracoCompression(value) | Obtiene o establece si se habilita la compresión draco |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportTextures{#getExportTextures}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExportTextures() | Intenta copiar las texturas usadas en la escena al directorio de salida. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextures{#setExportTextures}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExportTextures(value) | Intenta copiar las texturas usadas en la escena al directorio de salida. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileFormat() | Obtiene el formato de archivo especificado en la opción actual de Guardar/Cargar. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEncoding() | Obtiene o establece la codificación predeterminada para archivos basados en texto. El valor predeterminado es null, lo que significa que el importador/exportador decidirá qué codificación usar. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileSystem() | Permite al usuario manejar cómo gestionar las dependencias externas durante la carga/guardado. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFileSystem(value) | Permite al usuario manejar cómo gestionar las dependencias externas durante la carga/guardado. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| Nombre | Descripción |
+| --- | --- |
+| getLookupPaths() | Algunos archivos como OBJ dependen de archivos externos; las rutas de búsqueda permiten que Aspose.3D busque el archivo externo para cargarlo. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileName() | El nombre de archivo de la escena de exportación/importación. Es opcional, pero útil al serializar recursos externos como el material de OBJ. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFileName(value) | El nombre de archivo de la escena de exportación/importación. Es opcional, pero útil al serializar recursos externos como el material de OBJ. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/hollowcircleshape/_index.md
+++ b/spanish/nodejs-java/aspose.threed/hollowcircleshape/_index.md
@@ -1,0 +1,333 @@
+---
+title: "HollowCircleShape"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/hollowcircleshape/
+---
+## HollowCircleShape class
+
+Perfil circular hueco compatible con IFC.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getWallThickness{#getWallThickness}
+
+| Nombre | Descripción |
+| --- | --- |
+| getWallThickness() | Obtiene o establece la diferencia entre el radio exterior y el interior. |
+
+ **Result:**
+
+
+
+---
+
+
+### setWallThickness{#setWallThickness}
+
+| Nombre | Descripción |
+| --- | --- |
+| setWallThickness(value) | Obtiene o establece la diferencia entre el radio exterior y el interior. |
+
+ **Result:**
+
+
+
+---
+
+
+### getRadius{#getRadius}
+
+| Nombre | Descripción |
+| --- | --- |
+| getRadius() | Obtiene o establece el radio del círculo. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRadius{#setRadius}
+
+| Nombre | Descripción |
+| --- | --- |
+| setRadius(value) | Obtiene o establece el radio del círculo. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNodes() | Obtiene todos los nodos padre; una entidad puede estar adjunta a varios nodos padre para la instanciación de geometría. Los nodos. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExcluded() | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExcluded(value) | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNode() | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setParentNode(value) | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Nombre | Descripción |
+| --- | --- |
+| getScene() | Obtiene la escena a la que pertenece este objeto |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtent{#getExtent}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExtent() | Obtiene la extensión en las dimensiones x e y. |
+
+ **Result:**
+Vector2
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEntityRendererKey() | Obtiene la clave del renderizador de entidad registrado en el renderizador |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBoundingBox() | Obtiene el cuadro delimitador de la entidad actual en su sistema de coordenadas de espacio de objeto. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/hollowrectangleshape/_index.md
+++ b/spanish/nodejs-java/aspose.threed/hollowrectangleshape/_index.md
@@ -1,0 +1,411 @@
+---
+title: "HollowRectangleShape"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/hollowrectangleshape/
+---
+## HollowRectangleShape class
+
+Forma rectangular hueca compatible con IFC con esquinas redondeadas internas/externas.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getWallThickness{#getWallThickness}
+
+| Nombre | Descripción |
+| --- | --- |
+| getWallThickness() | El grosor entre el borde del rectángulo y el agujero interno |
+
+ **Result:**
+
+
+
+---
+
+
+### setWallThickness{#setWallThickness}
+
+| Nombre | Descripción |
+| --- | --- |
+| setWallThickness(value) | El grosor entre el borde del rectángulo y el agujero interno |
+
+ **Result:**
+
+
+
+---
+
+
+### getInnerFilletRadius{#getInnerFilletRadius}
+
+| Nombre | Descripción |
+| --- | --- |
+| getInnerFilletRadius() | El radio del filete interno del rectángulo interno. |
+
+ **Result:**
+
+
+
+---
+
+
+### setInnerFilletRadius{#setInnerFilletRadius}
+
+| Nombre | Descripción |
+| --- | --- |
+| setInnerFilletRadius(value) | El radio del filete interno del rectángulo interno. |
+
+ **Result:**
+
+
+
+---
+
+
+### getRoundingRadius{#getRoundingRadius}
+
+| Nombre | Descripción |
+| --- | --- |
+| getRoundingRadius() | Obtiene o establece el radio de los arcos circulares de las cuatro esquinas, medido en grados. El valor predeterminado es 0.0 |
+
+ **Result:**
+
+
+
+---
+
+
+### setRoundingRadius{#setRoundingRadius}
+
+| Nombre | Descripción |
+| --- | --- |
+| setRoundingRadius(value) | Obtiene o establece el radio de los arcos circulares de las cuatro esquinas, medido en grados. El valor predeterminado es 0.0 |
+
+ **Result:**
+
+
+
+---
+
+
+### getXDim{#getXDim}
+
+| Nombre | Descripción |
+| --- | --- |
+| getXDim() | Obtiene o establece la extensión del rectángulo en la dirección del eje x. El valor predeterminado es 2.0 |
+
+ **Result:**
+
+
+
+---
+
+
+### setXDim{#setXDim}
+
+| Nombre | Descripción |
+| --- | --- |
+| setXDim(value) | Obtiene o establece la extensión del rectángulo en la dirección del eje x. El valor predeterminado es 2.0 |
+
+ **Result:**
+
+
+
+---
+
+
+### getYDim{#getYDim}
+
+| Nombre | Descripción |
+| --- | --- |
+| getYDim() | Obtiene o establece la extensión del rectángulo en la dirección del eje y. El valor predeterminado es 2.0 |
+
+ **Result:**
+
+
+
+---
+
+
+### setYDim{#setYDim}
+
+| Nombre | Descripción |
+| --- | --- |
+| setYDim(value) | Obtiene o establece la extensión del rectángulo en la dirección del eje y. El valor predeterminado es 2.0 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNodes() | Obtiene todos los nodos padre; una entidad puede estar adjunta a varios nodos padre para la instanciación de geometría. Los nodos. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExcluded() | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExcluded(value) | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNode() | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setParentNode(value) | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Nombre | Descripción |
+| --- | --- |
+| getScene() | Obtiene la escena a la que pertenece este objeto |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtent{#getExtent}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExtent() | Obtiene la extensión en las dimensiones x e y. |
+
+ **Result:**
+Vector2
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEntityRendererKey() | Obtiene la clave del renderizador de entidad registrado en el renderizador |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBoundingBox() | Obtiene el cuadro delimitador de la entidad actual en su sistema de coordenadas de espacio de objeto. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/hshape/_index.md
+++ b/spanish/nodejs-java/aspose.threed/hshape/_index.md
@@ -1,0 +1,541 @@
+---
+title: "HShape"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/hshape/
+---
+## HShape class
+
+HShape proporciona los parámetros definitorios de una forma 'H' o 'I'.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Constructor de HShape |
+
+ **Result:**
+
+
+
+---
+
+
+### getOverallDepth{#getOverallDepth}
+
+| Nombre | Descripción |
+| --- | --- |
+| getOverallDepth() | Obtiene o establece la extensión de la profundidad. |
+
+ **Result:**
+
+
+
+---
+
+
+### setOverallDepth{#setOverallDepth}
+
+| Nombre | Descripción |
+| --- | --- |
+| setOverallDepth(value) | Obtiene o establece la extensión de la profundidad. |
+
+ **Result:**
+
+
+
+---
+
+
+### getBottomFlangeWidth{#getBottomFlangeWidth}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBottomFlangeWidth() | Obtiene o establece la extensión del ancho. |
+
+ **Result:**
+
+
+
+---
+
+
+### setBottomFlangeWidth{#setBottomFlangeWidth}
+
+| Nombre | Descripción |
+| --- | --- |
+| setBottomFlangeWidth(value) | Obtiene o establece la extensión del ancho. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTopFlangeWidth{#getTopFlangeWidth}
+
+| Nombre | Descripción |
+| --- | --- |
+| getTopFlangeWidth() | Obtiene o establece el ancho del ala superior. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTopFlangeWidth{#setTopFlangeWidth}
+
+| Nombre | Descripción |
+| --- | --- |
+| setTopFlangeWidth(value) | Obtiene o establece el ancho del ala superior. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTopFlangeThickness{#getTopFlangeThickness}
+
+| Nombre | Descripción |
+| --- | --- |
+| getTopFlangeThickness() | Obtiene o establece el espesor del ala superior. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTopFlangeThickness{#setTopFlangeThickness}
+
+| Nombre | Descripción |
+| --- | --- |
+| setTopFlangeThickness(value) | Obtiene o establece el espesor del ala superior. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTopFlangeEdgeRadius{#getTopFlangeEdgeRadius}
+
+| Nombre | Descripción |
+| --- | --- |
+| getTopFlangeEdgeRadius() | Obtiene o establece el radio de los bordes inferiores del ala superior. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTopFlangeEdgeRadius{#setTopFlangeEdgeRadius}
+
+| Nombre | Descripción |
+| --- | --- |
+| setTopFlangeEdgeRadius(value) | Obtiene o establece el radio de los bordes inferiores del ala superior. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTopFlangeFilletRadius{#getTopFlangeFilletRadius}
+
+| Nombre | Descripción |
+| --- | --- |
+| getTopFlangeFilletRadius() | Obtiene o establece el radio del filete entre la alma y el ala superior. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTopFlangeFilletRadius{#setTopFlangeFilletRadius}
+
+| Nombre | Descripción |
+| --- | --- |
+| setTopFlangeFilletRadius(value) | Obtiene o establece el radio del filete entre la alma y el ala superior. |
+
+ **Result:**
+
+
+
+---
+
+
+### getBottomFlangeThickness{#getBottomFlangeThickness}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBottomFlangeThickness() | Obtiene o establece el grosor del flange de la forma H. |
+
+ **Result:**
+
+
+
+---
+
+
+### setBottomFlangeThickness{#setBottomFlangeThickness}
+
+| Nombre | Descripción |
+| --- | --- |
+| setBottomFlangeThickness(value) | Obtiene o establece el grosor del flange de la forma H. |
+
+ **Result:**
+
+
+
+---
+
+
+### getWebThickness{#getWebThickness}
+
+| Nombre | Descripción |
+| --- | --- |
+| getWebThickness() | Obtiene o establece el grosor del web de la forma H. |
+
+ **Result:**
+
+
+
+---
+
+
+### setWebThickness{#setWebThickness}
+
+| Nombre | Descripción |
+| --- | --- |
+| setWebThickness(value) | Obtiene o establece el grosor del web de la forma H. |
+
+ **Result:**
+
+
+
+---
+
+
+### getBottomFlangeFilletRadius{#getBottomFlangeFilletRadius}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBottomFlangeFilletRadius() | Obtiene o establece el radio del filete entre el web y el flange inferior. |
+
+ **Result:**
+
+
+
+---
+
+
+### setBottomFlangeFilletRadius{#setBottomFlangeFilletRadius}
+
+| Nombre | Descripción |
+| --- | --- |
+| setBottomFlangeFilletRadius(value) | Obtiene o establece el radio del filete entre el web y el flange inferior. |
+
+ **Result:**
+
+
+
+---
+
+
+### getBottomFlangeEdgeRadius{#getBottomFlangeEdgeRadius}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBottomFlangeEdgeRadius() | Obtiene o establece el radio de los bordes superiores del flange inferior. |
+
+ **Result:**
+
+
+
+---
+
+
+### setBottomFlangeEdgeRadius{#setBottomFlangeEdgeRadius}
+
+| Nombre | Descripción |
+| --- | --- |
+| setBottomFlangeEdgeRadius(value) | Obtiene o establece el radio de los bordes superiores del flange inferior. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNodes() | Obtiene todos los nodos padre; una entidad puede estar adjunta a varios nodos padre para la instanciación de geometría. Los nodos. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExcluded() | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExcluded(value) | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNode() | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setParentNode(value) | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Nombre | Descripción |
+| --- | --- |
+| getScene() | Obtiene la escena a la que pertenece este objeto |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtent{#getExtent}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExtent() | Obtiene la extensión en las dimensiones x e y. |
+
+ **Result:**
+Vector2
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEntityRendererKey() | Obtiene la clave del renderizador de entidad registrado en el renderizador |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBoundingBox() | Obtiene el cuadro delimitador de la entidad actual en su sistema de coordenadas de espacio de objeto. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/html5saveoptions/_index.md
+++ b/spanish/nodejs-java/aspose.threed/html5saveoptions/_index.md
@@ -1,0 +1,406 @@
+---
+title: "Html5SaveOptions"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/html5saveoptions/
+---
+## Html5SaveOptions class
+
+Opciones de guardado para HTML5
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Constructor de Html5SaveOptions con todos los valores predeterminados. |
+
+ **Result:**
+
+
+
+---
+
+
+### getShowGrid{#getShowGrid}
+
+| Nombre | Descripción |
+| --- | --- |
+| getShowGrid() | Muestra una cuadrícula en la escena. El valor predeterminado es true. |
+
+ **Result:**
+
+
+
+---
+
+
+### setShowGrid{#setShowGrid}
+
+| Nombre | Descripción |
+| --- | --- |
+| setShowGrid(value) | Muestra una cuadrícula en la escena. El valor predeterminado es true. |
+
+ **Result:**
+
+
+
+---
+
+
+### getShowRulers{#getShowRulers}
+
+| Nombre | Descripción |
+| --- | --- |
+| getShowRulers() | Muestra reglas de los ejes x/y/z en la escena para medir el modelo. El valor predeterminado es false. |
+
+ **Result:**
+
+
+
+---
+
+
+### setShowRulers{#setShowRulers}
+
+| Nombre | Descripción |
+| --- | --- |
+| setShowRulers(value) | Muestra reglas de los ejes x/y/z en la escena para medir el modelo. El valor predeterminado es false. |
+
+ **Result:**
+
+
+
+---
+
+
+### getShowUI{#getShowUI}
+
+| Nombre | Descripción |
+| --- | --- |
+| getShowUI() | Muestra una interfaz de usuario simple en la escena. El valor predeterminado es true. |
+
+ **Result:**
+
+
+
+---
+
+
+### setShowUI{#setShowUI}
+
+| Nombre | Descripción |
+| --- | --- |
+| setShowUI(value) | Muestra una interfaz de usuario simple en la escena. El valor predeterminado es true. |
+
+ **Result:**
+
+
+
+---
+
+
+### getOrientationBox{#getOrientationBox}
+
+| Nombre | Descripción |
+| --- | --- |
+| getOrientationBox() | Muestra una caja de orientación. El valor predeterminado es true. |
+
+ **Result:**
+
+
+
+---
+
+
+### setOrientationBox{#setOrientationBox}
+
+| Nombre | Descripción |
+| --- | --- |
+| setOrientationBox(value) | Muestra una caja de orientación. El valor predeterminado es true. |
+
+ **Result:**
+
+
+
+---
+
+
+### getUpVector{#getUpVector}
+
+| Nombre | Descripción |
+| --- | --- |
+| getUpVector() | Obtiene o establece el vector up, el valor puede ser "x"/"y"/"z", el valor predeterminado es "y" |
+
+ **Result:**
+
+
+
+---
+
+
+### setUpVector{#setUpVector}
+
+| Nombre | Descripción |
+| --- | --- |
+| setUpVector(value) | Obtiene o establece el vector up, el valor puede ser "x"/"y"/"z", el valor predeterminado es "y" |
+
+ **Result:**
+
+
+
+---
+
+
+### getFarPlane{#getFarPlane}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFarPlane() | Obtiene o establece el plano lejano de la cámara, el valor predeterminado es 1000. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFarPlane{#setFarPlane}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFarPlane(value) | Obtiene o establece el plano lejano de la cámara, el valor predeterminado es 1000. |
+
+ **Result:**
+
+
+
+---
+
+
+### getNearPlane{#getNearPlane}
+
+| Nombre | Descripción |
+| --- | --- |
+| getNearPlane() | Obtiene o establece el plano cercano de la cámara, el valor predeterminado es 1 |
+
+ **Result:**
+
+
+
+---
+
+
+### setNearPlane{#setNearPlane}
+
+| Nombre | Descripción |
+| --- | --- |
+| setNearPlane(value) | Obtiene o establece el plano cercano de la cámara, el valor predeterminado es 1 |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookAt{#getLookAt}
+
+| Nombre | Descripción |
+| --- | --- |
+| getLookAt() | Obtiene o establece la posición de mirada predeterminada, el valor predeterminado es (0, 0, 0) |
+
+ **Result:**
+
+
+
+---
+
+
+### setLookAt{#setLookAt}
+
+| Nombre | Descripción |
+| --- | --- |
+| setLookAt(value) | Obtiene o establece la posición de mirada predeterminada, el valor predeterminado es (0, 0, 0) |
+
+ **Result:**
+
+
+
+---
+
+
+### getCameraPosition{#getCameraPosition}
+
+| Nombre | Descripción |
+| --- | --- |
+| getCameraPosition() | Obtiene o establece la posición inicial de la cámara, el valor predeterminado es (10, 10, 10) |
+
+ **Result:**
+
+
+
+---
+
+
+### setCameraPosition{#setCameraPosition}
+
+| Nombre | Descripción |
+| --- | --- |
+| setCameraPosition(value) | Obtiene o establece la posición inicial de la cámara, el valor predeterminado es (10, 10, 10) |
+
+ **Result:**
+
+
+
+---
+
+
+### getFieldOfView{#getFieldOfView}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFieldOfView() | Obtiene o establece el campo de visión, el valor predeterminado es 45, medido en grados. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFieldOfView{#setFieldOfView}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFieldOfView(value) | Obtiene o establece el campo de visión, el valor predeterminado es 45, medido en grados. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportTextures{#getExportTextures}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExportTextures() | Intenta copiar las texturas usadas en la escena al directorio de salida. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextures{#setExportTextures}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExportTextures(value) | Intenta copiar las texturas usadas en la escena al directorio de salida. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileFormat() | Obtiene el formato de archivo especificado en la opción actual de Guardar/Cargar. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEncoding() | Obtiene o establece la codificación predeterminada para archivos basados en texto. El valor predeterminado es null, lo que significa que el importador/exportador decidirá qué codificación usar. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileSystem() | Permite al usuario manejar cómo gestionar las dependencias externas durante la carga/guardado. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFileSystem(value) | Permite al usuario manejar cómo gestionar las dependencias externas durante la carga/guardado. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| Nombre | Descripción |
+| --- | --- |
+| getLookupPaths() | Algunos archivos como OBJ dependen de archivos externos; las rutas de búsqueda permiten que Aspose.3D busque el archivo externo para cargarlo. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileName() | El nombre de archivo de la escena de exportación/importación. Es opcional, pero útil al serializar recursos externos como el material de OBJ. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFileName(value) | El nombre de archivo de la escena de exportación/importación. Es opcional, pero útil al serializar recursos externos como el material de OBJ. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/imagerenderoptions/_index.md
+++ b/spanish/nodejs-java/aspose.threed/imagerenderoptions/_index.md
@@ -1,0 +1,229 @@
+---
+title: "ImageRenderOptions"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/imagerenderoptions/
+---
+## ImageRenderOptions class
+
+Opciones para Scene.render(com.aspose.threed.Camera, java.lang.String, com.aspose.threed.Vector2, java.lang.String, com.aspose.threed.ImageRenderOptions) y Scene.render(com.aspose.threed.Camera, com.aspose.threed.TextureData, com.aspose.threed.ImageRenderOptions)
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Inicializar una instancia de ImageRenderOptions |
+
+ **Result:**
+
+
+
+---
+
+
+### getBackgroundColor{#getBackgroundColor}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBackgroundColor() | El color de fondo del resultado de renderizado. |
+
+ **Result:**
+
+
+
+---
+
+
+### setBackgroundColor{#setBackgroundColor}
+
+| Nombre | Descripción |
+| --- | --- |
+| setBackgroundColor(value) | El color de fondo del resultado de renderizado. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAssetDirectories{#getAssetDirectories}
+
+| Nombre | Descripción |
+| --- | --- |
+| getAssetDirectories() | Directorios que almacenan activos externos (como texturas) |
+
+ **Result:**
+
+
+
+---
+
+
+### getEnableShadows{#getEnableShadows}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEnableShadows() | Obtiene o establece si se renderizan sombras. |
+
+ **Result:**
+
+
+
+---
+
+
+### setEnableShadows{#setEnableShadows}
+
+| Nombre | Descripción |
+| --- | --- |
+| setEnableShadows(value) | Obtiene o establece si se renderizan sombras. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/importexception/_index.md
+++ b/spanish/nodejs-java/aspose.threed/importexception/_index.md
@@ -1,0 +1,35 @@
+---
+title: "ImportException"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/importexception/
+---
+## ImportException class
+
+Excepción cuando Aspose.3D no pudo abrir la fuente especificada
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor(msg) | Inicializa una nueva instancia |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| msg | Cadena | Mensaje de error |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/indexdatatype/_index.md
+++ b/spanish/nodejs-java/aspose.threed/indexdatatype/_index.md
@@ -1,0 +1,13 @@
+---
+title: "IndexDataType"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/indexdatatype/
+---
+## IndexDataType class
+
+Clase de utilidad que contiene constantes.  El tipo de datos de los elementos en com.aspose.threed.IIndexBuffer  @hideconstructor
+
+

--- a/spanish/nodejs-java/aspose.threed/initializationexception/_index.md
+++ b/spanish/nodejs-java/aspose.threed/initializationexception/_index.md
@@ -1,0 +1,42 @@
+---
+title: "InitializationException"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/initializationexception/
+---
+## InitializationException class
+
+Excepciones en la inicialización del pipeline de renderizado
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Inicializa una instancia de InitializationException |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload(msg) | Inicializa una instancia de InitializationException con el mensaje de excepción especificado. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/ioconfig/_index.md
+++ b/spanish/nodejs-java/aspose.threed/ioconfig/_index.md
@@ -1,0 +1,133 @@
+---
+title: "IOConfig"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/ioconfig/
+---
+## IOConfig class
+
+Configuración de E/S para serialización/deserialización.  El usuario puede especificar configuraciones detalladas como la ruta de búsqueda de dependencias  o configuraciones relacionadas con el formato aquí  @hideconstructor
+
+
+## Métodos
+
+### getFileSystemFactory{#getFileSystemFactory}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileSystemFactory() | Obtiene o establece la clase fábrica para FileSystem. La fábrica predeterminada creará LocalFileSystem, que no es adecuada para entornos de servidor. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystemFactory{#setFileSystemFactory}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFileSystemFactory(value) | Obtiene o establece la clase fábrica para FileSystem. La fábrica predeterminada creará LocalFileSystem, que no es adecuada para entornos de servidor. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileFormat() | Obtiene el formato de archivo especificado en la opción actual de Guardar/Cargar. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEncoding() | Obtiene o establece la codificación predeterminada para archivos basados en texto. El valor predeterminado es null, lo que significa que el importador/exportador decidirá qué codificación usar. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileSystem() | Permite al usuario manejar cómo gestionar las dependencias externas durante la carga/guardado. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFileSystem(value) | Permite al usuario manejar cómo gestionar las dependencias externas durante la carga/guardado. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| Nombre | Descripción |
+| --- | --- |
+| getLookupPaths() | Algunos archivos como OBJ dependen de archivos externos; las rutas de búsqueda permiten que Aspose.3D busque el archivo externo para cargarlo. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileName() | El nombre de archivo de la escena de exportación/importación. Es opcional, pero útil al serializar recursos externos como el material de OBJ. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFileName(value) | El nombre de archivo de la escena de exportación/importación. Es opcional, pero útil al serializar recursos externos como el material de OBJ. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/ioutils/_index.md
+++ b/spanish/nodejs-java/aspose.threed/ioutils/_index.md
@@ -1,0 +1,13 @@
+---
+title: "IOUtils"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/ioutils/
+---
+## IOUtils class
+
+Utilidades para escribir matrices/vectores en un escritor binario  @hideconstructor
+
+

--- a/spanish/nodejs-java/aspose.threed/keyframe/_index.md
+++ b/spanish/nodejs-java/aspose.threed/keyframe/_index.md
@@ -1,0 +1,439 @@
+---
+title: "KeyFrame"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/keyframe/
+---
+## KeyFrame class
+
+Un fotograma clave se define principalmente por un tiempo y un valor; para algunos tipos de interpolación, también se utilizan tangente/ tensión/ sesgo/ continuidad al calcular el valor muestreado final.  Los valores muestreados en una posición de tiempo sin fotograma clave se interpolan mediante fotogramas clave entre el fotograma clave anterior y el siguiente.  Los valores antes/después del primer/último fotograma clave se calculan con la clase Extrapolation.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor(curve, time) | Crear un nuevo fotograma clave en la curva especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| curve | KeyframeSequence | La curva en la que se creará el fotograma clave |
+| tiempo | Número | La posición de tiempo del fotograma clave |
+
+ **Result:**
+
+
+
+---
+
+
+### getTime{#getTime}
+
+| Nombre | Descripción |
+| --- | --- |
+| getTime() | Obtiene o establece la posición de tiempo del fotograma clave list.data[index], medida en segundos. El tiempo. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTime{#setTime}
+
+| Nombre | Descripción |
+| --- | --- |
+| setTime(value) | Obtiene o establece la posición de tiempo del fotograma clave list.data[index], medida en segundos. El tiempo. |
+
+ **Result:**
+
+
+
+---
+
+
+### getValue{#getValue}
+
+| Nombre | Descripción |
+| --- | --- |
+| getValue() | Obtiene o establece el valor del fotograma clave. El valor. |
+
+ **Result:**
+
+
+
+---
+
+
+### setValue{#setValue}
+
+| Nombre | Descripción |
+| --- | --- |
+| setValue(value) | Obtiene o establece el valor del fotograma clave. El valor. |
+
+ **Result:**
+
+
+
+---
+
+
+### getInterpolation{#getInterpolation}
+
+| Nombre | Descripción |
+| --- | --- |
+| getInterpolation() | Obtiene o establece el tipo de interpolación de la clave, list.data[index] define el algoritmo con el que se calcula el valor muestreado. El valor de la propiedad es la constante entera Interpolation. La interpolación. |
+
+ **Result:**
+
+
+
+---
+
+
+### setInterpolation{#setInterpolation}
+
+| Nombre | Descripción |
+| --- | --- |
+| setInterpolation(value) | Obtiene o establece el tipo de interpolación de la clave, list.data[index] define el algoritmo con el que se calcula el valor muestreado. El valor de la propiedad es la constante entera Interpolation. La interpolación. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTangentWeightMode{#getTangentWeightMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getTangentWeightMode() | Obtiene o establece el modo de peso de la tangente de la clave. La tangente de salida o la siguiente tangente de entrada pueden personalizarse seleccionando el WeightedMode correcto. El valor de la propiedad es la constante entera WeightedMode. El modo de peso de la tangente. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTangentWeightMode{#setTangentWeightMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setTangentWeightMode(value) | Obtiene o establece el modo de peso de la tangente de la clave. La tangente de salida o la siguiente tangente de entrada pueden personalizarse seleccionando el WeightedMode correcto. El valor de la propiedad es la constante entera WeightedMode. El modo de peso de la tangente. |
+
+ **Result:**
+
+
+
+---
+
+
+### getStepMode{#getStepMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getStepMode() | Obtiene o establece el modo de paso de la clave. Si el tipo de interpolación es Interpolation.CONSTANT, list.data[index] decide qué valor del fotograma clave se utilizará durante la interpolación. Un StepMode.PREVIOUS_VALUE significa que se usará el valor del fotograma clave izquierdo. Un StepMode.NEXT_VALUE significa que se usará el valor del fotograma clave derecho siguiente. El valor de la propiedad es la constante entera StepMode. El modo de paso. |
+
+ **Result:**
+
+
+
+---
+
+
+### setStepMode{#setStepMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setStepMode(value) | Obtiene o establece el modo de paso de la clave. Si el tipo de interpolación es Interpolation.CONSTANT, list.data[index] decide qué valor del fotograma clave se utilizará durante la interpolación. Un StepMode.PREVIOUS_VALUE significa que se usará el valor del fotograma clave izquierdo. Un StepMode.NEXT_VALUE significa que se usará el valor del fotograma clave derecho siguiente. El valor de la propiedad es la constante entera StepMode. El modo de paso. |
+
+ **Result:**
+
+
+
+---
+
+
+### getNextInTangent{#getNextInTangent}
+
+| Nombre | Descripción |
+| --- | --- |
+| getNextInTangent() | Obtiene o establece la siguiente tangente de entrada (izquierda) en este fotograma clave. |
+
+ **Result:**
+
+
+
+---
+
+
+### setNextInTangent{#setNextInTangent}
+
+| Nombre | Descripción |
+| --- | --- |
+| setNextInTangent(value) | Obtiene o establece la siguiente tangente de entrada (izquierda) en este fotograma clave. |
+
+ **Result:**
+
+
+
+---
+
+
+### getOutTangent{#getOutTangent}
+
+| Nombre | Descripción |
+| --- | --- |
+| getOutTangent() | Obtiene o establece la tangente de salida (derecha) en este fotograma clave. |
+
+ **Result:**
+
+
+
+---
+
+
+### setOutTangent{#setOutTangent}
+
+| Nombre | Descripción |
+| --- | --- |
+| setOutTangent(value) | Obtiene o establece la tangente de salida (derecha) en este fotograma clave. |
+
+ **Result:**
+
+
+
+---
+
+
+### getOutWeight{#getOutWeight}
+
+| Nombre | Descripción |
+| --- | --- |
+| getOutWeight() | Obtiene o establece el peso de salida (derecha) en este fotograma clave. |
+
+ **Result:**
+
+
+
+---
+
+
+### setOutWeight{#setOutWeight}
+
+| Nombre | Descripción |
+| --- | --- |
+| setOutWeight(value) | Obtiene o establece el peso de salida (derecha) en este fotograma clave. |
+
+ **Result:**
+
+
+
+---
+
+
+### getNextInWeight{#getNextInWeight}
+
+| Nombre | Descripción |
+| --- | --- |
+| getNextInWeight() | Obtiene o establece el siguiente peso in(left) en este fotograma clave. |
+
+ **Result:**
+
+
+
+---
+
+
+### setNextInWeight{#setNextInWeight}
+
+| Nombre | Descripción |
+| --- | --- |
+| setNextInWeight(value) | Obtiene o establece el siguiente peso in(left) en este fotograma clave. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTension{#getTension}
+
+| Nombre | Descripción |
+| --- | --- |
+| getTension() | Obtiene o establece la tensión utilizada en la spline TCB |
+
+ **Result:**
+
+
+
+---
+
+
+### setTension{#setTension}
+
+| Nombre | Descripción |
+| --- | --- |
+| setTension(value) | Obtiene o establece la tensión utilizada en la spline TCB |
+
+ **Result:**
+
+
+
+---
+
+
+### getContinuity{#getContinuity}
+
+| Nombre | Descripción |
+| --- | --- |
+| getContinuity() | Obtiene o establece la continuidad utilizada en la spline TCB |
+
+ **Result:**
+
+
+
+---
+
+
+### setContinuity{#setContinuity}
+
+| Nombre | Descripción |
+| --- | --- |
+| setContinuity(value) | Obtiene o establece la continuidad utilizada en la spline TCB |
+
+ **Result:**
+
+
+
+---
+
+
+### getBias{#getBias}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBias() | Obtiene o establece el sesgo utilizado en la spline TCB |
+
+ **Result:**
+
+
+
+---
+
+
+### setBias{#setBias}
+
+| Nombre | Descripción |
+| --- | --- |
+| setBias(value) | Obtiene o establece el sesgo utilizado en la spline TCB |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndependentTangent{#getIndependentTangent}
+
+| Nombre | Descripción |
+| --- | --- |
+| getIndependentTangent() | Obtiene o establece que las tangentes de salida y la siguiente de entrada son independientes. |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndependentTangent{#setIndependentTangent}
+
+| Nombre | Descripción |
+| --- | --- |
+| setIndependentTangent(value) | Obtiene o establece que las tangentes de salida y la siguiente de entrada son independientes. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlat{#getFlat}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFlat() | Obtenga o establezca si el fotograma clave es plano. El fotograma clave debe ser plano si el siguiente o el anterior fotograma clave tiene el mismo valor. Un fotograma clave plano tiene tangentes planas e interpolación fija. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlat{#setFlat}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFlat(value) | Obtenga o establezca si el fotograma clave es plano. El fotograma clave debe ser plano si el siguiente o el anterior fotograma clave tiene el mismo valor. Un fotograma clave plano tiene tangentes planas e interpolación fija. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTimeIndependentTangent{#getTimeIndependentTangent}
+
+| Nombre | Descripción |
+| --- | --- |
+| getTimeIndependentTangent() | Obtiene o establece que la tangente es independiente del tiempo |
+
+ **Result:**
+
+
+
+---
+
+
+### setTimeIndependentTangent{#setTimeIndependentTangent}
+
+| Nombre | Descripción |
+| --- | --- |
+| setTimeIndependentTangent(value) | Obtiene o establece que la tangente es independiente del tiempo |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| Nombre | Descripción |
+| --- | --- |
+| toString() | Obtiene la representación en cadena del fotograma clave |
+
+ **Result:**
+Cadena
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/keyframesequence/_index.md
+++ b/spanish/nodejs-java/aspose.threed/keyframesequence/_index.md
@@ -1,0 +1,302 @@
+---
+title: "KeyframeSequence"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/keyframesequence/
+---
+## KeyframeSequence class
+
+La secuencia de fotogramas clave, describe la transformación de un valor muestreado a lo largo del tiempo.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor(name) | Inicializa una nueva instancia de la clase KeyframeSequence. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| name | Cadena | Nombre |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload() | Inicializa una nueva instancia de la clase KeyframeSequence. |
+
+ **Result:**
+
+
+
+---
+
+
+### getBindPoint{#getBindPoint}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBindPoint() | Obtiene el punto de enlace de la propiedad que posee esta curva. |
+
+ **Result:**
+
+
+
+---
+
+
+### getKeyFrames{#getKeyFrames}
+
+| Nombre | Descripción |
+| --- | --- |
+| getKeyFrames() | Obtiene los fotogramas clave de esta curva. Las claves. |
+
+ **Result:**
+
+
+
+---
+
+
+### getPostBehavior{#getPostBehavior}
+
+| Nombre | Descripción |
+| --- | --- |
+| getPostBehavior() | Obtiene el comportamiento post que indica cuál debe ser el valor muestreado después del último fotograma clave. |
+
+ **Result:**
+
+
+
+---
+
+
+### getPreBehavior{#getPreBehavior}
+
+| Nombre | Descripción |
+| --- | --- |
+| getPreBehavior() | Obtiene el comportamiento pre que indica cuál debe ser el valor muestreado antes del primer fotograma. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### add{#add}
+
+| Nombre | Descripción |
+| --- | --- |
+| add(time, value) | Crear un nuevo fotograma clave con el valor especificado |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| tiempo | Número | Posición de tiempo (medida en segundos) |
+| valor | Número | El valor en esta posición de tiempo |
+
+ **Result:**
+
+
+
+---
+
+
+### add{#add}
+
+| Nombre | Descripción |
+| --- | --- |
+| add(time, value, interpolation) | Crear un nuevo fotograma clave con el valor especificado |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| tiempo | Número | Posición de tiempo (medida en segundos) |
+| valor | Número | El valor en esta posición de tiempo |
+| interpolación | Interpolación | Interpolación |
+
+ **Result:**
+
+
+
+---
+
+
+### reset{#reset}
+
+| Nombre | Descripción |
+| --- | --- |
+| reset() | Elimina todos los fotogramas clave y restablece los comportamientos post/pre. |
+
+ **Result:**
+
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+### iterator{#iterator}
+
+| Nombre | Descripción |
+| --- | --- |
+| iterator() | Reservado para uso interno. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/lambertmaterial/_index.md
+++ b/spanish/nodejs-java/aspose.threed/lambertmaterial/_index.md
@@ -1,0 +1,378 @@
+---
+title: "LambertMaterial"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/lambertmaterial/
+---
+## LambertMaterial class
+
+Material para el modelo de sombreado Lambert
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Inicializa una nueva instancia de la clase LambertMaterial. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload(name) | Inicializa una nueva instancia de la clase LambertMaterial. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| name | Cadena | Nombre |
+
+ **Result:**
+
+
+
+---
+
+
+### getEmissiveColor{#getEmissiveColor}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEmissiveColor() | Obtiene o establece el color emisivo |
+
+ **Result:**
+
+
+
+---
+
+
+### setEmissiveColor{#setEmissiveColor}
+
+| Nombre | Descripción |
+| --- | --- |
+| setEmissiveColor(value) | Obtiene o establece el color emisivo |
+
+ **Result:**
+
+
+
+---
+
+
+### getAmbientColor{#getAmbientColor}
+
+| Nombre | Descripción |
+| --- | --- |
+| getAmbientColor() | Obtiene o establece el color ambiental. El ejemplo: var mat = new LambertMaterial(); mat.AmbientColor = new Vector3(1, 1, 1); ambient. |
+
+ **Result:**
+
+
+
+---
+
+
+### setAmbientColor{#setAmbientColor}
+
+| Nombre | Descripción |
+| --- | --- |
+| setAmbientColor(value) | Obtiene o establece el color ambiental. El ejemplo: var mat = new LambertMaterial(); mat.AmbientColor = new Vector3(1, 1, 1); ambient. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDiffuseColor{#getDiffuseColor}
+
+| Nombre | Descripción |
+| --- | --- |
+| getDiffuseColor() | Obtiene o establece el color difuso. El ejemplo: var mat = new LambertMaterial(); mat.DiffuseColor = new Vector3(1, 0, 0); difuso. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDiffuseColor{#setDiffuseColor}
+
+| Nombre | Descripción |
+| --- | --- |
+| setDiffuseColor(value) | Obtiene o establece el color difuso. El ejemplo: var mat = new LambertMaterial(); mat.DiffuseColor = new Vector3(1, 0, 0); difuso. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTransparentColor{#getTransparentColor}
+
+| Nombre | Descripción |
+| --- | --- |
+| getTransparentColor() | Obtiene o establece el color transparente. El ejemplo: var mat = new LambertMaterial(); mat.TransparentColor = new Vector3(0.3, 0.5, 0.2); color del transparente. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTransparentColor{#setTransparentColor}
+
+| Nombre | Descripción |
+| --- | --- |
+| setTransparentColor(value) | Obtiene o establece el color transparente. El ejemplo: var mat = new LambertMaterial(); mat.TransparentColor = new Vector3(0.3, 0.5, 0.2); color del transparente. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTransparency{#getTransparency}
+
+| Nombre | Descripción |
+| --- | --- |
+| getTransparency() | Obtiene o establece el factor de transparencia. El factor debe estar en el rango entre 0 (0 %, totalmente opaco) y 1 (100 %, totalmente transparente). Cualquier valor de factor no válido será limitado. El ejemplo: var mat = new LambertMaterial(); mat.Transparency = 0.3; factor de transparencia. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTransparency{#setTransparency}
+
+| Nombre | Descripción |
+| --- | --- |
+| setTransparency(value) | Obtiene o establece el factor de transparencia. El factor debe estar en el rango entre 0 (0 %, totalmente opaco) y 1 (100 %, totalmente transparente). Cualquier valor de factor no válido será limitado. El ejemplo: var mat = new LambertMaterial(); mat.Transparency = 0.3; factor de transparencia. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTexture{#getTexture}
+
+| Nombre | Descripción |
+| --- | --- |
+| getTexture(slotName) | Obtiene la textura del slot especificado, puede ser el nombre de una propiedad del material o el nombre de un parámetro del shader |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| slotName | Cadena | Nombre del slot. |
+
+ **Result:**
+TextureBase
+
+
+---
+
+
+### setTexture{#setTexture}
+
+| Nombre | Descripción |
+| --- | --- |
+| setTexture(slotName, texture) | Establece la textura al slot especificado |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| slotName | Cadena | Nombre del slot. |
+| texture | TextureBase | Textura. |
+
+ **Result:**
+TextureBase
+
+
+---
+
+
+### toString{#toString}
+
+| Nombre | Descripción |
+| --- | --- |
+| toString() | Formatea el objeto a cadena |
+
+ **Result:**
+Cadena
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+### iterator{#iterator}
+
+| Nombre | Descripción |
+| --- | --- |
+| iterator() | Reservado para uso interno. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/license/_index.md
+++ b/spanish/nodejs-java/aspose.threed/license/_index.md
@@ -1,0 +1,61 @@
+---
+title: "Licencia"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/license/
+---
+## License class
+
+Proporciona métodos para licenciar el componente.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Inicializa una nueva instancia de esta clase. |
+
+ **Result:**
+
+
+
+---
+
+
+### setLicense{#setLicense}
+
+| Nombre | Descripción |
+| --- | --- |
+| setLicense(licenseName) | Licencia el componente. Intenta encontrar la licencia en las siguientes ubicaciones:1. Ruta explícita.2. La carpeta que contiene el archivo JAR del componente Aspose.3. La carpeta que contiene el archivo JAR que llama el cliente. |
+
+ **Result:**
+
+
+
+---
+
+
+### setLicense{#setLicense}
+
+| Nombre | Descripción |
+| --- | --- |
+| setLicense(stream) | Licencia el componente. Use este método para cargar una licencia desde un flujo. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| flujo | InputStream | Un flujo que contiene la licencia. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/light/_index.md
+++ b/spanish/nodejs-java/aspose.threed/light/_index.md
@@ -1,0 +1,827 @@
+---
+title: "Light"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/light/
+---
+## Light class
+
+La luz ilumina la escena.  La fórmula para calcular la atenuación total de la luz es:  A = ConstantAttenuation + (Dist  LinearAttenuation) + ((Dist^2)  QuadraticAttenuation)
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Inicializa una nueva instancia de la clase Light. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload(name) | Inicializa una nueva instancia de la clase Light. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| name | Cadena | Nombre |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload2(name, type) | Inicializa una nueva instancia de la clase Light. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| name | Cadena | Nombre |
+| type | LightType | LightType |
+
+ **Result:**
+
+
+
+---
+
+
+### getColor{#getColor}
+
+| Nombre | Descripción |
+| --- | --- |
+| getColor() | Obtiene o establece el color de la luz |
+
+ **Result:**
+
+
+
+---
+
+
+### setColor{#setColor}
+
+| Nombre | Descripción |
+| --- | --- |
+| setColor(value) | Obtiene o establece el color de la luz |
+
+ **Result:**
+
+
+
+---
+
+
+### getLightType{#getLightType}
+
+| Nombre | Descripción |
+| --- | --- |
+| getLightType() | Obtiene o establece el tipo de la luz. El valor de la propiedad es la constante entera LightType. |
+
+ **Result:**
+
+
+
+---
+
+
+### setLightType{#setLightType}
+
+| Nombre | Descripción |
+| --- | --- |
+| setLightType(value) | Obtiene o establece el tipo de la luz. El valor de la propiedad es la constante entera LightType. |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastLight{#getCastLight}
+
+| Nombre | Descripción |
+| --- | --- |
+| getCastLight() | Obtiene o establece si la instancia actual de luz puede iluminar otros objetos. |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastLight{#setCastLight}
+
+| Nombre | Descripción |
+| --- | --- |
+| setCastLight(value) | Obtiene o establece si la instancia actual de luz puede iluminar otros objetos. |
+
+ **Result:**
+
+
+
+---
+
+
+### getIntensity{#getIntensity}
+
+| Nombre | Descripción |
+| --- | --- |
+| getIntensity() | Obtiene o establece la intensidad de la luz, el valor predeterminado es 100 |
+
+ **Result:**
+
+
+
+---
+
+
+### setIntensity{#setIntensity}
+
+| Nombre | Descripción |
+| --- | --- |
+| setIntensity(value) | Obtiene o establece la intensidad de la luz, el valor predeterminado es 100 |
+
+ **Result:**
+
+
+
+---
+
+
+### getHotSpot{#getHotSpot}
+
+| Nombre | Descripción |
+| --- | --- |
+| getHotSpot() | Obtiene o establece el ángulo del cono del punto caliente(in grados). |
+
+ **Result:**
+
+
+
+---
+
+
+### setHotSpot{#setHotSpot}
+
+| Nombre | Descripción |
+| --- | --- |
+| setHotSpot(value) | Obtiene o establece el ángulo del cono del punto caliente(in grados). |
+
+ **Result:**
+
+
+
+---
+
+
+### getFalloff{#getFalloff}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFalloff() | Obtiene o establece el ángulo del cono de atenuación (en grados). |
+
+ **Result:**
+
+
+
+---
+
+
+### setFalloff{#setFalloff}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFalloff(value) | Obtiene o establece el ángulo del cono de atenuación (en grados). |
+
+ **Result:**
+
+
+
+---
+
+
+### getConstantAttenuation{#getConstantAttenuation}
+
+| Nombre | Descripción |
+| --- | --- |
+| getConstantAttenuation() | Obtiene o establece la atenuación constante para calcular la atenuación total de la luz |
+
+ **Result:**
+
+
+
+---
+
+
+### setConstantAttenuation{#setConstantAttenuation}
+
+| Nombre | Descripción |
+| --- | --- |
+| setConstantAttenuation(value) | Obtiene o establece la atenuación constante para calcular la atenuación total de la luz |
+
+ **Result:**
+
+
+
+---
+
+
+### getLinearAttenuation{#getLinearAttenuation}
+
+| Nombre | Descripción |
+| --- | --- |
+| getLinearAttenuation() | Obtiene o establece la atenuación lineal para calcular la atenuación total de la luz |
+
+ **Result:**
+
+
+
+---
+
+
+### setLinearAttenuation{#setLinearAttenuation}
+
+| Nombre | Descripción |
+| --- | --- |
+| setLinearAttenuation(value) | Obtiene o establece la atenuación lineal para calcular la atenuación total de la luz |
+
+ **Result:**
+
+
+
+---
+
+
+### getQuadraticAttenuation{#getQuadraticAttenuation}
+
+| Nombre | Descripción |
+| --- | --- |
+| getQuadraticAttenuation() | Obtiene o establece la atenuación cuadrática para calcular la atenuación total de la luz |
+
+ **Result:**
+
+
+
+---
+
+
+### setQuadraticAttenuation{#setQuadraticAttenuation}
+
+| Nombre | Descripción |
+| --- | --- |
+| setQuadraticAttenuation(value) | Obtiene o establece la atenuación cuadrática para calcular la atenuación total de la luz |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastShadows{#getCastShadows}
+
+| Nombre | Descripción |
+| --- | --- |
+| getCastShadows() | Obtiene o establece si la luz puede proyectar sombras sobre otros objetos. |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastShadows{#setCastShadows}
+
+| Nombre | Descripción |
+| --- | --- |
+| setCastShadows(value) | Obtiene o establece si la luz puede proyectar sombras sobre otros objetos. |
+
+ **Result:**
+
+
+
+---
+
+
+### getShadowColor{#getShadowColor}
+
+| Nombre | Descripción |
+| --- | --- |
+| getShadowColor() | Obtiene o establece el color de la sombra. |
+
+ **Result:**
+
+
+
+---
+
+
+### setShadowColor{#setShadowColor}
+
+| Nombre | Descripción |
+| --- | --- |
+| setShadowColor(value) | Obtiene o establece el color de la sombra. |
+
+ **Result:**
+
+
+
+---
+
+
+### getRotationMode{#getRotationMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getRotationMode() | Obtiene o establece el modo de orientación del frustum. Esta propiedad solo funciona cuando Target es nulo. Si el valor es RotationMode.FIXED_TARGET, la dirección siempre se calcula mediante la propiedad LookAt. De lo contrario, LookAt siempre se calcula mediante Direction. El valor de la propiedad es la constante entera RotationMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRotationMode{#setRotationMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setRotationMode(value) | Obtiene o establece el modo de orientación del frustum. Esta propiedad solo funciona cuando Target es nulo. Si el valor es RotationMode.FIXED_TARGET, la dirección siempre se calcula mediante la propiedad LookAt. De lo contrario, LookAt siempre se calcula mediante Direction. El valor de la propiedad es la constante entera RotationMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getNearPlane{#getNearPlane}
+
+| Nombre | Descripción |
+| --- | --- |
+| getNearPlane() | Obtiene o establece la distancia del plano cercano del frustum. |
+
+ **Result:**
+
+
+
+---
+
+
+### setNearPlane{#setNearPlane}
+
+| Nombre | Descripción |
+| --- | --- |
+| setNearPlane(value) | Obtiene o establece la distancia del plano cercano del frustum. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFarPlane{#getFarPlane}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFarPlane() | Obtiene o establece la distancia del plano lejano del frustum. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFarPlane{#setFarPlane}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFarPlane(value) | Obtiene o establece la distancia del plano lejano del frustum. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAspect{#getAspect}
+
+| Nombre | Descripción |
+| --- | --- |
+| getAspect() | Obtiene o establece la relación de aspecto del frustum |
+
+ **Result:**
+
+
+
+---
+
+
+### setAspect{#setAspect}
+
+| Nombre | Descripción |
+| --- | --- |
+| setAspect(value) | Obtiene o establece la relación de aspecto del frustum |
+
+ **Result:**
+
+
+
+---
+
+
+### getOrthoHeight{#getOrthoHeight}
+
+| Nombre | Descripción |
+| --- | --- |
+| getOrthoHeight() | Obtiene o establece la altura cuando el frustum está en proyección ortográfica. |
+
+ **Result:**
+
+
+
+---
+
+
+### setOrthoHeight{#setOrthoHeight}
+
+| Nombre | Descripción |
+| --- | --- |
+| setOrthoHeight(value) | Obtiene o establece la altura cuando el frustum está en proyección ortográfica. |
+
+ **Result:**
+
+
+
+---
+
+
+### getUp{#getUp}
+
+| Nombre | Descripción |
+| --- | --- |
+| getUp() | Obtiene o establece la dirección ascendente de la cámara |
+
+ **Result:**
+
+
+
+---
+
+
+### setUp{#setUp}
+
+| Nombre | Descripción |
+| --- | --- |
+| setUp(value) | Obtiene o establece la dirección ascendente de la cámara |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookAt{#getLookAt}
+
+| Nombre | Descripción |
+| --- | --- |
+| getLookAt() | Obtiene o establece la posición de interés a la que la cámara está mirando. |
+
+ **Result:**
+
+
+
+---
+
+
+### setLookAt{#setLookAt}
+
+| Nombre | Descripción |
+| --- | --- |
+| setLookAt(value) | Obtiene o establece la posición de interés a la que la cámara está mirando. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDirection{#getDirection}
+
+| Nombre | Descripción |
+| --- | --- |
+| getDirection() | Obtiene o establece la dirección a la que la cámara está mirando. Los cambios en esta propiedad también afectarán a LookAt y Target. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDirection{#setDirection}
+
+| Nombre | Descripción |
+| --- | --- |
+| setDirection(value) | Obtiene o establece la dirección a la que la cámara está mirando. Los cambios en esta propiedad también afectarán a LookAt y Target. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTarget{#getTarget}
+
+| Nombre | Descripción |
+| --- | --- |
+| getTarget() | Obtiene o establece el objetivo al que la cámara está mirando. Si el usuario admite esta propiedad, debe ser anterior a la propiedad LookAt. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTarget{#setTarget}
+
+| Nombre | Descripción |
+| --- | --- |
+| setTarget(value) | Obtiene o establece el objetivo al que la cámara está mirando. Si el usuario admite esta propiedad, debe ser anterior a la propiedad LookAt. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNodes() | Obtiene todos los nodos padre; una entidad puede estar adjunta a varios nodos padre para la instanciación de geometría. Los nodos. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExcluded() | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExcluded(value) | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNode() | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setParentNode(value) | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Nombre | Descripción |
+| --- | --- |
+| getScene() | Obtiene la escena a la que pertenece este objeto |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBoundingBox() | Obtiene el cuadro delimitador de la entidad actual en su sistema de coordenadas de espacio de objeto. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEntityRendererKey() | Obtiene la clave del renderizador de entidad registrado en el renderizador |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/line/_index.md
+++ b/spanish/nodejs-java/aspose.threed/line/_index.md
@@ -1,0 +1,397 @@
+---
+title: "Line"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/line/
+---
+## Line class
+
+Una polilínea es una ruta definida por un conjunto de puntos con Geometry.ControlPoints, y conectada por Segments, lo que significa que también puede ser un conjunto de segmentos de línea conectados. La línea suele ser un objeto lineal, lo que significa que no puede usarse para representar una curva; para representar una curva, se utiliza NurbsCurve.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Inicializa una nueva instancia de la clase Line. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload(name) | Inicializa una nueva instancia de la clase Line. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| name | Cadena | Nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getControlPoints{#getControlPoints}
+
+| Nombre | Descripción |
+| --- | --- |
+| getControlPoints() | Obtiene todos los puntos de control |
+
+ **Result:**
+
+
+
+---
+
+
+### getVisible{#getVisible}
+
+| Nombre | Descripción |
+| --- | --- |
+| getVisible() | Obtiene o establece si la geometría es visible |
+
+ **Result:**
+
+
+
+---
+
+
+### setVisible{#setVisible}
+
+| Nombre | Descripción |
+| --- | --- |
+| setVisible(value) | Obtiene o establece si la geometría es visible |
+
+ **Result:**
+
+
+
+---
+
+
+### getSegments{#getSegments}
+
+| Nombre | Descripción |
+| --- | --- |
+| getSegments() | Obtiene los segmentos de la línea |
+
+ **Result:**
+
+
+
+---
+
+
+### getColor{#getColor}
+
+| Nombre | Descripción |
+| --- | --- |
+| getColor() | Obtiene o establece el color de la línea, el valor predeterminado es blanco(1, 1, 1) |
+
+ **Result:**
+
+
+
+---
+
+
+### setColor{#setColor}
+
+| Nombre | Descripción |
+| --- | --- |
+| setColor(value) | Obtiene o establece el color de la línea, el valor predeterminado es blanco(1, 1, 1) |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNodes() | Obtiene todos los nodos padre; una entidad puede estar adjunta a varios nodos padre para la instanciación de geometría. Los nodos. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExcluded() | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExcluded(value) | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNode() | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setParentNode(value) | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Nombre | Descripción |
+| --- | --- |
+| getScene() | Obtiene la escena a la que pertenece este objeto |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### fromPoints{#fromPoints}
+
+| Nombre | Descripción |
+| --- | --- |
+| fromPoints(points) | Construye una instancia de Line a partir de un conjunto de puntos. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| punto | Vector3[] | null |
+
+ **Result:**
+Line
+
+
+---
+
+
+### makeDefaultIndices{#makeDefaultIndices}
+
+| Nombre | Descripción |
+| --- | --- |
+| makeDefaultIndices() | Genera la secuencia 0,1,2,3....Geometry.ControlPoints.Length-1 a Segments para que los ControlPoints puedan usarse como una sola línea |
+
+ **Result:**
+Line
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEntityRendererKey() | Obtiene la clave del renderizador de entidad registrado en el renderizador |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBoundingBox() | Obtiene el cuadro delimitador de la entidad actual en su sistema de coordenadas de espacio de objeto. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/linearextrusion/_index.md
+++ b/spanish/nodejs-java/aspose.threed/linearextrusion/_index.md
@@ -1,0 +1,476 @@
+---
+title: "LinearExtrusion"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/linearextrusion/
+---
+## LinearExtrusion class
+
+La extrusión lineal toma una forma 2D como entrada y extiende la forma en la tercera dimensión.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Constructor de la instancia LinearExtrusion. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload(shape, height) | Constructor de la instancia LinearExtrusion. |
+
+ **Result:**
+
+
+
+---
+
+
+### getShape{#getShape}
+
+| Nombre | Descripción |
+| --- | --- |
+| getShape() | La forma base que se extruirá. |
+
+ **Result:**
+
+
+
+---
+
+
+### setShape{#setShape}
+
+| Nombre | Descripción |
+| --- | --- |
+| setShape(value) | La forma base que se extruirá. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDirection{#getDirection}
+
+| Nombre | Descripción |
+| --- | --- |
+| getDirection() | La dirección de la extrusión, el valor predeterminado es (0, 0, 1) |
+
+ **Result:**
+
+
+
+---
+
+
+### setDirection{#setDirection}
+
+| Nombre | Descripción |
+| --- | --- |
+| setDirection(value) | La dirección de la extrusión, el valor predeterminado es (0, 0, 1) |
+
+ **Result:**
+
+
+
+---
+
+
+### getHeight{#getHeight}
+
+| Nombre | Descripción |
+| --- | --- |
+| getHeight() | La altura de la geometría extruida, el valor predeterminado es 1.0 |
+
+ **Result:**
+
+
+
+---
+
+
+### setHeight{#setHeight}
+
+| Nombre | Descripción |
+| --- | --- |
+| setHeight(value) | La altura de la geometría extruida, el valor predeterminado es 1.0 |
+
+ **Result:**
+
+
+
+---
+
+
+### getSlices{#getSlices}
+
+| Nombre | Descripción |
+| --- | --- |
+| getSlices() | Las capas de la geometría extruida y retorcida, el valor predeterminado es 1. |
+
+ **Result:**
+
+
+
+---
+
+
+### setSlices{#setSlices}
+
+| Nombre | Descripción |
+| --- | --- |
+| setSlices(value) | Las capas de la geometría extruida y retorcida, el valor predeterminado es 1. |
+
+ **Result:**
+
+
+
+---
+
+
+### getCenter{#getCenter}
+
+| Nombre | Descripción |
+| --- | --- |
+| getCenter() | Si este valor es false, el rango Z de la extrusión lineal es de 0 a la altura; de lo contrario, el rango es de -altura/2 a altura/2. |
+
+ **Result:**
+
+
+
+---
+
+
+### setCenter{#setCenter}
+
+| Nombre | Descripción |
+| --- | --- |
+| setCenter(value) | Si este valor es false, el rango Z de la extrusión lineal es de 0 a la altura; de lo contrario, el rango es de -altura/2 a altura/2. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTwistOffset{#getTwistOffset}
+
+| Nombre | Descripción |
+| --- | --- |
+| getTwistOffset() | El desplazamiento usado en la torsión, el valor predeterminado es (0, 0, 0). |
+
+ **Result:**
+
+
+
+---
+
+
+### setTwistOffset{#setTwistOffset}
+
+| Nombre | Descripción |
+| --- | --- |
+| setTwistOffset(value) | El desplazamiento usado en la torsión, el valor predeterminado es (0, 0, 0). |
+
+ **Result:**
+
+
+
+---
+
+
+### getTwist{#getTwist}
+
+| Nombre | Descripción |
+| --- | --- |
+| getTwist() | El número de grados a través de los cuales se extruye la forma. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTwist{#setTwist}
+
+| Nombre | Descripción |
+| --- | --- |
+| setTwist(value) | El número de grados a través de los cuales se extruye la forma. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNodes() | Obtiene todos los nodos padre; una entidad puede estar adjunta a varios nodos padre para la instanciación de geometría. Los nodos. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExcluded() | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExcluded(value) | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNode() | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setParentNode(value) | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Nombre | Descripción |
+| --- | --- |
+| getScene() | Obtiene la escena a la que pertenece este objeto |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### toMesh{#toMesh}
+
+| Nombre | Descripción |
+| --- | --- |
+| toMesh() | Convertir la extrusión a malla. |
+
+ **Result:**
+Malla
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBoundingBox() | Obtiene el cuadro delimitador de la entidad actual en su sistema de coordenadas de espacio de objeto. |
+
+ **Result:**
+Malla
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEntityRendererKey() | Obtiene la clave del renderizador de entidad registrado en el renderizador |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/loadoptions/_index.md
+++ b/spanish/nodejs-java/aspose.threed/loadoptions/_index.md
@@ -1,0 +1,107 @@
+---
+title: "LoadOptions"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/loadoptions/
+---
+## LoadOptions class
+
+La clase base para configurar opciones en la carga de archivos para diferentes tipos  @hideconstructor
+
+
+## Métodos
+
+### getFileFormat{#getFileFormat}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileFormat() | Obtiene el formato de archivo especificado en la opción actual de Guardar/Cargar. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEncoding() | Obtiene o establece la codificación predeterminada para archivos basados en texto. El valor predeterminado es null, lo que significa que el importador/exportador decidirá qué codificación usar. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileSystem() | Permite al usuario manejar cómo gestionar las dependencias externas durante la carga/guardado. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFileSystem(value) | Permite al usuario manejar cómo gestionar las dependencias externas durante la carga/guardado. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| Nombre | Descripción |
+| --- | --- |
+| getLookupPaths() | Algunos archivos como OBJ dependen de archivos externos; las rutas de búsqueda permiten que Aspose.3D busque el archivo externo para cargarlo. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileName() | El nombre de archivo de la escena de exportación/importación. Es opcional, pero útil al serializar recursos externos como el material de OBJ. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFileName(value) | El nombre de archivo de la escena de exportación/importación. Es opcional, pero útil al serializar recursos externos como el material de OBJ. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/localfilesystem/_index.md
+++ b/spanish/nodejs-java/aspose.threed/localfilesystem/_index.md
@@ -1,0 +1,75 @@
+---
+title: "LocalFileSystem"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/localfilesystem/
+---
+## LocalFileSystem class
+
+El LocalFileSystem asignará las operaciones de lectura/escritura al directorio local.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor(directory) | Inicializa un nuevo LocalFileSystem con el directorio base especificado. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| director | Cadena | null |
+
+ **Result:**
+
+
+
+---
+
+
+### readFile{#readFile}
+
+| Nombre | Descripción |
+| --- | --- |
+| readFile(fileName, options) | Crea un flujo para leer dependencias. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| fileNam | Cadena | null |
+| opción | IOConfig | null |
+
+ **Result:**
+Stream
+
+
+---
+
+
+### writeFile{#writeFile}
+
+| Nombre | Descripción |
+| --- | --- |
+| writeFile(fileName, options) | Crea un flujo para escribir dependencias. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| fileNam | Cadena | null |
+| opción | IOConfig | null |
+
+ **Result:**
+Stream
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/lshape/_index.md
+++ b/spanish/nodejs-java/aspose.threed/lshape/_index.md
@@ -1,0 +1,411 @@
+---
+title: "LShape"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/lshape/
+---
+## LShape class
+
+Perfil en forma de L compatible con IFC que se define mediante parámetros.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Constructor de LShape |
+
+ **Result:**
+
+
+
+---
+
+
+### getDepth{#getDepth}
+
+| Nombre | Descripción |
+| --- | --- |
+| getDepth() | Obtiene o establece la profundidad del perfil. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDepth{#setDepth}
+
+| Nombre | Descripción |
+| --- | --- |
+| setDepth(value) | Obtiene o establece la profundidad del perfil. |
+
+ **Result:**
+
+
+
+---
+
+
+### getWidth{#getWidth}
+
+| Nombre | Descripción |
+| --- | --- |
+| getWidth() | Obtiene o establece el ancho del perfil. |
+
+ **Result:**
+
+
+
+---
+
+
+### setWidth{#setWidth}
+
+| Nombre | Descripción |
+| --- | --- |
+| setWidth(value) | Obtiene o establece el ancho del perfil. |
+
+ **Result:**
+
+
+
+---
+
+
+### getThickness{#getThickness}
+
+| Nombre | Descripción |
+| --- | --- |
+| getThickness() | Obtiene o establece el grosor de la pared constante. |
+
+ **Result:**
+
+
+
+---
+
+
+### setThickness{#setThickness}
+
+| Nombre | Descripción |
+| --- | --- |
+| setThickness(value) | Obtiene o establece el grosor de la pared constante. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFilletRadius{#getFilletRadius}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFilletRadius() | Obtiene o establece el radio del chaflán. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFilletRadius{#setFilletRadius}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFilletRadius(value) | Obtiene o establece el radio del chaflán. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEdgeRadius{#getEdgeRadius}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEdgeRadius() | Obtiene o establece el radio del borde. |
+
+ **Result:**
+
+
+
+---
+
+
+### setEdgeRadius{#setEdgeRadius}
+
+| Nombre | Descripción |
+| --- | --- |
+| setEdgeRadius(value) | Obtiene o establece el radio del borde. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNodes() | Obtiene todos los nodos padre; una entidad puede estar adjunta a varios nodos padre para la instanciación de geometría. Los nodos. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExcluded() | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExcluded(value) | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNode() | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setParentNode(value) | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Nombre | Descripción |
+| --- | --- |
+| getScene() | Obtiene la escena a la que pertenece este objeto |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtent{#getExtent}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExtent() | Obtiene la extensión en las dimensiones x e y. |
+
+ **Result:**
+Vector2
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEntityRendererKey() | Obtiene la clave del renderizador de entidad registrado en el renderizador |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBoundingBox() | Obtiene el cuadro delimitador de la entidad actual en su sistema de coordenadas de espacio de objeto. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/material/_index.md
+++ b/spanish/nodejs-java/aspose.threed/material/_index.md
@@ -1,0 +1,226 @@
+---
+title: "Material"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/material/
+---
+## Material class
+
+Material define los parámetros necesarios para la apariencia visual de la geometría.  Aspose.3D proporciona modelos de sombreado para LambertMaterial, PhongMaterial y ShaderMaterial  @hideconstructor
+
+
+## Propiedades
+
+| Nombre | Descripción |
+| --- | --- |
+| MAP_SPECULAR | Usado en setTexture(java.lang.String, com.aspose.threed.TextureBase) para asignar un mapeo de textura especular. |
+| MAP_DIFFUSE | Usado en setTexture(java.lang.String, com.aspose.threed.TextureBase) para asignar un mapeo de textura difusa. |
+| MAP_EMISSIVE | Usado en setTexture(java.lang.String, com.aspose.threed.TextureBase) para asignar un mapeo de textura emisiva. |
+| MAP_AMBIENT | Usado en setTexture(java.lang.String, com.aspose.threed.TextureBase) para asignar un mapeo de textura ambiental. |
+| MAP_NORMAL | Usado en setTexture(java.lang.String, com.aspose.threed.TextureBase) para asignar un mapeo de textura normal. |
+
+## Métodos
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTexture{#getTexture}
+
+| Nombre | Descripción |
+| --- | --- |
+| getTexture(slotName) | Obtiene la textura del slot especificado, puede ser el nombre de una propiedad del material o el nombre de un parámetro del shader |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| slotName | Cadena | Nombre del slot. |
+
+ **Result:**
+TextureBase
+
+
+---
+
+
+### setTexture{#setTexture}
+
+| Nombre | Descripción |
+| --- | --- |
+| setTexture(slotName, texture) | Establece la textura al slot especificado |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| slotName | Cadena | Nombre del slot. |
+| texture | TextureBase | Textura. |
+
+ **Result:**
+TextureBase
+
+
+---
+
+
+### toString{#toString}
+
+| Nombre | Descripción |
+| --- | --- |
+| toString() | Formatea el objeto a cadena |
+
+ **Result:**
+Cadena
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+### iterator{#iterator}
+
+| Nombre | Descripción |
+| --- | --- |
+| iterator() | Reservado para uso interno. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/mathutils/_index.md
+++ b/spanish/nodejs-java/aspose.threed/mathutils/_index.md
@@ -1,0 +1,193 @@
+---
+title: "MathUtils"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/mathutils/
+---
+## MathUtils class
+
+Un conjunto de utilidades matemáticas útiles.  @hideconstructor
+
+
+## Métodos
+
+### clamp{#clamp}
+
+| Nombre | Descripción |
+| --- | --- |
+| clamp(val, min, max) | Limitar el valor al rango [min, max] |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| val | Número | Valor a limitar. |
+| min | Número | Valor mínimo. |
+| max | Número | Valor máximo. |
+
+ **Result:**
+Número
+
+
+---
+
+
+### toDegree{#toDegree}
+
+| Nombre | Descripción |
+| --- | --- |
+| toDegree(radian) | Convertir un Vector3 de radianes a grados. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| radian | Vector3 | El valor en radianes. |
+
+ **Result:**
+Vector3
+
+
+---
+
+
+### toRadian{#toRadian}
+
+| Nombre | Descripción |
+| --- | --- |
+| toRadian(degree) | Convertir un Vector3 de grados a radianes |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| degree | Vector3 | El valor en grados. |
+
+ **Result:**
+Vector3
+
+
+---
+
+
+### toDegree{#toDegree}
+
+| Nombre | Descripción |
+| --- | --- |
+| toDegree(radian) | Convertir un número de radianes a grados |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| radian | Número | El valor en radianes. |
+
+ **Result:**
+Número
+
+
+---
+
+
+### toDegree{#toDegree}
+
+| Nombre | Descripción |
+| --- | --- |
+| toDegree(radian) | Convertir un número de radianes a grados |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| radian | Número | El valor en radianes. |
+
+ **Result:**
+Número
+
+
+---
+
+
+### toDegree{#toDegree}
+
+| Nombre | Descripción |
+| --- | --- |
+| toDegree(x, y, z) | Convertir un número de radianes a grados |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| x | Número | El componente x en valor radianes. |
+| y | Número | El componente y en valor radianes. |
+| z | Número | El componente z en valor radianes. |
+
+ **Result:**
+Vector3
+
+
+---
+
+
+### toRadian{#toRadian}
+
+| Nombre | Descripción |
+| --- | --- |
+| toRadian(degree) | Convertir un número de grados a radianes |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| degree | Número | El valor en grados. |
+
+ **Result:**
+Número
+
+
+---
+
+
+### toRadian{#toRadian}
+
+| Nombre | Descripción |
+| --- | --- |
+| toRadian(degree) | Convertir un número de grados a radianes |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| degree | Número | El valor en grados. |
+
+ **Result:**
+Número
+
+
+---
+
+
+### toRadian{#toRadian}
+
+| Nombre | Descripción |
+| --- | --- |
+| toRadian(x, y, z) | Convertir un vector de grados a radianes |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| x | Número | El componente x en valor de grados. |
+| y | Número | El componente y en valor de grados. |
+| z | Número | El componente z en valor de grados. |
+
+ **Result:**
+Vector3
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/matrix4/_index.md
+++ b/spanish/nodejs-java/aspose.threed/matrix4/_index.md
@@ -1,0 +1,453 @@
+---
+title: "Matrix4"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/matrix4/
+---
+## Matrix4 class
+
+Implementación de matriz 4x4.
+
+
+## Propiedades
+
+| Nombre | Descripción |
+| --- | --- |
+| m00 | El m00. |
+| m01 | El m01. |
+| m02 | El m02. |
+| m03 | El m03. |
+| m10 | El m10. |
+| m11 | El m11. |
+| m12 | El m12. |
+| m13 | El m13. |
+| m20 | El m20. |
+| m21 | El m21. |
+| m22 | El m22. |
+| m23 | El m23. |
+| m30 | El m30. |
+| m31 | El m31. |
+| m32 | El m32. |
+| m33 | El m33. |
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload(r0, r1, r2, r3) | Construye la matriz a partir de 4 filas. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| r0 | Vector4 | R0. |
+| r1 | Vector4 | R1. |
+| r2 | Vector4 | R2. |
+| r3 | Vector4 | R3. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload2(m00, m01, m02, m03, m10, m11, m12, m13, m20, m21, m22, m23, m30, m31, m32, m33) | Inicializa una nueva instancia de la estructura Matrix4. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| m00 | Número | M00. |
+| m01 | Número | M01. |
+| m02 | Número | M02. |
+| m03 | Número | M03. |
+| m10 | Número | M10. |
+| m11 | Número | M11. |
+| m12 | Número | M12. |
+| m13 | Número | M13. |
+| m20 | Número | M20. |
+| m21 | Número | M21. |
+| m22 | Número | M22. |
+| m23 | Número | M23. |
+| m30 | Número | M30. |
+| m31 | Número | M31. |
+| m32 | Número | M32. |
+| m33 | Número | M33. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload3{#constructor_overload3}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload3(m) | Construye Matrix4 a partir de una instancia de FMatrix4. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+|  | FMatrix4 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload4{#constructor_overload4}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload4(m) | Inicializa una nueva instancia de la estructura Matrix4. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| m | Number[] | M. |
+
+ **Result:**
+
+
+
+---
+
+
+### getIdentity{#getIdentity}
+
+| Nombre | Descripción |
+| --- | --- |
+| getIdentity() | Obtiene la matriz identidad. La identidad. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDeterminant{#getDeterminant}
+
+| Nombre | Descripción |
+| --- | --- |
+| getDeterminant() | Obtiene el determinante de la matriz. El determinante. |
+
+ **Result:**
+
+
+
+---
+
+
+### concatenate{#concatenate}
+
+| Nombre | Descripción |
+| --- | --- |
+| concatenate(m2) | Concatena las dos matrices |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| m2 | Matrix4 | M2. |
+
+ **Result:**
+Matrix4
+
+
+---
+
+
+### transpose{#transpose}
+
+| Nombre | Descripción |
+| --- | --- |
+| transpose() | Transpone esta instancia. |
+
+ **Result:**
+Matrix4
+
+
+---
+
+
+### normalize{#normalize}
+
+| Nombre | Descripción |
+| --- | --- |
+| normalize() | Normaliza esta instancia. |
+
+ **Result:**
+Matrix4
+
+
+---
+
+
+### inverse{#inverse}
+
+| Nombre | Descripción |
+| --- | --- |
+| inverse() | Invierte esta instancia. |
+
+ **Result:**
+Matrix4
+
+
+---
+
+
+### setTRS{#setTRS}
+
+| Nombre | Descripción |
+| --- | --- |
+| setTRS(translation, rotation, scale) | Inicializa la matriz con traducción/rotación/escala |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| traducción | Vector3 | Traducción. |
+| rotación | Vector3 | Ángulos de Euler para rotación, los campos están en grados. |
+| escala | Vector3 | Escala. |
+
+ **Result:**
+Matrix4
+
+
+---
+
+
+### toArray{#toArray}
+
+| Nombre | Descripción |
+| --- | --- |
+| toArray() | Convierte la matriz a un arreglo. |
+
+ **Result:**
+Number[]
+
+
+---
+
+
+### toString{#toString}
+
+| Nombre | Descripción |
+| --- | --- |
+| toString() | Devuelve un java.lang.String que representa el actual Matrix4. |
+
+ **Result:**
+Cadena
+
+
+---
+
+
+### translate{#translate}
+
+| Nombre | Descripción |
+| --- | --- |
+| translate(t) | Crea una matriz que traduce a lo largo del eje x, el eje y y el eje z |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| t | Vector3 | Desplazamiento de traducción |
+
+ **Result:**
+Matrix4
+
+
+---
+
+
+### translate{#translate}
+
+| Nombre | Descripción |
+| --- | --- |
+| translate(tx, ty, tz) | Crea una matriz que traduce a lo largo del eje x, el eje y y el eje z |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| tx | Número | Desplazamiento de coordenada X |
+| ty | Número | Desplazamiento de la coordenada Y |
+| tz | Número | Desplazamiento de la coordenada Z |
+
+ **Result:**
+Matrix4
+
+
+---
+
+
+### scale{#scale}
+
+| Nombre | Descripción |
+| --- | --- |
+| escala(s) | Crea una matriz que escala a lo largo del eje x, el eje y y el eje z. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| s | Vector3 | Las fábricas de escalado se aplican al eje x, al eje y y al eje z |
+
+ **Result:**
+Matrix4
+
+
+---
+
+
+### scale{#scale}
+
+| Nombre | Descripción |
+| --- | --- |
+| escala(s) | Crea una matriz que escala a lo largo del eje x, el eje y y el eje z. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| s | Número | Las fábricas de escalado se aplican a todos los ejes |
+
+ **Result:**
+Matrix4
+
+
+---
+
+
+### scale{#scale}
+
+| Nombre | Descripción |
+| --- | --- |
+| scale(sx, sy, sz) | Crea una matriz que escala a lo largo del eje x, el eje y y el eje z. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| sx | Número | Las fábricas de escalado se aplican al eje x |
+| sy | Número | Las fábricas de escalado se aplican al eje y |
+| sz | Número | Las fábricas de escalado se aplican al eje z |
+
+ **Result:**
+Matrix4
+
+
+---
+
+
+### rotateFromEuler{#rotateFromEuler}
+
+| Nombre | Descripción |
+| --- | --- |
+| rotateFromEuler(eul) | Crea una matriz de rotación a partir del ángulo de Euler |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| eul | Vector3 | Rotación en radianes |
+
+ **Result:**
+Matrix4
+
+
+---
+
+
+### rotateFromEuler{#rotateFromEuler}
+
+| Nombre | Descripción |
+| --- | --- |
+| rotateFromEuler(rx, ry, rz) | Crea una matriz de rotación a partir del ángulo de Euler |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| rx | Número | Rotación en el eje x en radianes |
+| ry | Número | Rotación en el eje y en radianes |
+| rz | Número | Rotación en el eje z en radianes |
+
+ **Result:**
+Matrix4
+
+
+---
+
+
+### rotate{#rotate}
+
+| Nombre | Descripción |
+| --- | --- |
+| rotate(angle, axis) | Crear una matriz de rotación mediante el ángulo de rotación y el eje |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| ángulo | Número | Ángulo de rotación en radianes |
+| eje | Vector3 | Eje de rotación |
+
+ **Result:**
+Matrix4
+
+
+---
+
+
+### rotate{#rotate}
+
+| Nombre | Descripción |
+| --- | --- |
+| rotate(q) | Crear una matriz de rotación a partir de un cuaternión |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| q | Cuaternión | Cuaternión de rotación |
+
+ **Result:**
+Matrix4
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/memoryfilesystem/_index.md
+++ b/spanish/nodejs-java/aspose.threed/memoryfilesystem/_index.md
@@ -1,0 +1,101 @@
+---
+title: "MemoryFileSystem"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/memoryfilesystem/
+---
+## MemoryFileSystem class
+
+El MemoryFileSystem asignará las operaciones de lectura/escritura a la memoria.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileNames{#getFileNames}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileNames() | Nombres de archivo que se encuentran en este sistema de archivos en memoria. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileContent{#getFileContent}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileContent(fileName) | Devuelve el contenido bruto del archivo especificado. Lanza System.IO.FileNotFoundException si el archivo especificado no existe. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| fileNam | Cadena | null |
+
+ **Result:**
+byte[]
+
+
+---
+
+
+### readFile{#readFile}
+
+| Nombre | Descripción |
+| --- | --- |
+| readFile(fileName, options) | Crea un flujo para leer dependencias. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| fileNam | Cadena | null |
+| opción | IOConfig | null |
+
+ **Result:**
+Stream
+
+
+---
+
+
+### writeFile{#writeFile}
+
+| Nombre | Descripción |
+| --- | --- |
+| writeFile(fileName, options) | Crea un flujo para escribir dependencias. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| fileNam | Cadena | null |
+| opción | IOConfig | null |
+
+ **Result:**
+Stream
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/mesh/_index.md
+++ b/spanish/nodejs-java/aspose.threed/mesh/_index.md
@@ -1,0 +1,708 @@
+---
+title: "Malla"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/mesh/
+---
+## Mesh class
+
+Una malla está compuesta por muchos polígonos de n lados.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Inicializa una nueva instancia de la clase Mesh. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload(name) | Inicializa una nueva instancia de la clase Mesh. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| name | Cadena | Nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEdges{#getEdges}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEdges() | Obtiene los bordes de la Mesh. Edge es opcional en la mesh, por lo que puede estar vacío. |
+
+ **Result:**
+
+
+
+---
+
+
+### getPolygonCount{#getPolygonCount}
+
+| Nombre | Descripción |
+| --- | --- |
+| getPolygonCount() | Obtiene el recuento de polígonos. El recuento de polígonos. |
+
+ **Result:**
+
+
+
+---
+
+
+### getPolygons{#getPolygons}
+
+| Nombre | Descripción |
+| --- | --- |
+| getPolygons() | Obtiene la definición de polígonos de la mesh |
+
+ **Result:**
+
+
+
+---
+
+
+### getVisible{#getVisible}
+
+| Nombre | Descripción |
+| --- | --- |
+| getVisible() | Obtiene o establece si la geometría es visible |
+
+ **Result:**
+
+
+
+---
+
+
+### setVisible{#setVisible}
+
+| Nombre | Descripción |
+| --- | --- |
+| setVisible(value) | Obtiene o establece si la geometría es visible |
+
+ **Result:**
+
+
+
+---
+
+
+### getDeformers{#getDeformers}
+
+| Nombre | Descripción |
+| --- | --- |
+| getDeformers() | Obtiene todos los deformadores asociados con esta geometría. Los deformadores. |
+
+ **Result:**
+
+
+
+---
+
+
+### getControlPoints{#getControlPoints}
+
+| Nombre | Descripción |
+| --- | --- |
+| getControlPoints() | Obtiene todos los puntos de control |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastShadows{#getCastShadows}
+
+| Nombre | Descripción |
+| --- | --- |
+| getCastShadows() | Obtiene o establece si esta geometría puede proyectar sombra |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastShadows{#setCastShadows}
+
+| Nombre | Descripción |
+| --- | --- |
+| setCastShadows(value) | Obtiene o establece si esta geometría puede proyectar sombra |
+
+ **Result:**
+
+
+
+---
+
+
+### getReceiveShadows{#getReceiveShadows}
+
+| Nombre | Descripción |
+| --- | --- |
+| getReceiveShadows() | Obtiene o establece si esta geometría puede recibir sombra. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReceiveShadows{#setReceiveShadows}
+
+| Nombre | Descripción |
+| --- | --- |
+| setReceiveShadows(value) | Obtiene o establece si esta geometría puede recibir sombra. |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElements{#getVertexElements}
+
+| Nombre | Descripción |
+| --- | --- |
+| getVertexElements() | Obtiene todos los elementos de vértice |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNodes() | Obtiene todos los nodos padre; una entidad puede estar adjunta a varios nodos padre para la instanciación de geometría. Los nodos. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExcluded() | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExcluded(value) | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNode() | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setParentNode(value) | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Nombre | Descripción |
+| --- | --- |
+| getScene() | Obtiene la escena a la que pertenece este objeto |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### getPolygonSize{#getPolygonSize}
+
+| Nombre | Descripción |
+| --- | --- |
+| getPolygonSize(index) | Obtiene el recuento de vértices del polígono especificado. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| index | Número | Índice. |
+
+ **Result:**
+Número
+
+
+---
+
+
+### createPolygon{#createPolygon}
+
+| Nombre | Descripción |
+| --- | --- |
+| createPolygon(indices, offset, length) | Crea un nuevo polígono con todos los vértices definidos en indices. Para crear el polígono vértice a vértice, por favor use PolygonBuilder. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| indices | Number[] | Arreglo de los índices del polígono, cada índice apunta a un punto de control que forma el polígono. |
+| offset | Número | El desplazamiento del primer índice del polígono |
+| length | Número | La longitud de los índices |
+
+ **Result:**
+Número
+
+
+---
+
+
+### createPolygon{#createPolygon}
+
+| Nombre | Descripción |
+| --- | --- |
+| createPolygon(indices) | Crea un nuevo polígono con todos los vértices definidos en indices. Para crear el polígono vértice a vértice, por favor use PolygonBuilder. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| indices | Number[] | Arreglo de los índices del polígono, cada índice apunta a un punto de control que forma el polígono. |
+
+ **Result:**
+Número
+
+
+---
+
+
+### createPolygon{#createPolygon}
+
+| Nombre | Descripción |
+| --- | --- |
+| createPolygon(v1, v2, v3, v4) | Crea un polígono con 4 vértices(quad) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| v1 | Número | Índice del primer vértice |
+| v2 | Número | Índice del segundo vértice |
+| v3 | Número | Índice del tercer vértice |
+| v4 | Número | Índice del cuarto vértice |
+
+ **Result:**
+Número
+
+
+---
+
+
+### createPolygon{#createPolygon}
+
+| Nombre | Descripción |
+| --- | --- |
+| createPolygon(v1, v2, v3) | Crear un polígono con 3 vértices(triángulo) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| v1 | Número | Índice del primer vértice |
+| v2 | Número | Índice del segundo vértice |
+| v3 | Número | Índice del tercer vértice |
+
+ **Result:**
+Número
+
+
+---
+
+
+### toMesh{#toMesh}
+
+| Nombre | Descripción |
+| --- | --- |
+| toMesh() | Obtiene la instancia de Mesh de la entidad actual. |
+
+ **Result:**
+Malla
+
+
+---
+
+
+### getElement{#getElement}
+
+| Nombre | Descripción |
+| --- | --- |
+| getElement(type) | Obtiene un elemento de vértice con el tipo especificado |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| type | VertexElementType | VertexElementType |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### getVertexElementOfUV{#getVertexElementOfUV}
+
+| Nombre | Descripción |
+| --- | --- |
+| getVertexElementOfUV(textureMapping) | Obtiene una instancia de VertexElementUV con el tipo de TextureMapping dado |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| textureMapping | TextureMapping | TextureMapping |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### createElement{#createElement}
+
+| Nombre | Descripción |
+| --- | --- |
+| createElement(type) | Crea un elemento de vértice con el tipo especificado y lo agrega a la geometría. Si el tipo es VertexElementType.UV, se creará un VertexElementUV con el tipo de mapeo de textura a TextureMapping.DIFFUSE. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| type | VertexElementType | VertexElementType |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### addElement{#addElement}
+
+| Nombre | Descripción |
+| --- | --- |
+| addElement(element) | Agrega un elemento de vértice existente a la geometría actual |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| element | VertexElement | El elemento de vértice a agregar |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### createElement{#createElement}
+
+| Nombre | Descripción |
+| --- | --- |
+| createElement(type, mappingMode, referenceMode) | Crea un elemento de vértice con el tipo especificado y lo agrega a la geometría. Si el tipo es VertexElementType.UV, se creará un VertexElementUV con el tipo de mapeo de textura a TextureMapping.DIFFUSE. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| type | VertexElementType | VertexElementType |
+| mappingMode | MappingMode | MappingMode |
+| referenceMode | ReferenceMode | ReferenceMode |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### createElementUV{#createElementUV}
+
+| Nombre | Descripción |
+| --- | --- |
+| createElementUV(uvMapping) | Crea un VertexElementUV con el tipo de mapeo de textura dado. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| uvMapping | TextureMapping | TextureMapping |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### createElementUV{#createElementUV}
+
+| Nombre | Descripción |
+| --- | --- |
+| createElementUV(uvMapping, mappingMode, referenceMode) | Crea un VertexElementUV con el tipo de mapeo de textura dado. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| uvMapping | TextureMapping | TextureMapping |
+| mappingMode | MappingMode | MappingMode |
+| referenceMode | ReferenceMode | ReferenceMode |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBoundingBox() | Obtiene el cuadro delimitador de la entidad actual en su sistema de coordenadas de espacio de objeto. |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEntityRendererKey() | Obtiene la clave del renderizador de entidad registrado en el renderizador |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+### iterator{#iterator}
+
+| Nombre | Descripción |
+| --- | --- |
+| iterator() | Reservado para uso interno. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/metered/_index.md
+++ b/spanish/nodejs-java/aspose.threed/metered/_index.md
@@ -1,0 +1,75 @@
+---
+title: "Metered"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/metered/
+---
+## Metered class
+
+Proporciona métodos para establecer la clave medida.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Inicializa una nueva instancia de esta clase. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMeteredKey{#setMeteredKey}
+
+| Nombre | Descripción |
+| --- | --- |
+| setMeteredKey(publicKey, privateKey) | Establece la clave pública y privada con medida. Si adquiere una licencia con medida, al iniciar la aplicación, debe llamarse a esta API; normalmente, eso es suficiente. Sin embargo, si siempre falla la carga de datos de consumo y supera las 24 horas, la licencia se establecerá en estado de evaluación; para evitar este caso, debe comprobar regularmente el estado de la licencia y, si está en estado de evaluación, llamar a esta API nuevamente. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| publicKey | Cadena | clave pública |
+| privateKey | Cadena | clave privada |
+
+ **Result:**
+
+
+
+---
+
+
+### getConsumptionQuantity{#getConsumptionQuantity}
+
+| Nombre | Descripción |
+| --- | --- |
+| getConsumptionQuantity() | Obtiene el tamaño del archivo de consumo |
+
+ **Result:**
+BigDecimal
+
+
+---
+
+
+### getConsumptionCredit{#getConsumptionCredit}
+
+| Nombre | Descripción |
+| --- | --- |
+| getConsumptionCredit() | Obtiene el crédito de consumo |
+
+ **Result:**
+BigDecimal
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/mirroredprofile/_index.md
+++ b/spanish/nodejs-java/aspose.threed/mirroredprofile/_index.md
@@ -1,0 +1,287 @@
+---
+title: "MirroredProfile"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/mirroredprofile/
+---
+## MirroredProfile class
+
+Perfil espejo compatible con IFC.  Este perfil define un nuevo perfil al reflejar el perfil base respecto al eje y.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor(baseProfile) | Construye un nuevo MirroredProfile a partir de un perfil existente. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| baseProfile | Profile | El perfil base que será reflejado. |
+
+ **Result:**
+
+
+
+---
+
+
+### getBaseProfile{#getBaseProfile}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBaseProfile() | El perfil base que será reflejado. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNodes() | Obtiene todos los nodos padre; una entidad puede estar adjunta a varios nodos padre para la instanciación de geometría. Los nodos. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExcluded() | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExcluded(value) | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNode() | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setParentNode(value) | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Nombre | Descripción |
+| --- | --- |
+| getScene() | Obtiene la escena a la que pertenece este objeto |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEntityRendererKey() | Obtiene la clave del renderizador de entidad registrado en el renderizador |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBoundingBox() | Obtiene el cuadro delimitador de la entidad actual en su sistema de coordenadas de espacio de objeto. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/morphtargetchannel/_index.md
+++ b/spanish/nodejs-java/aspose.threed/morphtargetchannel/_index.md
@@ -1,0 +1,306 @@
+---
+title: "MorphTargetChannel"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/morphtargetchannel/
+---
+## MorphTargetChannel class
+
+Un MorphTargetChannel es utilizado por MorphTargetDeformer para organizar las geometrías objetivo. Algunos formatos de archivo como FBX admiten múltiples canales en paralelo. El peso está entre 0 y 1.0, y el peso predeterminado para el objetivo es 0.0;
+
+
+## Propiedades
+
+| Nombre | Descripción |
+| --- | --- |
+| DEFAULT_WEIGHT | Peso predeterminado para el objetivo de morph. |
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor(name) | Inicializa una nueva instancia de la clase MorphTargetChannel. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| name | Cadena | Nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload() | Inicializa una nueva instancia de la clase MorphTargetChannel. |
+
+ **Result:**
+
+
+
+---
+
+
+### getWeights{#getWeights}
+
+| Nombre | Descripción |
+| --- | --- |
+| getWeights() | Obtiene los valores completos de peso de las geometrías objetivo. Los pesos completos. |
+
+ **Result:**
+
+
+
+---
+
+
+### getChannelWeight{#getChannelWeight}
+
+| Nombre | Descripción |
+| --- | --- |
+| getChannelWeight() | Obtiene o establece el peso del deformador de este canal. El peso está entre 0.0 y 1.0 |
+
+ **Result:**
+
+
+
+---
+
+
+### setChannelWeight{#setChannelWeight}
+
+| Nombre | Descripción |
+| --- | --- |
+| setChannelWeight(value) | Obtiene o establece el peso del deformador de este canal. El peso está entre 0.0 y 1.0 |
+
+ **Result:**
+
+
+
+---
+
+
+### getTargets{#getTargets}
+
+| Nombre | Descripción |
+| --- | --- |
+| getTargets() | Obtiene todos los objetivos asociados con el canal. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### get{#get}
+
+| Nombre | Descripción |
+| --- | --- |
+| get(target) |  |
+
+ **Result:**
+
+
+
+---
+
+
+### set{#set}
+
+| Nombre | Descripción |
+| --- | --- |
+| set(target, value) |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getWeight{#getWeight}
+
+| Nombre | Descripción |
+| --- | --- |
+| getWeight(target) | Obtiene el peso del objetivo especificado; si el objetivo no pertenece a este canal, se devuelve el valor predeterminado 0. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| objetivo | Forma | null |
+
+ **Result:**
+Número
+
+
+---
+
+
+### setWeight{#setWeight}
+
+| Nombre | Descripción |
+| --- | --- |
+| setWeight(target, weight) | Establece el peso para el objetivo especificado, el valor predeterminado es 1, el rango debe estar entre 0 y 1. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| objetivo | Forma | null |
+| pesar | Número | null |
+
+ **Result:**
+Número
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/morphtargetdeformer/_index.md
+++ b/spanish/nodejs-java/aspose.threed/morphtargetdeformer/_index.md
@@ -1,0 +1,235 @@
+---
+title: "MorphTargetDeformer"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/morphtargetdeformer/
+---
+## MorphTargetDeformer class
+
+MorphTargetDeformer proporciona animación por vértice. MorphTargetDeformer organiza todos los objetivos a través de MorphTargetChannel, cada canal puede organizar múltiples objetivos. Un uso común del deformador de objetivos de morfología es aplicar expresiones faciales a un personaje. Más detalles pueden encontrarse en https://en.wikipedia.org/wiki/Morph_target_animation
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor(name) | Inicializa una nueva instancia de la clase MorphTargetDeformer. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| name | Cadena | Nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload() | Inicializa una nueva instancia de la clase MorphTargetDeformer. |
+
+ **Result:**
+
+
+
+---
+
+
+### getChannels{#getChannels}
+
+| Nombre | Descripción |
+| --- | --- |
+| getChannels() | Obtiene todos los canales contenidos en este deformador |
+
+ **Result:**
+
+
+
+---
+
+
+### getOwner{#getOwner}
+
+| Nombre | Descripción |
+| --- | --- |
+| getOwner() | Obtiene la geometría que posee este deformer |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### get{#get}
+
+| Nombre | Descripción |
+| --- | --- |
+| get(target) |  |
+
+ **Result:**
+
+
+
+---
+
+
+### set{#set}
+
+| Nombre | Descripción |
+| --- | --- |
+| set(target, value) |  |
+
+ **Result:**
+
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/node/_index.md
+++ b/spanish/nodejs-java/aspose.threed/node/_index.md
@@ -1,0 +1,739 @@
+---
+title: "Nodo"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/node/
+---
+## Node class
+
+Representa un elemento en el grafo de escena. Un grafo de escena es un árbol de objetos Node. Los servicios de gestión del árbol están contenidos en esta clase. Nota: el SDK Aspose.3D no verifica la validez del grafo de escena construido. Es responsabilidad del llamador asegurarse de que no genere grafos cíclicos en una jerarquía de nodos. Además de la gestión del árbol, esta clase define todas las propiedades necesarias para describir la posición del objeto en la escena. Esta información incluye las propiedades básicas de Translación, Rotación y Escalado, y las opciones más avanzadas para pivotes, límites y atributos de articulaciones IK como la rigidez y el amortiguamiento. Cuando se crea por primera vez, el objeto Node está "empty" (es decir, es un objeto sin representación gráfica que solo contiene la información de posición). En este estado, puede usarse para representar padres en la estructura del árbol de nodos pero no mucho más. El uso normal de este tipo de objetos es añadirles una entidad que especializará el nodo (ver "Entity"). La entidad es un objeto por sí misma y está conectada al Node. Esto también significa que la misma entidad puede compartirse entre varios nodos. Cámara, Luz, Malla, etc... son todas entidades y todas derivan de la clase base Entity.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Inicializa una nueva instancia de la clase Node. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload(name, entity) | Inicializa una nueva instancia de la clase Node. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| name | Cadena | Nombre. |
+| entidad | Entidad | Entidad predeterminada. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload2(name) | Inicializa una nueva instancia de la clase Node. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| name | Cadena | Nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAssetInfo{#getAssetInfo}
+
+| Nombre | Descripción |
+| --- | --- |
+| getAssetInfo() | Información de activo por nodo |
+
+ **Result:**
+
+
+
+---
+
+
+### setAssetInfo{#setAssetInfo}
+
+| Nombre | Descripción |
+| --- | --- |
+| setAssetInfo(value) | Información de activo por nodo |
+
+ **Result:**
+
+
+
+---
+
+
+### getVisible{#getVisible}
+
+| Nombre | Descripción |
+| --- | --- |
+| getVisible() | Obtiene o establece si se muestra el nodo |
+
+ **Result:**
+
+
+
+---
+
+
+### setVisible{#setVisible}
+
+| Nombre | Descripción |
+| --- | --- |
+| setVisible(value) | Obtiene o establece si se muestra el nodo |
+
+ **Result:**
+
+
+
+---
+
+
+### getChildNodes{#getChildNodes}
+
+| Nombre | Descripción |
+| --- | --- |
+| getChildNodes() | Obtiene los nodos hijos. Los nodos. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntity{#getEntity}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEntity() | Obtiene o establece la primera entidad adjunta a este nodo; si se establece, se eliminarán las demás entidades. La entidad del nodo. |
+
+ **Result:**
+
+
+
+---
+
+
+### setEntity{#setEntity}
+
+| Nombre | Descripción |
+| --- | --- |
+| setEntity(value) | Obtiene o establece la primera entidad adjunta a este nodo; si se establece, se eliminarán las demás entidades. La entidad del nodo. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExcluded() | Obtiene o establece si excluir este nodo y todos los nodos/entidades hijos durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExcluded(value) | Obtiene o establece si excluir este nodo y todos los nodos/entidades hijos durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntities{#getEntities}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEntities() | Obtiene todas las entidades del nodo. Las entidades del nodo. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMetaDatas{#getMetaDatas}
+
+| Nombre | Descripción |
+| --- | --- |
+| getMetaDatas() | Obtiene los metadatos definidos en este nodo. Los metadatos. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMaterials{#getMaterials}
+
+| Nombre | Descripción |
+| --- | --- |
+| getMaterials() | Obtiene los materiales asociados a este nodo. Los materiales. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMaterial{#getMaterial}
+
+| Nombre | Descripción |
+| --- | --- |
+| getMaterial() | Obtiene o establece el primer material asociado a este nodo; si se establece, se eliminarán los demás materiales. El material. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMaterial{#setMaterial}
+
+| Nombre | Descripción |
+| --- | --- |
+| setMaterial(value) | Obtiene o establece el primer material asociado a este nodo; si se establece, se eliminarán los demás materiales. El material. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNode() | Obtiene o establece el nodo padre. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setParentNode(value) | Obtiene o establece el nodo padre. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTransform{#getTransform}
+
+| Nombre | Descripción |
+| --- | --- |
+| getTransform() | Obtiene la transformación local. La transformación. |
+
+ **Result:**
+
+
+
+---
+
+
+### getGlobalTransform{#getGlobalTransform}
+
+| Nombre | Descripción |
+| --- | --- |
+| getGlobalTransform() | Obtiene la transformación global. La transformación global. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Nombre | Descripción |
+| --- | --- |
+| getScene() | Obtiene la escena a la que pertenece este objeto |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### createChildNode{#createChildNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| createChildNode() | Crea un nodo hijo |
+
+ **Result:**
+Nodo
+
+
+---
+
+
+### merge{#merge}
+
+| Nombre | Descripción |
+| --- | --- |
+| merge(node) | Desvincula todo bajo el nodo y adjúntalo al nodo actual. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| asentir | Nodo | null |
+
+ **Result:**
+Nodo
+
+
+---
+
+
+### createChildNode{#createChildNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| createChildNode(nodeName) | Crea un nuevo nodo hijo con el nombre de nodo proporcionado |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| nodeName | Cadena | El nombre del nuevo nodo hijo |
+
+ **Result:**
+Nodo
+
+
+---
+
+
+### createChildNode{#createChildNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| createChildNode(entity) | Crea un nuevo nodo hijo con la entidad proporcionada adjunta |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| entidad | Entidad | Entidad predeterminada adjunta al nodo |
+
+ **Result:**
+Nodo
+
+
+---
+
+
+### createChildNode{#createChildNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| createChildNode(nodeName, entity) | Crea un nuevo nodo hijo con el nombre de nodo proporcionado |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| nodeName | Cadena | El nombre del nuevo nodo hijo |
+| entidad | Entidad | Entidad predeterminada adjunta al nodo |
+
+ **Result:**
+Nodo
+
+
+---
+
+
+### createChildNode{#createChildNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| createChildNode(nodeName, entity, material) | Crea un nuevo nodo hijo con el nombre de nodo proporcionado y adjunta la entidad especificada y un material |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| nodeName | Cadena | El nombre del nuevo nodo hijo |
+| entidad | Entidad | Entidad predeterminada adjunta al nodo |
+| material | Material | El material adjunto al nodo |
+
+ **Result:**
+Nodo
+
+
+---
+
+
+### evaluateGlobalTransform{#evaluateGlobalTransform}
+
+| Nombre | Descripción |
+| --- | --- |
+| evaluateGlobalTransform(withGeometricTransform) | Evalúa la transformación global, incluye la transformación geométrica o no. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| withGeometricTransform | boolean | Si se necesita la transformación geométrica. |
+
+ **Result:**
+Matrix4
+
+
+---
+
+
+### getChild{#getChild}
+
+| Nombre | Descripción |
+| --- | --- |
+| getChild(index) | Obtiene el nodo hijo en el índice especificado. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| index | Número | Índice. |
+
+ **Result:**
+Nodo
+
+
+---
+
+
+### getChild{#getChild}
+
+| Nombre | Descripción |
+| --- | --- |
+| getChild(nodeName) | Obtiene el nodo hijo con el nombre especificado |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| nodeName | Cadena | El nombre del hijo a buscar. |
+
+ **Result:**
+Nodo
+
+
+---
+
+
+### accept{#accept}
+
+| Nombre | Descripción |
+| --- | --- |
+| accept(visitor) | Recorre todos los nodos descendientes (incluyendo el nodo actual) y llama al visitante con el nodo. El visitante puede interrumpir el recorrido devolviendo false |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| visitor | NodeVisitor | Callback del Visitor para visitar el nodo |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### toString{#toString}
+
+| Nombre | Descripción |
+| --- | --- |
+| toString() | Obtiene la representación en cadena de este nodo. |
+
+ **Result:**
+Cadena
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBoundingBox() | Calcula la caja delimitadora del nodo |
+
+ **Result:**
+BoundingBox
+
+
+---
+
+
+### addEntity{#addEntity}
+
+| Nombre | Descripción |
+| --- | --- |
+| addEntity(entity) | Añade una entidad al nodo. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| entidad | Entidad | La entidad que se adjuntará al nodo |
+
+ **Result:**
+BoundingBox
+
+
+---
+
+
+### addChildNode{#addChildNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| addChildNode(node) | Añade un nodo hijo a este nodo |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| nodo | Nodo | El nodo hijo que se adjuntará |
+
+ **Result:**
+BoundingBox
+
+
+---
+
+
+### selectSingleObject{#selectSingleObject}
+
+| Nombre | Descripción |
+| --- | --- |
+| selectSingleObject(path) | Selecciona un único objeto bajo el nodo actual usando sintaxis de consulta similar a XPath. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| pat | Cadena | null |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### selectObjects{#selectObjects}
+
+| Nombre | Descripción |
+| --- | --- |
+| selectObjects(path) | Selecciona múltiples objetos bajo el nodo actual usando sintaxis de consulta similar a XPath. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| pat | Cadena | null |
+
+ **Result:**
+0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/nurbscurve/_index.md
+++ b/spanish/nodejs-java/aspose.threed/nurbscurve/_index.md
@@ -1,0 +1,494 @@
+---
+title: "NurbsCurve"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/nurbscurve/
+---
+## NurbsCurve class
+
+Una curva NURBS es una curva representada por NURBS (Non-uniform rational basis spline). Una curva NURBS se define por su Order, un conjunto de Geometry.ControlPoints ponderados y un KnotVectors. El componente w en el punto de control se usa como peso del punto de control, sea que sea CurveDimension.TWO_DIMENSIONAL o CurveDimension.THREE_DIMENSIONAL.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Inicializa una nueva instancia de la clase NurbsCurve. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload(name) | Inicializa una nueva instancia de la clase NurbsCurve. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| name | Cadena | Nombre |
+
+ **Result:**
+
+
+
+---
+
+
+### getControlPoints{#getControlPoints}
+
+| Nombre | Descripción |
+| --- | --- |
+| getControlPoints() | Obtiene todos los puntos de control |
+
+ **Result:**
+
+
+
+---
+
+
+### getMultiplicity{#getMultiplicity}
+
+| Nombre | Descripción |
+| --- | --- |
+| getMultiplicity() | Obtiene la multiplicidad. La multiplicidad. |
+
+ **Result:**
+
+
+
+---
+
+
+### getOrder{#getOrder}
+
+| Nombre | Descripción |
+| --- | --- |
+| getOrder() | Obtiene o establece el orden de una curva NURBS, define el número de puntos de control cercanos que influyen en cualquier punto dado de la curva. El orden. |
+
+ **Result:**
+
+
+
+---
+
+
+### setOrder{#setOrder}
+
+| Nombre | Descripción |
+| --- | --- |
+| setOrder(value) | Obtiene o establece el orden de una curva NURBS, define el número de puntos de control cercanos que influyen en cualquier punto dado de la curva. El orden. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDimension{#getDimension}
+
+| Nombre | Descripción |
+| --- | --- |
+| getDimension() | Obtiene o establece la dimensión de la curva. El valor de la propiedad es una constante entera CurveDimension. Para una curva CurveDimension.TWO_DIMENSIONAL, el componente z en el punto de control no se usa. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDimension{#setDimension}
+
+| Nombre | Descripción |
+| --- | --- |
+| setDimension(value) | Obtiene o establece la dimensión de la curva. El valor de la propiedad es una constante entera CurveDimension. Para una curva CurveDimension.TWO_DIMENSIONAL, el componente z en el punto de control no se usa. |
+
+ **Result:**
+
+
+
+---
+
+
+### getCurveType{#getCurveType}
+
+| Nombre | Descripción |
+| --- | --- |
+| getCurveType() | Obtiene o establece el tipo de la curva. El valor de la propiedad es la constante entera NurbsType. El tipo de la curva. |
+
+ **Result:**
+
+
+
+---
+
+
+### setCurveType{#setCurveType}
+
+| Nombre | Descripción |
+| --- | --- |
+| setCurveType(value) | Obtiene o establece el tipo de la curva. El valor de la propiedad es la constante entera NurbsType. El tipo de la curva. |
+
+ **Result:**
+
+
+
+---
+
+
+### getKnotVectors{#getKnotVectors}
+
+| Nombre | Descripción |
+| --- | --- |
+| getKnotVectors() | Obtiene el vector de nudos, es una secuencia de valores de parámetro que determina dónde y cómo los puntos de control afectan la curva NURBS. |
+
+ **Result:**
+
+
+
+---
+
+
+### getRational{#getRational}
+
+| Nombre | Descripción |
+| --- | --- |
+| getRational() | Obtiene o establece si es racional, este valor indica si este NurbsCurve es una spline racional o una spline no racional. La B-spline no racional es un caso especial de B-splines racionales. true si es una spline racional; de lo contrario, false es una spline no racional. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRational{#setRational}
+
+| Nombre | Descripción |
+| --- | --- |
+| setRational(value) | Obtiene o establece si es racional, este valor indica si este NurbsCurve es una spline racional o una spline no racional. La B-spline no racional es un caso especial de B-splines racionales. true si es una spline racional; de lo contrario, false es una spline no racional. |
+
+ **Result:**
+
+
+
+---
+
+
+### getColor{#getColor}
+
+| Nombre | Descripción |
+| --- | --- |
+| getColor() | Obtiene o establece el color de la línea, el valor predeterminado es blanco(1, 1, 1) |
+
+ **Result:**
+
+
+
+---
+
+
+### setColor{#setColor}
+
+| Nombre | Descripción |
+| --- | --- |
+| setColor(value) | Obtiene o establece el color de la línea, el valor predeterminado es blanco(1, 1, 1) |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNodes() | Obtiene todos los nodos padre; una entidad puede estar adjunta a varios nodos padre para la instanciación de geometría. Los nodos. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExcluded() | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExcluded(value) | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNode() | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setParentNode(value) | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Nombre | Descripción |
+| --- | --- |
+| getScene() | Obtiene la escena a la que pertenece este objeto |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### evaluate{#evaluate}
+
+| Nombre | Descripción |
+| --- | --- |
+| evaluate(steps) | Evalúa la curva NURBS |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| steps | Número | La frecuencia de evaluación entre dos nudos vecinos, el valor predeterminado es 20 |
+
+ **Result:**
+Vector4[]
+
+
+---
+
+
+### evaluateAt{#evaluateAt}
+
+| Nombre | Descripción |
+| --- | --- |
+| evaluateAt(u) | Evalúa el punto de la curva en la posición especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| u | Número | La posición en la curva, entre 0 y 1 |
+
+ **Result:**
+Vector4
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEntityRendererKey() | Obtiene la clave del renderizador de entidad registrado en el renderizador |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBoundingBox() | Obtiene el cuadro delimitador de la entidad actual en su sistema de coordenadas de espacio de objeto. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/nurbsdirection/_index.md
+++ b/spanish/nodejs-java/aspose.threed/nurbsdirection/_index.md
@@ -1,0 +1,159 @@
+---
+title: "NurbsDirection"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/nurbsdirection/
+---
+## NurbsDirection class
+
+Una NurbsSurface 3D tiene dos direcciones, NurbsSurface.U y NurbsSurface.V; NurbsDirection define los datos para cada dirección. Una dirección es en realidad una curva NURBS, lo que significa que también se define por su Order, un KnotVectors y un conjunto de puntos de control ponderados (definidos en NurbsSurface).
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getKnotVectors{#getKnotVectors}
+
+| Nombre | Descripción |
+| --- | --- |
+| getKnotVectors() | Obtiene el vector de nudos, es una secuencia de valores de parámetro que determina dónde y cómo los puntos de control afectan la curva NURBS. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMultiplicity{#getMultiplicity}
+
+| Nombre | Descripción |
+| --- | --- |
+| getMultiplicity() | Obtiene la multiplicidad. La multiplicidad. |
+
+ **Result:**
+
+
+
+---
+
+
+### getOrder{#getOrder}
+
+| Nombre | Descripción |
+| --- | --- |
+| getOrder() | Obtiene o establece el orden de una curva NURBS, define el número de puntos de control cercanos que influyen en cualquier punto de la curva. |
+
+ **Result:**
+
+
+
+---
+
+
+### setOrder{#setOrder}
+
+| Nombre | Descripción |
+| --- | --- |
+| setOrder(value) | Obtiene o establece el orden de una curva NURBS, define el número de puntos de control cercanos que influyen en cualquier punto de la curva. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDivisions{#getDivisions}
+
+| Nombre | Descripción |
+| --- | --- |
+| getDivisions() | Obtiene o establece el número de divisiones entre puntos de control adyacentes en la dirección actual. El paso. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDivisions{#setDivisions}
+
+| Nombre | Descripción |
+| --- | --- |
+| setDivisions(value) | Obtiene o establece el número de divisiones entre puntos de control adyacentes en la dirección actual. El paso. |
+
+ **Result:**
+
+
+
+---
+
+
+### getType{#getType}
+
+| Nombre | Descripción |
+| --- | --- |
+| getType() | Obtiene o establece el tipo de la dirección actual. El valor de la propiedad es la constante entera NurbsType. |
+
+ **Result:**
+
+
+
+---
+
+
+### setType{#setType}
+
+| Nombre | Descripción |
+| --- | --- |
+| setType(value) | Obtiene o establece el tipo de la dirección actual. El valor de la propiedad es la constante entera NurbsType. |
+
+ **Result:**
+
+
+
+---
+
+
+### getCount{#getCount}
+
+| Nombre | Descripción |
+| --- | --- |
+| getCount() | Obtiene o establece el recuento de puntos de control en la dirección actual. El recuento. |
+
+ **Result:**
+
+
+
+---
+
+
+### setCount{#setCount}
+
+| Nombre | Descripción |
+| --- | --- |
+| setCount(value) | Obtiene o establece el recuento de puntos de control en la dirección actual. El recuento. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/nurbssurface/_index.md
+++ b/spanish/nodejs-java/aspose.threed/nurbssurface/_index.md
@@ -1,0 +1,580 @@
+---
+title: "NurbsSurface"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/nurbssurface/
+---
+## NurbsSurface class
+
+NurbsSurface es una superficie representada por NURBS (Non-uniform rational basis spline). Una NurbsSurface se define por dos NurbsDirectionU y V. El componente w en el punto de control se usa como peso del punto de control, sea que el tipo de dirección sea CurveDimension.TWO_DIMENSIONAL o CurveDimension.THREE_DIMENSIONAL.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Inicializa una nueva instancia de la clase NurbsSurface. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload(name) | Inicializa una nueva instancia de la clase NurbsSurface. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| name | Cadena | Nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getU{#getU}
+
+| Nombre | Descripción |
+| --- | --- |
+| getU() | Obtiene la dirección U de la superficie NURBS |
+
+ **Result:**
+
+
+
+---
+
+
+### getV{#getV}
+
+| Nombre | Descripción |
+| --- | --- |
+| getV() | Obtiene la dirección V de la superficie NURBS |
+
+ **Result:**
+
+
+
+---
+
+
+### getVisible{#getVisible}
+
+| Nombre | Descripción |
+| --- | --- |
+| getVisible() | Obtiene o establece si la geometría es visible |
+
+ **Result:**
+
+
+
+---
+
+
+### setVisible{#setVisible}
+
+| Nombre | Descripción |
+| --- | --- |
+| setVisible(value) | Obtiene o establece si la geometría es visible |
+
+ **Result:**
+
+
+
+---
+
+
+### getDeformers{#getDeformers}
+
+| Nombre | Descripción |
+| --- | --- |
+| getDeformers() | Obtiene todos los deformadores asociados con esta geometría. Los deformadores. |
+
+ **Result:**
+
+
+
+---
+
+
+### getControlPoints{#getControlPoints}
+
+| Nombre | Descripción |
+| --- | --- |
+| getControlPoints() | Obtiene todos los puntos de control |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastShadows{#getCastShadows}
+
+| Nombre | Descripción |
+| --- | --- |
+| getCastShadows() | Obtiene o establece si esta geometría puede proyectar sombra |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastShadows{#setCastShadows}
+
+| Nombre | Descripción |
+| --- | --- |
+| setCastShadows(value) | Obtiene o establece si esta geometría puede proyectar sombra |
+
+ **Result:**
+
+
+
+---
+
+
+### getReceiveShadows{#getReceiveShadows}
+
+| Nombre | Descripción |
+| --- | --- |
+| getReceiveShadows() | Obtiene o establece si esta geometría puede recibir sombra. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReceiveShadows{#setReceiveShadows}
+
+| Nombre | Descripción |
+| --- | --- |
+| setReceiveShadows(value) | Obtiene o establece si esta geometría puede recibir sombra. |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElements{#getVertexElements}
+
+| Nombre | Descripción |
+| --- | --- |
+| getVertexElements() | Obtiene todos los elementos de vértice |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNodes() | Obtiene todos los nodos padre; una entidad puede estar adjunta a varios nodos padre para la instanciación de geometría. Los nodos. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExcluded() | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExcluded(value) | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNode() | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setParentNode(value) | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Nombre | Descripción |
+| --- | --- |
+| getScene() | Obtiene la escena a la que pertenece este objeto |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### toMesh{#toMesh}
+
+| Nombre | Descripción |
+| --- | --- |
+| toMesh() | Convierte la superficie NURBS a la malla |
+
+ **Result:**
+Malla
+
+
+---
+
+
+### getElement{#getElement}
+
+| Nombre | Descripción |
+| --- | --- |
+| getElement(type) | Obtiene un elemento de vértice con el tipo especificado |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| type | VertexElementType | VertexElementType |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### getVertexElementOfUV{#getVertexElementOfUV}
+
+| Nombre | Descripción |
+| --- | --- |
+| getVertexElementOfUV(textureMapping) | Obtiene una instancia de VertexElementUV con el tipo de TextureMapping dado |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| textureMapping | TextureMapping | TextureMapping |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### createElement{#createElement}
+
+| Nombre | Descripción |
+| --- | --- |
+| createElement(type) | Crea un elemento de vértice con el tipo especificado y lo agrega a la geometría. Si el tipo es VertexElementType.UV, se creará un VertexElementUV con el tipo de mapeo de textura a TextureMapping.DIFFUSE. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| type | VertexElementType | VertexElementType |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### addElement{#addElement}
+
+| Nombre | Descripción |
+| --- | --- |
+| addElement(element) | Agrega un elemento de vértice existente a la geometría actual |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| element | VertexElement | El elemento de vértice a agregar |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### createElement{#createElement}
+
+| Nombre | Descripción |
+| --- | --- |
+| createElement(type, mappingMode, referenceMode) | Crea un elemento de vértice con el tipo especificado y lo agrega a la geometría. Si el tipo es VertexElementType.UV, se creará un VertexElementUV con el tipo de mapeo de textura a TextureMapping.DIFFUSE. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| type | VertexElementType | VertexElementType |
+| mappingMode | MappingMode | MappingMode |
+| referenceMode | ReferenceMode | ReferenceMode |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### createElementUV{#createElementUV}
+
+| Nombre | Descripción |
+| --- | --- |
+| createElementUV(uvMapping) | Crea un VertexElementUV con el tipo de mapeo de textura dado. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| uvMapping | TextureMapping | TextureMapping |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### createElementUV{#createElementUV}
+
+| Nombre | Descripción |
+| --- | --- |
+| createElementUV(uvMapping, mappingMode, referenceMode) | Crea un VertexElementUV con el tipo de mapeo de textura dado. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| uvMapping | TextureMapping | TextureMapping |
+| mappingMode | MappingMode | MappingMode |
+| referenceMode | ReferenceMode | ReferenceMode |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBoundingBox() | Obtiene el cuadro delimitador de la entidad actual en su sistema de coordenadas de espacio de objeto. |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEntityRendererKey() | Obtiene la clave del renderizador de entidad registrado en el renderizador |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/objloadoptions/_index.md
+++ b/spanish/nodejs-java/aspose.threed/objloadoptions/_index.md
@@ -1,0 +1,224 @@
+---
+title: "ObjLoadOptions"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/objloadoptions/
+---
+## ObjLoadOptions class
+
+Opciones de carga para wavefront obj
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Constructor de ObjLoadOptions |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlipCoordinateSystem{#getFlipCoordinateSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFlipCoordinateSystem() | Obtiene o establece si se invierte el sistema de coordenadas de los puntos de control/normal durante la importación |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlipCoordinateSystem{#setFlipCoordinateSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFlipCoordinateSystem(value) | Obtiene o establece si se invierte el sistema de coordenadas de los puntos de control/normal durante la importación |
+
+ **Result:**
+
+
+
+---
+
+
+### getEnableMaterials{#getEnableMaterials}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEnableMaterials() | Obtiene o establece si se importan materiales para cada objeto |
+
+ **Result:**
+
+
+
+---
+
+
+### setEnableMaterials{#setEnableMaterials}
+
+| Nombre | Descripción |
+| --- | --- |
+| setEnableMaterials(value) | Obtiene o establece si se importan materiales para cada objeto |
+
+ **Result:**
+
+
+
+---
+
+
+### getScale{#getScale}
+
+| Nombre | Descripción |
+| --- | --- |
+| getScale() | Escalas en los ejes x/y/z, el valor predeterminado es 1.0 |
+
+ **Result:**
+
+
+
+---
+
+
+### setScale{#setScale}
+
+| Nombre | Descripción |
+| --- | --- |
+| setScale(value) | Escalas en los ejes x/y/z, el valor predeterminado es 1.0 |
+
+ **Result:**
+
+
+
+---
+
+
+### getNormalizeNormal{#getNormalizeNormal}
+
+| Nombre | Descripción |
+| --- | --- |
+| getNormalizeNormal() | Obtiene o establece si se normaliza el vector normal durante la carga. El valor predeterminado es verdadero. |
+
+ **Result:**
+
+
+
+---
+
+
+### setNormalizeNormal{#setNormalizeNormal}
+
+| Nombre | Descripción |
+| --- | --- |
+| setNormalizeNormal(value) | Obtiene o establece si se normaliza el vector normal durante la carga. El valor predeterminado es verdadero. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileFormat() | Obtiene el formato de archivo especificado en la opción actual de Guardar/Cargar. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEncoding() | Obtiene o establece la codificación predeterminada para archivos basados en texto. El valor predeterminado es null, lo que significa que el importador/exportador decidirá qué codificación usar. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileSystem() | Permite al usuario manejar cómo gestionar las dependencias externas durante la carga/guardado. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFileSystem(value) | Permite al usuario manejar cómo gestionar las dependencias externas durante la carga/guardado. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| Nombre | Descripción |
+| --- | --- |
+| getLookupPaths() | Algunos archivos como OBJ dependen de archivos externos; las rutas de búsqueda permiten que Aspose.3D busque el archivo externo para cargarlo. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileName() | El nombre de archivo de la escena de exportación/importación. Es opcional, pero útil al serializar recursos externos como el material de OBJ. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFileName(value) | El nombre de archivo de la escena de exportación/importación. Es opcional, pero útil al serializar recursos externos como el material de OBJ. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/objsaveoptions/_index.md
+++ b/spanish/nodejs-java/aspose.threed/objsaveoptions/_index.md
@@ -1,0 +1,302 @@
+---
+title: "ObjSaveOptions"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/objsaveoptions/
+---
+## ObjSaveOptions class
+
+Opciones de guardado para archivo wavefront obj
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Constructor de ObjSaveOptions |
+
+ **Result:**
+
+
+
+---
+
+
+### getApplyUnitScale{#getApplyUnitScale}
+
+| Nombre | Descripción |
+| --- | --- |
+| getApplyUnitScale() | Aplicar AssetInfo.UnitScaleFactor a la malla. El valor predeterminado es false. |
+
+ **Result:**
+
+
+
+---
+
+
+### setApplyUnitScale{#setApplyUnitScale}
+
+| Nombre | Descripción |
+| --- | --- |
+| setApplyUnitScale(value) | Aplicar AssetInfo.UnitScaleFactor a la malla. El valor predeterminado es false. |
+
+ **Result:**
+
+
+
+---
+
+
+### getPointCloud{#getPointCloud}
+
+| Nombre | Descripción |
+| --- | --- |
+| getPointCloud() | Obtiene o establece la bandera que indica si el exportador debe exportar la escena como nube de puntos (sin estructura topológica), el valor predeterminado es false |
+
+ **Result:**
+
+
+
+---
+
+
+### setPointCloud{#setPointCloud}
+
+| Nombre | Descripción |
+| --- | --- |
+| setPointCloud(value) | Obtiene o establece la bandera que indica si el exportador debe exportar la escena como nube de puntos (sin estructura topológica), el valor predeterminado es false |
+
+ **Result:**
+
+
+
+---
+
+
+### getVerbose{#getVerbose}
+
+| Nombre | Descripción |
+| --- | --- |
+| getVerbose() | Obtiene o establece si se generan comentarios para cada sección |
+
+ **Result:**
+
+
+
+---
+
+
+### setVerbose{#setVerbose}
+
+| Nombre | Descripción |
+| --- | --- |
+| setVerbose(value) | Obtiene o establece si se generan comentarios para cada sección |
+
+ **Result:**
+
+
+
+---
+
+
+### getSerializeW{#getSerializeW}
+
+| Nombre | Descripción |
+| --- | --- |
+| getSerializeW() | Obtiene o establece si se serializa el componente W en la posición de vértice del modelo. |
+
+ **Result:**
+
+
+
+---
+
+
+### setSerializeW{#setSerializeW}
+
+| Nombre | Descripción |
+| --- | --- |
+| setSerializeW(value) | Obtiene o establece si se serializa el componente W en la posición de vértice del modelo. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEnableMaterials{#getEnableMaterials}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEnableMaterials() | Obtiene o establece si se importan/exportan materiales para cada objeto |
+
+ **Result:**
+
+
+
+---
+
+
+### setEnableMaterials{#setEnableMaterials}
+
+| Nombre | Descripción |
+| --- | --- |
+| setEnableMaterials(value) | Obtiene o establece si se importan/exportan materiales para cada objeto |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlipCoordinateSystem{#getFlipCoordinateSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFlipCoordinateSystem() | Obtiene o establece si se invierte el sistema de coordenadas de los puntos de control/normal durante la importación/exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlipCoordinateSystem{#setFlipCoordinateSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFlipCoordinateSystem(value) | Obtiene o establece si se invierte el sistema de coordenadas de los puntos de control/normal durante la importación/exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportTextures{#getExportTextures}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExportTextures() | Intenta copiar las texturas usadas en la escena al directorio de salida. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextures{#setExportTextures}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExportTextures(value) | Intenta copiar las texturas usadas en la escena al directorio de salida. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileFormat() | Obtiene el formato de archivo especificado en la opción actual de Guardar/Cargar. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEncoding() | Obtiene o establece la codificación predeterminada para archivos basados en texto. El valor predeterminado es null, lo que significa que el importador/exportador decidirá qué codificación usar. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileSystem() | Permite al usuario manejar cómo gestionar las dependencias externas durante la carga/guardado. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFileSystem(value) | Permite al usuario manejar cómo gestionar las dependencias externas durante la carga/guardado. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| Nombre | Descripción |
+| --- | --- |
+| getLookupPaths() | Algunos archivos como OBJ dependen de archivos externos; las rutas de búsqueda permiten que Aspose.3D busque el archivo externo para cargarlo. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileName() | El nombre de archivo de la escena de exportación/importación. Es opcional, pero útil al serializar recursos externos como el material de OBJ. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFileName(value) | El nombre de archivo de la escena de exportación/importación. Es opcional, pero útil al serializar recursos externos como el material de OBJ. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/parameterizedprofile/_index.md
+++ b/spanish/nodejs-java/aspose.threed/parameterizedprofile/_index.md
@@ -1,0 +1,268 @@
+---
+title: "ParameterizedProfile"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/parameterizedprofile/
+---
+## ParameterizedProfile class
+
+La clase base de todos los perfiles parametrizados.  @hideconstructor
+
+
+## Métodos
+
+### getParentNodes{#getParentNodes}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNodes() | Obtiene todos los nodos padre; una entidad puede estar adjunta a varios nodos padre para la instanciación de geometría. Los nodos. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExcluded() | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExcluded(value) | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNode() | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setParentNode(value) | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Nombre | Descripción |
+| --- | --- |
+| getScene() | Obtiene la escena a la que pertenece este objeto |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtent{#getExtent}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExtent() | Obtiene la extensión en las dimensiones x e y. |
+
+ **Result:**
+Vector2
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEntityRendererKey() | Obtiene la clave del renderizador de entidad registrado en el renderizador |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBoundingBox() | Obtiene el cuadro delimitador de la entidad actual en su sistema de coordenadas de espacio de objeto. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/parseexception/_index.md
+++ b/spanish/nodejs-java/aspose.threed/parseexception/_index.md
@@ -1,0 +1,35 @@
+---
+title: "ParseException"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/parseexception/
+---
+## ParseException class
+
+Excepción cuando Aspose.3D no pudo analizar la entrada.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor(msg) | Constructor de ParseException |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| ms | Cadena | null |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/patch/_index.md
+++ b/spanish/nodejs-java/aspose.threed/patch/_index.md
@@ -1,0 +1,567 @@
+---
+title: "Patch"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/patch/
+---
+## Patch class
+
+Un Patch es una superficie de modelado paramétrico, similar a NurbsSurface, también está definida por dos PatchDirection, la U y la V. Pero la diferencia entre Patch y NurbsSurface es que la curva PatchDirection puede ser una de PatchDirectionType.BEZIER, PatchDirectionType.QUADRATIC_BEZIER, PatchDirectionType.BASIS_SPLINE, PatchDirectionType.CARDINAL_SPLINE y PatchDirectionType.LINEAR
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Inicializa una nueva instancia de la clase Patch. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload(name) | Inicializa una nueva instancia de la clase Patch. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| name | Cadena | Nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getU{#getU}
+
+| Nombre | Descripción |
+| --- | --- |
+| getU() | Obtiene la dirección u. |
+
+ **Result:**
+
+
+
+---
+
+
+### getV{#getV}
+
+| Nombre | Descripción |
+| --- | --- |
+| getV() | Obtiene la dirección v. El v. |
+
+ **Result:**
+
+
+
+---
+
+
+### getVisible{#getVisible}
+
+| Nombre | Descripción |
+| --- | --- |
+| getVisible() | Obtiene o establece si la geometría es visible |
+
+ **Result:**
+
+
+
+---
+
+
+### setVisible{#setVisible}
+
+| Nombre | Descripción |
+| --- | --- |
+| setVisible(value) | Obtiene o establece si la geometría es visible |
+
+ **Result:**
+
+
+
+---
+
+
+### getDeformers{#getDeformers}
+
+| Nombre | Descripción |
+| --- | --- |
+| getDeformers() | Obtiene todos los deformadores asociados con esta geometría. Los deformadores. |
+
+ **Result:**
+
+
+
+---
+
+
+### getControlPoints{#getControlPoints}
+
+| Nombre | Descripción |
+| --- | --- |
+| getControlPoints() | Obtiene todos los puntos de control |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastShadows{#getCastShadows}
+
+| Nombre | Descripción |
+| --- | --- |
+| getCastShadows() | Obtiene o establece si esta geometría puede proyectar sombra |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastShadows{#setCastShadows}
+
+| Nombre | Descripción |
+| --- | --- |
+| setCastShadows(value) | Obtiene o establece si esta geometría puede proyectar sombra |
+
+ **Result:**
+
+
+
+---
+
+
+### getReceiveShadows{#getReceiveShadows}
+
+| Nombre | Descripción |
+| --- | --- |
+| getReceiveShadows() | Obtiene o establece si esta geometría puede recibir sombra. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReceiveShadows{#setReceiveShadows}
+
+| Nombre | Descripción |
+| --- | --- |
+| setReceiveShadows(value) | Obtiene o establece si esta geometría puede recibir sombra. |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElements{#getVertexElements}
+
+| Nombre | Descripción |
+| --- | --- |
+| getVertexElements() | Obtiene todos los elementos de vértice |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNodes() | Obtiene todos los nodos padre; una entidad puede estar adjunta a varios nodos padre para la instanciación de geometría. Los nodos. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExcluded() | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExcluded(value) | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNode() | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setParentNode(value) | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Nombre | Descripción |
+| --- | --- |
+| getScene() | Obtiene la escena a la que pertenece este objeto |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### getElement{#getElement}
+
+| Nombre | Descripción |
+| --- | --- |
+| getElement(type) | Obtiene un elemento de vértice con el tipo especificado |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| type | VertexElementType | VertexElementType |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### getVertexElementOfUV{#getVertexElementOfUV}
+
+| Nombre | Descripción |
+| --- | --- |
+| getVertexElementOfUV(textureMapping) | Obtiene una instancia de VertexElementUV con el tipo de TextureMapping dado |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| textureMapping | TextureMapping | TextureMapping |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### createElement{#createElement}
+
+| Nombre | Descripción |
+| --- | --- |
+| createElement(type) | Crea un elemento de vértice con el tipo especificado y lo agrega a la geometría. Si el tipo es VertexElementType.UV, se creará un VertexElementUV con el tipo de mapeo de textura a TextureMapping.DIFFUSE. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| type | VertexElementType | VertexElementType |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### addElement{#addElement}
+
+| Nombre | Descripción |
+| --- | --- |
+| addElement(element) | Agrega un elemento de vértice existente a la geometría actual |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| element | VertexElement | El elemento de vértice a agregar |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### createElement{#createElement}
+
+| Nombre | Descripción |
+| --- | --- |
+| createElement(type, mappingMode, referenceMode) | Crea un elemento de vértice con el tipo especificado y lo agrega a la geometría. Si el tipo es VertexElementType.UV, se creará un VertexElementUV con el tipo de mapeo de textura a TextureMapping.DIFFUSE. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| type | VertexElementType | VertexElementType |
+| mappingMode | MappingMode | MappingMode |
+| referenceMode | ReferenceMode | ReferenceMode |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### createElementUV{#createElementUV}
+
+| Nombre | Descripción |
+| --- | --- |
+| createElementUV(uvMapping) | Crea un VertexElementUV con el tipo de mapeo de textura dado. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| uvMapping | TextureMapping | TextureMapping |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### createElementUV{#createElementUV}
+
+| Nombre | Descripción |
+| --- | --- |
+| createElementUV(uvMapping, mappingMode, referenceMode) | Crea un VertexElementUV con el tipo de mapeo de textura dado. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| uvMapping | TextureMapping | TextureMapping |
+| mappingMode | MappingMode | MappingMode |
+| referenceMode | ReferenceMode | ReferenceMode |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBoundingBox() | Obtiene el cuadro delimitador de la entidad actual en su sistema de coordenadas de espacio de objeto. |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEntityRendererKey() | Obtiene la clave del renderizador de entidad registrado en el renderizador |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/patchdirection/_index.md
+++ b/spanish/nodejs-java/aspose.threed/patchdirection/_index.md
@@ -1,0 +1,133 @@
+---
+title: "PatchDirection"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/patchdirection/
+---
+## PatchDirection class
+
+Dirección U y V del Patch.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getType{#getType}
+
+| Nombre | Descripción |
+| --- | --- |
+| getType() | Obtiene o establece el tipo del parche. El valor de la propiedad es la constante entera PatchDirectionType. El tipo. |
+
+ **Result:**
+
+
+
+---
+
+
+### setType{#setType}
+
+| Nombre | Descripción |
+| --- | --- |
+| setType(value) | Obtiene o establece el tipo del parche. El valor de la propiedad es la constante entera PatchDirectionType. El tipo. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDivisions{#getDivisions}
+
+| Nombre | Descripción |
+| --- | --- |
+| getDivisions() | Obtiene o establece el número de divisiones entre puntos de control adyacentes. El paso. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDivisions{#setDivisions}
+
+| Nombre | Descripción |
+| --- | --- |
+| setDivisions(value) | Obtiene o establece el número de divisiones entre puntos de control adyacentes. El paso. |
+
+ **Result:**
+
+
+
+---
+
+
+### getControlPoints{#getControlPoints}
+
+| Nombre | Descripción |
+| --- | --- |
+| getControlPoints() | Obtiene o establece el recuento de puntos de control en la dirección actual. El recuento. |
+
+ **Result:**
+
+
+
+---
+
+
+### setControlPoints{#setControlPoints}
+
+| Nombre | Descripción |
+| --- | --- |
+| setControlPoints(value) | Obtiene o establece el recuento de puntos de control en la dirección actual. El recuento. |
+
+ **Result:**
+
+
+
+---
+
+
+### getClosed{#getClosed}
+
+| Nombre | Descripción |
+| --- | --- |
+| getClosed() | Obtiene o establece un valor que indica si este PatchDirection es una curva cerrada. |
+
+ **Result:**
+
+
+
+---
+
+
+### setClosed{#setClosed}
+
+| Nombre | Descripción |
+| --- | --- |
+| setClosed(value) | Obtiene o establece un valor que indica si este PatchDirection es una curva cerrada. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/pbrmaterial/_index.md
+++ b/spanish/nodejs-java/aspose.threed/pbrmaterial/_index.md
@@ -1,0 +1,579 @@
+---
+title: "PbrMaterial"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/pbrmaterial/
+---
+## PbrMaterial class
+
+Material para renderizado físicamente basado en color albedo/metallic/roughness
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Construye una instancia de material PBR predeterminada |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload(albedo) | Construye un material PBR predeterminado con el valor de color albedo especificado. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| albedo | Vector3 | El valor de color albedo predeterminado |
+
+ **Result:**
+
+
+
+---
+
+
+### getTransparency{#getTransparency}
+
+| Nombre | Descripción |
+| --- | --- |
+| getTransparency() | Obtiene o establece el factor de transparencia. El factor debe estar en el rango entre 0 (0%, totalmente opaco) y 1 (100%, totalmente transparente). Cualquier valor de factor no válido será limitado. El factor de transparencia. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTransparency{#setTransparency}
+
+| Nombre | Descripción |
+| --- | --- |
+| setTransparency(value) | Obtiene o establece el factor de transparencia. El factor debe estar en el rango entre 0 (0%, totalmente opaco) y 1 (100%, totalmente transparente). Cualquier valor de factor no válido será limitado. El factor de transparencia. |
+
+ **Result:**
+
+
+
+---
+
+
+### getNormalTexture{#getNormalTexture}
+
+| Nombre | Descripción |
+| --- | --- |
+| getNormalTexture() | Obtiene o establece la textura del mapeo normal |
+
+ **Result:**
+
+
+
+---
+
+
+### setNormalTexture{#setNormalTexture}
+
+| Nombre | Descripción |
+| --- | --- |
+| setNormalTexture(value) | Obtiene o establece la textura del mapeo normal |
+
+ **Result:**
+
+
+
+---
+
+
+### getSpecularTexture{#getSpecularTexture}
+
+| Nombre | Descripción |
+| --- | --- |
+| getSpecularTexture() | Obtiene o establece la textura para el color especular |
+
+ **Result:**
+
+
+
+---
+
+
+### setSpecularTexture{#setSpecularTexture}
+
+| Nombre | Descripción |
+| --- | --- |
+| setSpecularTexture(value) | Obtiene o establece la textura para el color especular |
+
+ **Result:**
+
+
+
+---
+
+
+### getAlbedoTexture{#getAlbedoTexture}
+
+| Nombre | Descripción |
+| --- | --- |
+| getAlbedoTexture() | Obtiene o establece la textura para albedo |
+
+ **Result:**
+
+
+
+---
+
+
+### setAlbedoTexture{#setAlbedoTexture}
+
+| Nombre | Descripción |
+| --- | --- |
+| setAlbedoTexture(value) | Obtiene o establece la textura para albedo |
+
+ **Result:**
+
+
+
+---
+
+
+### getAlbedo{#getAlbedo}
+
+| Nombre | Descripción |
+| --- | --- |
+| getAlbedo() | Obtiene o establece el color base del material |
+
+ **Result:**
+
+
+
+---
+
+
+### setAlbedo{#setAlbedo}
+
+| Nombre | Descripción |
+| --- | --- |
+| setAlbedo(value) | Obtiene o establece el color base del material |
+
+ **Result:**
+
+
+
+---
+
+
+### getOcclusionTexture{#getOcclusionTexture}
+
+| Nombre | Descripción |
+| --- | --- |
+| getOcclusionTexture() | Obtiene o establece la textura para la oclusión ambiental |
+
+ **Result:**
+
+
+
+---
+
+
+### setOcclusionTexture{#setOcclusionTexture}
+
+| Nombre | Descripción |
+| --- | --- |
+| setOcclusionTexture(value) | Obtiene o establece la textura para la oclusión ambiental |
+
+ **Result:**
+
+
+
+---
+
+
+### getOcclusionFactor{#getOcclusionFactor}
+
+| Nombre | Descripción |
+| --- | --- |
+| getOcclusionFactor() | Obtiene o establece el factor de oclusión ambiental |
+
+ **Result:**
+
+
+
+---
+
+
+### setOcclusionFactor{#setOcclusionFactor}
+
+| Nombre | Descripción |
+| --- | --- |
+| setOcclusionFactor(value) | Obtiene o establece el factor de oclusión ambiental |
+
+ **Result:**
+
+
+
+---
+
+
+### getMetallicFactor{#getMetallicFactor}
+
+| Nombre | Descripción |
+| --- | --- |
+| getMetallicFactor() | Obtiene o establece la metalicidad del material, un valor de 1 indica que el material es un metal y un valor de 0 indica que el material es un dieléctrico. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMetallicFactor{#setMetallicFactor}
+
+| Nombre | Descripción |
+| --- | --- |
+| setMetallicFactor(value) | Obtiene o establece la metalicidad del material, un valor de 1 indica que el material es un metal y un valor de 0 indica que el material es un dieléctrico. |
+
+ **Result:**
+
+
+
+---
+
+
+### getRoughnessFactor{#getRoughnessFactor}
+
+| Nombre | Descripción |
+| --- | --- |
+| getRoughnessFactor() | Obtiene o establece la rugosidad del material, un valor de 1 indica que el material es completamente rugoso y un valor de 0 indica que el material es completamente liso. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRoughnessFactor{#setRoughnessFactor}
+
+| Nombre | Descripción |
+| --- | --- |
+| setRoughnessFactor(value) | Obtiene o establece la rugosidad del material, un valor de 1 indica que el material es completamente rugoso y un valor de 0 indica que el material es completamente liso. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMetallicRoughness{#getMetallicRoughness}
+
+| Nombre | Descripción |
+| --- | --- |
+| getMetallicRoughness() | Obtiene o establece la textura para metalicidad (en el canal R) y rugosidad (en el canal G) |
+
+ **Result:**
+
+
+
+---
+
+
+### setMetallicRoughness{#setMetallicRoughness}
+
+| Nombre | Descripción |
+| --- | --- |
+| setMetallicRoughness(value) | Obtiene o establece la textura para metalicidad (en el canal R) y rugosidad (en el canal G) |
+
+ **Result:**
+
+
+
+---
+
+
+### getEmissiveTexture{#getEmissiveTexture}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEmissiveTexture() | Obtiene o establece la textura para emisivo |
+
+ **Result:**
+
+
+
+---
+
+
+### setEmissiveTexture{#setEmissiveTexture}
+
+| Nombre | Descripción |
+| --- | --- |
+| setEmissiveTexture(value) | Obtiene o establece la textura para emisivo |
+
+ **Result:**
+
+
+
+---
+
+
+### getEmissiveColor{#getEmissiveColor}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEmissiveColor() | Obtiene o establece el color emisivo |
+
+ **Result:**
+
+
+
+---
+
+
+### setEmissiveColor{#setEmissiveColor}
+
+| Nombre | Descripción |
+| --- | --- |
+| setEmissiveColor(value) | Obtiene o establece el color emisivo |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### fromMaterial{#fromMaterial}
+
+| Nombre | Descripción |
+| --- | --- |
+| fromMaterial(material) | Permite convertir otro material a PbrMaterial |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| materia | Material | null |
+
+ **Result:**
+PbrMaterial
+
+
+---
+
+
+### getTexture{#getTexture}
+
+| Nombre | Descripción |
+| --- | --- |
+| getTexture(slotName) | Obtiene la textura del slot especificado, puede ser el nombre de una propiedad del material o el nombre de un parámetro del shader |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| slotName | Cadena | Nombre del slot. |
+
+ **Result:**
+TextureBase
+
+
+---
+
+
+### setTexture{#setTexture}
+
+| Nombre | Descripción |
+| --- | --- |
+| setTexture(slotName, texture) | Establece la textura al slot especificado |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| slotName | Cadena | Nombre del slot. |
+| texture | TextureBase | Textura. |
+
+ **Result:**
+TextureBase
+
+
+---
+
+
+### toString{#toString}
+
+| Nombre | Descripción |
+| --- | --- |
+| toString() | Formatea el objeto a cadena |
+
+ **Result:**
+Cadena
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+### iterator{#iterator}
+
+| Nombre | Descripción |
+| --- | --- |
+| iterator() | Reservado para uso interno. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/pbrspecularmaterial/_index.md
+++ b/spanish/nodejs-java/aspose.threed/pbrspecularmaterial/_index.md
@@ -1,0 +1,469 @@
+---
+title: "PbrSpecularMaterial"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/pbrspecularmaterial/
+---
+## PbrSpecularMaterial class
+
+Material para renderizado físicamente basado en color difuso/specular/glossiness
+
+
+## Propiedades
+
+| Nombre | Descripción |
+| --- | --- |
+| MAP_SPECULAR_GLOSSINESS | El mapa de textura para el brillo especular |
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Constructor de PbrSpecularMaterial |
+
+ **Result:**
+
+
+
+---
+
+
+### getTransparency{#getTransparency}
+
+| Nombre | Descripción |
+| --- | --- |
+| getTransparency() | Obtiene o establece el factor de transparencia. El factor debe estar en el rango entre 0 (0%, totalmente opaco) y 1 (100%, totalmente transparente). Cualquier valor de factor no válido será limitado. El factor de transparencia. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTransparency{#setTransparency}
+
+| Nombre | Descripción |
+| --- | --- |
+| setTransparency(value) | Obtiene o establece el factor de transparencia. El factor debe estar en el rango entre 0 (0%, totalmente opaco) y 1 (100%, totalmente transparente). Cualquier valor de factor no válido será limitado. El factor de transparencia. |
+
+ **Result:**
+
+
+
+---
+
+
+### getNormalTexture{#getNormalTexture}
+
+| Nombre | Descripción |
+| --- | --- |
+| getNormalTexture() | Obtiene o establece la textura del mapeo normal |
+
+ **Result:**
+
+
+
+---
+
+
+### setNormalTexture{#setNormalTexture}
+
+| Nombre | Descripción |
+| --- | --- |
+| setNormalTexture(value) | Obtiene o establece la textura del mapeo normal |
+
+ **Result:**
+
+
+
+---
+
+
+### getSpecularGlossinessTexture{#getSpecularGlossinessTexture}
+
+| Nombre | Descripción |
+| --- | --- |
+| getSpecularGlossinessTexture() | Obtiene o establece la textura para el color especular, el canal RGB almacena el color especular y el canal A almacena el brillo. |
+
+ **Result:**
+
+
+
+---
+
+
+### setSpecularGlossinessTexture{#setSpecularGlossinessTexture}
+
+| Nombre | Descripción |
+| --- | --- |
+| setSpecularGlossinessTexture(value) | Obtiene o establece la textura para el color especular, el canal RGB almacena el color especular y el canal A almacena el brillo. |
+
+ **Result:**
+
+
+
+---
+
+
+### getGlossinessFactor{#getGlossinessFactor}
+
+| Nombre | Descripción |
+| --- | --- |
+| getGlossinessFactor() | Obtiene o establece el brillo (suavidad) del material, 1 significa perfectamente liso y 0 significa perfectamente rugoso, el valor predeterminado es 1, el rango es [0, 1] |
+
+ **Result:**
+
+
+
+---
+
+
+### setGlossinessFactor{#setGlossinessFactor}
+
+| Nombre | Descripción |
+| --- | --- |
+| setGlossinessFactor(value) | Obtiene o establece el brillo (suavidad) del material, 1 significa perfectamente liso y 0 significa perfectamente rugoso, el valor predeterminado es 1, el rango es [0, 1] |
+
+ **Result:**
+
+
+
+---
+
+
+### getSpecular{#getSpecular}
+
+| Nombre | Descripción |
+| --- | --- |
+| getSpecular() | Obtiene o establece el color especular del material, el valor predeterminado es (1, 1, 1). |
+
+ **Result:**
+
+
+
+---
+
+
+### setSpecular{#setSpecular}
+
+| Nombre | Descripción |
+| --- | --- |
+| setSpecular(value) | Obtiene o establece el color especular del material, el valor predeterminado es (1, 1, 1). |
+
+ **Result:**
+
+
+
+---
+
+
+### getDiffuseTexture{#getDiffuseTexture}
+
+| Nombre | Descripción |
+| --- | --- |
+| getDiffuseTexture() | Obtiene o establece la textura para difuso |
+
+ **Result:**
+
+
+
+---
+
+
+### setDiffuseTexture{#setDiffuseTexture}
+
+| Nombre | Descripción |
+| --- | --- |
+| setDiffuseTexture(value) | Obtiene o establece la textura para difuso |
+
+ **Result:**
+
+
+
+---
+
+
+### getDiffuse{#getDiffuse}
+
+| Nombre | Descripción |
+| --- | --- |
+| getDiffuse() | Obtiene o establece el color difuso del material, el valor predeterminado es (1, 1, 1) |
+
+ **Result:**
+
+
+
+---
+
+
+### setDiffuse{#setDiffuse}
+
+| Nombre | Descripción |
+| --- | --- |
+| setDiffuse(value) | Obtiene o establece el color difuso del material, el valor predeterminado es (1, 1, 1) |
+
+ **Result:**
+
+
+
+---
+
+
+### getEmissiveTexture{#getEmissiveTexture}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEmissiveTexture() | Obtiene o establece la textura para emisivo |
+
+ **Result:**
+
+
+
+---
+
+
+### setEmissiveTexture{#setEmissiveTexture}
+
+| Nombre | Descripción |
+| --- | --- |
+| setEmissiveTexture(value) | Obtiene o establece la textura para emisivo |
+
+ **Result:**
+
+
+
+---
+
+
+### getEmissiveColor{#getEmissiveColor}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEmissiveColor() | Obtiene o establece el color emisivo, el valor predeterminado es (0, 0, 0) |
+
+ **Result:**
+
+
+
+---
+
+
+### setEmissiveColor{#setEmissiveColor}
+
+| Nombre | Descripción |
+| --- | --- |
+| setEmissiveColor(value) | Obtiene o establece el color emisivo, el valor predeterminado es (0, 0, 0) |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTexture{#getTexture}
+
+| Nombre | Descripción |
+| --- | --- |
+| getTexture(slotName) | Obtiene la textura del slot especificado, puede ser el nombre de una propiedad del material o el nombre de un parámetro del shader |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| slotName | Cadena | Nombre del slot. |
+
+ **Result:**
+TextureBase
+
+
+---
+
+
+### setTexture{#setTexture}
+
+| Nombre | Descripción |
+| --- | --- |
+| setTexture(slotName, texture) | Establece la textura al slot especificado |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| slotName | Cadena | Nombre del slot. |
+| texture | TextureBase | Textura. |
+
+ **Result:**
+TextureBase
+
+
+---
+
+
+### toString{#toString}
+
+| Nombre | Descripción |
+| --- | --- |
+| toString() | Formatea el objeto a cadena |
+
+ **Result:**
+Cadena
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+### iterator{#iterator}
+
+| Nombre | Descripción |
+| --- | --- |
+| iterator() | Reservado para uso interno. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/pdfformat/_index.md
+++ b/spanish/nodejs-java/aspose.threed/pdfformat/_index.md
@@ -1,0 +1,179 @@
+---
+title: "PdfFormat"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/pdfformat/
+---
+## PdfFormat class
+
+Formato de Documento Portátil de Adobe  @hideconstructor
+
+
+## Métodos
+
+### getVersion{#getVersion}
+
+| Nombre | Descripción |
+| --- | --- |
+| getVersion() | Obtiene la versión del formato de archivo |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtension{#getExtension}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExtension() | Obtiene el nombre de la extensión de este tipo. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtensions{#getExtensions}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExtensions() | Obtiene los nombres de las extensiones de este tipo. |
+
+ **Result:**
+
+
+
+---
+
+
+### getContentType{#getContentType}
+
+| Nombre | Descripción |
+| --- | --- |
+| getContentType() | Obtiene el tipo de contenido del formato de archivo. El valor de la propiedad es la constante entera FileContentType. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormatType{#getFileFormatType}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileFormatType() | Obtiene el tipo de formato de archivo |
+
+ **Result:**
+
+
+
+---
+
+
+### extract{#extract}
+
+| Nombre | Descripción |
+| --- | --- |
+| extract(fileName, password) | Extrae contenido 3D sin procesar de un archivo PDF. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| fileNam | Cadena | null |
+| contraseña | byte[] | null |
+
+ **Result:**
+0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]
+
+
+---
+
+
+### extractScene{#extractScene}
+
+| Nombre | Descripción |
+| --- | --- |
+| extractScene(fileName) | Extrae escenas 3D de un archivo PDF. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| fileNam | Cadena | null |
+
+ **Result:**
+0, Culture=neutral, PublicKeyToken=f071c641d0b4582b]]
+
+
+---
+
+
+### extractScene{#extractScene}
+
+| Nombre | Descripción |
+| --- | --- |
+| extractScene(fileName, password) | Extrae escenas 3D de un archivo PDF. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| fileNam | Cadena | null |
+| contraseña | byte[] | null |
+
+ **Result:**
+0, Culture=neutral, PublicKeyToken=f071c641d0b4582b]]
+
+
+---
+
+
+### createLoadOptions{#createLoadOptions}
+
+| Nombre | Descripción |
+| --- | --- |
+| createLoadOptions() | Crea opciones de carga predeterminadas para este formato de archivo |
+
+ **Result:**
+LoadOptions
+
+
+---
+
+
+### createSaveOptions{#createSaveOptions}
+
+| Nombre | Descripción |
+| --- | --- |
+| createSaveOptions() | Crea opciones de guardado predeterminadas para este formato de archivo |
+
+ **Result:**
+SaveOptions
+
+
+---
+
+
+### toString{#toString}
+
+| Nombre | Descripción |
+| --- | --- |
+| toString() | Formatos a cadena |
+
+ **Result:**
+Cadena
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/pdfloadoptions/_index.md
+++ b/spanish/nodejs-java/aspose.threed/pdfloadoptions/_index.md
@@ -1,0 +1,146 @@
+---
+title: "PdfLoadOptions"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/pdfloadoptions/
+---
+## PdfLoadOptions class
+
+Opciones para cargar PDF
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Constructor de PdfLoadOptions |
+
+ **Result:**
+
+
+
+---
+
+
+### getPassword{#getPassword}
+
+| Nombre | Descripción |
+| --- | --- |
+| getPassword() | La contraseña para desbloquear el archivo PDF cifrado. |
+
+ **Result:**
+
+
+
+---
+
+
+### setPassword{#setPassword}
+
+| Nombre | Descripción |
+| --- | --- |
+| setPassword(value) | La contraseña para desbloquear el archivo PDF cifrado. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileFormat() | Obtiene el formato de archivo especificado en la opción actual de Guardar/Cargar. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEncoding() | Obtiene o establece la codificación predeterminada para archivos basados en texto. El valor predeterminado es null, lo que significa que el importador/exportador decidirá qué codificación usar. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileSystem() | Permite al usuario manejar cómo gestionar las dependencias externas durante la carga/guardado. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFileSystem(value) | Permite al usuario manejar cómo gestionar las dependencias externas durante la carga/guardado. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| Nombre | Descripción |
+| --- | --- |
+| getLookupPaths() | Algunos archivos como OBJ dependen de archivos externos; las rutas de búsqueda permiten que Aspose.3D busque el archivo externo para cargarlo. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileName() | El nombre de archivo de la escena de exportación/importación. Es opcional, pero útil al serializar recursos externos como el material de OBJ. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFileName(value) | El nombre de archivo de la escena de exportación/importación. Es opcional, pero útil al serializar recursos externos como el material de OBJ. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/pdfsaveoptions/_index.md
+++ b/spanish/nodejs-java/aspose.threed/pdfsaveoptions/_index.md
@@ -1,0 +1,328 @@
+---
+title: "PdfSaveOptions"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/pdfsaveoptions/
+---
+## PdfSaveOptions class
+
+Las opciones de guardado al exportar PDF.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Constructor de PdfSaveOptions |
+
+ **Result:**
+
+
+
+---
+
+
+### getRenderMode{#getRenderMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getRenderMode() | El modo de renderizado especifica el estilo en el que se representa la obra 3D. El valor de la propiedad es la constante entera PdfRenderMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRenderMode{#setRenderMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setRenderMode(value) | El modo de renderizado especifica el estilo en el que se representa la obra 3D. El valor de la propiedad es la constante entera PdfRenderMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLightingScheme{#getLightingScheme}
+
+| Nombre | Descripción |
+| --- | --- |
+| getLightingScheme() | LightingScheme especifica la iluminación a aplicar a la obra 3D. El valor de la propiedad es la constante entera PdfLightingScheme. |
+
+ **Result:**
+
+
+
+---
+
+
+### setLightingScheme{#setLightingScheme}
+
+| Nombre | Descripción |
+| --- | --- |
+| setLightingScheme(value) | LightingScheme especifica la iluminación a aplicar a la obra 3D. El valor de la propiedad es la constante entera PdfLightingScheme. |
+
+ **Result:**
+
+
+
+---
+
+
+### getBackgroundColor{#getBackgroundColor}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBackgroundColor() | Color de fondo de la vista 3D en el archivo PDF. |
+
+ **Result:**
+
+
+
+---
+
+
+### setBackgroundColor{#setBackgroundColor}
+
+| Nombre | Descripción |
+| --- | --- |
+| setBackgroundColor(value) | Color de fondo de la vista 3D en el archivo PDF. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFaceColor{#getFaceColor}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFaceColor() | Obtiene o establece el color de la cara que se usará al renderizar el contenido 3D. Esto solo es relevante cuando el RenderMode tiene un valor de Illustration. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFaceColor{#setFaceColor}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFaceColor(value) | Obtiene o establece el color de la cara que se usará al renderizar el contenido 3D. Esto solo es relevante cuando el RenderMode tiene un valor de Illustration. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAuxiliaryColor{#getAuxiliaryColor}
+
+| Nombre | Descripción |
+| --- | --- |
+| getAuxiliaryColor() | Obtiene o establece el color auxiliar que se usará al renderizar el contenido 3D. La interpretación de este color depende del RenderMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setAuxiliaryColor{#setAuxiliaryColor}
+
+| Nombre | Descripción |
+| --- | --- |
+| setAuxiliaryColor(value) | Obtiene o establece el color auxiliar que se usará al renderizar el contenido 3D. La interpretación de este color depende del RenderMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlipCoordinateSystem{#getFlipCoordinateSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFlipCoordinateSystem() | Obtiene o establece si se invierte el sistema de coordenadas de la escena durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlipCoordinateSystem{#setFlipCoordinateSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFlipCoordinateSystem(value) | Obtiene o establece si se invierte el sistema de coordenadas de la escena durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEmbedTextures{#getEmbedTextures}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEmbedTextures() | Incrusta las texturas externas en el archivo PDF, el valor predeterminado es false. |
+
+ **Result:**
+
+
+
+---
+
+
+### setEmbedTextures{#setEmbedTextures}
+
+| Nombre | Descripción |
+| --- | --- |
+| setEmbedTextures(value) | Incrusta las texturas externas en el archivo PDF, el valor predeterminado es false. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportTextures{#getExportTextures}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExportTextures() | Intenta copiar las texturas usadas en la escena al directorio de salida. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextures{#setExportTextures}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExportTextures(value) | Intenta copiar las texturas usadas en la escena al directorio de salida. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileFormat() | Obtiene el formato de archivo especificado en la opción actual de Guardar/Cargar. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEncoding() | Obtiene o establece la codificación predeterminada para archivos basados en texto. El valor predeterminado es null, lo que significa que el importador/exportador decidirá qué codificación usar. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileSystem() | Permite al usuario manejar cómo gestionar las dependencias externas durante la carga/guardado. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFileSystem(value) | Permite al usuario manejar cómo gestionar las dependencias externas durante la carga/guardado. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| Nombre | Descripción |
+| --- | --- |
+| getLookupPaths() | Algunos archivos como OBJ dependen de archivos externos; las rutas de búsqueda permiten que Aspose.3D busque el archivo externo para cargarlo. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileName() | El nombre de archivo de la escena de exportación/importación. Es opcional, pero útil al serializar recursos externos como el material de OBJ. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFileName(value) | El nombre de archivo de la escena de exportación/importación. Es opcional, pero útil al serializar recursos externos como el material de OBJ. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/phongmaterial/_index.md
+++ b/spanish/nodejs-java/aspose.threed/phongmaterial/_index.md
@@ -1,0 +1,508 @@
+---
+title: "PhongMaterial"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/phongmaterial/
+---
+## PhongMaterial class
+
+Material para el modelo de sombreado Blinn-Phong.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Inicializa una nueva instancia de la clase PhongMaterial. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload(name) | Inicializa una nueva instancia de la clase PhongMaterial. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| name | Cadena | Nombre |
+
+ **Result:**
+
+
+
+---
+
+
+### getSpecularColor{#getSpecularColor}
+
+| Nombre | Descripción |
+| --- | --- |
+| getSpecularColor() | Obtiene o establece el color especular. |
+
+ **Result:**
+
+
+
+---
+
+
+### setSpecularColor{#setSpecularColor}
+
+| Nombre | Descripción |
+| --- | --- |
+| setSpecularColor(value) | Obtiene o establece el color especular. |
+
+ **Result:**
+
+
+
+---
+
+
+### getSpecularFactor{#getSpecularFactor}
+
+| Nombre | Descripción |
+| --- | --- |
+| getSpecularFactor() | Obtiene o establece el factor especular. La fórmula del especular: SpecularColor SpecularFactor (N dot H) ^ Shininess |
+
+ **Result:**
+
+
+
+---
+
+
+### setSpecularFactor{#setSpecularFactor}
+
+| Nombre | Descripción |
+| --- | --- |
+| setSpecularFactor(value) | Obtiene o establece el factor especular. La fórmula del especular: SpecularColor SpecularFactor (N dot H) ^ Shininess |
+
+ **Result:**
+
+
+
+---
+
+
+### getShininess{#getShininess}
+
+| Nombre | Descripción |
+| --- | --- |
+| getShininess() | Obtiene o establece el brillo, esto controla el tamaño del reflejo especular. La fórmula del especular: SpecularColor SpecularFactor (N dot H) ^ Shininess El brillo. |
+
+ **Result:**
+
+
+
+---
+
+
+### setShininess{#setShininess}
+
+| Nombre | Descripción |
+| --- | --- |
+| setShininess(value) | Obtiene o establece el brillo, esto controla el tamaño del reflejo especular. La fórmula del especular: SpecularColor SpecularFactor (N dot H) ^ Shininess El brillo. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReflectionColor{#getReflectionColor}
+
+| Nombre | Descripción |
+| --- | --- |
+| getReflectionColor() | Obtiene o establece el color de reflexión. La reflexión. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReflectionColor{#setReflectionColor}
+
+| Nombre | Descripción |
+| --- | --- |
+| setReflectionColor(value) | Obtiene o establece el color de reflexión. La reflexión. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReflectionFactor{#getReflectionFactor}
+
+| Nombre | Descripción |
+| --- | --- |
+| getReflectionFactor() | Obtiene o establece la atenuación del color de reflexión. El factor de reflexión. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReflectionFactor{#setReflectionFactor}
+
+| Nombre | Descripción |
+| --- | --- |
+| setReflectionFactor(value) | Obtiene o establece la atenuación del color de reflexión. El factor de reflexión. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEmissiveColor{#getEmissiveColor}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEmissiveColor() | Obtiene o establece el color emisivo |
+
+ **Result:**
+
+
+
+---
+
+
+### setEmissiveColor{#setEmissiveColor}
+
+| Nombre | Descripción |
+| --- | --- |
+| setEmissiveColor(value) | Obtiene o establece el color emisivo |
+
+ **Result:**
+
+
+
+---
+
+
+### getAmbientColor{#getAmbientColor}
+
+| Nombre | Descripción |
+| --- | --- |
+| getAmbientColor() | Obtiene o establece el color ambiental. El ejemplo: var mat = new LambertMaterial(); mat.AmbientColor = new Vector3(1, 1, 1); ambient. |
+
+ **Result:**
+
+
+
+---
+
+
+### setAmbientColor{#setAmbientColor}
+
+| Nombre | Descripción |
+| --- | --- |
+| setAmbientColor(value) | Obtiene o establece el color ambiental. El ejemplo: var mat = new LambertMaterial(); mat.AmbientColor = new Vector3(1, 1, 1); ambient. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDiffuseColor{#getDiffuseColor}
+
+| Nombre | Descripción |
+| --- | --- |
+| getDiffuseColor() | Obtiene o establece el color difuso. El ejemplo: var mat = new LambertMaterial(); mat.DiffuseColor = new Vector3(1, 0, 0); difuso. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDiffuseColor{#setDiffuseColor}
+
+| Nombre | Descripción |
+| --- | --- |
+| setDiffuseColor(value) | Obtiene o establece el color difuso. El ejemplo: var mat = new LambertMaterial(); mat.DiffuseColor = new Vector3(1, 0, 0); difuso. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTransparentColor{#getTransparentColor}
+
+| Nombre | Descripción |
+| --- | --- |
+| getTransparentColor() | Obtiene o establece el color transparente. El ejemplo: var mat = new LambertMaterial(); mat.TransparentColor = new Vector3(0.3, 0.5, 0.2); color del transparente. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTransparentColor{#setTransparentColor}
+
+| Nombre | Descripción |
+| --- | --- |
+| setTransparentColor(value) | Obtiene o establece el color transparente. El ejemplo: var mat = new LambertMaterial(); mat.TransparentColor = new Vector3(0.3, 0.5, 0.2); color del transparente. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTransparency{#getTransparency}
+
+| Nombre | Descripción |
+| --- | --- |
+| getTransparency() | Obtiene o establece el factor de transparencia. El factor debe estar en el rango entre 0 (0 %, totalmente opaco) y 1 (100 %, totalmente transparente). Cualquier valor de factor no válido será limitado. El ejemplo: var mat = new LambertMaterial(); mat.Transparency = 0.3; factor de transparencia. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTransparency{#setTransparency}
+
+| Nombre | Descripción |
+| --- | --- |
+| setTransparency(value) | Obtiene o establece el factor de transparencia. El factor debe estar en el rango entre 0 (0 %, totalmente opaco) y 1 (100 %, totalmente transparente). Cualquier valor de factor no válido será limitado. El ejemplo: var mat = new LambertMaterial(); mat.Transparency = 0.3; factor de transparencia. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTexture{#getTexture}
+
+| Nombre | Descripción |
+| --- | --- |
+| getTexture(slotName) | Obtiene la textura del slot especificado, puede ser el nombre de una propiedad del material o el nombre de un parámetro del shader |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| slotName | Cadena | Nombre del slot. |
+
+ **Result:**
+TextureBase
+
+
+---
+
+
+### setTexture{#setTexture}
+
+| Nombre | Descripción |
+| --- | --- |
+| setTexture(slotName, texture) | Establece la textura al slot especificado |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| slotName | Cadena | Nombre del slot. |
+| texture | TextureBase | Textura. |
+
+ **Result:**
+TextureBase
+
+
+---
+
+
+### toString{#toString}
+
+| Nombre | Descripción |
+| --- | --- |
+| toString() | Formatea el objeto a cadena |
+
+ **Result:**
+Cadena
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+### iterator{#iterator}
+
+| Nombre | Descripción |
+| --- | --- |
+| iterator() | Reservado para uso interno. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/pixelmapping/_index.md
+++ b/spanish/nodejs-java/aspose.threed/pixelmapping/_index.md
@@ -1,0 +1,68 @@
+---
+title: "PixelMapping"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/pixelmapping/
+---
+## PixelMapping class
+
+@hideconstructor
+
+
+## Métodos
+
+### getStride{#getStride}
+
+| Nombre | Descripción |
+| --- | --- |
+| getStride() | Bytes de píxeles en una fila. |
+
+ **Result:**
+
+
+
+---
+
+
+### getHeight{#getHeight}
+
+| Nombre | Descripción |
+| --- | --- |
+| getHeight() | Filas de los píxeles |
+
+ **Result:**
+
+
+
+---
+
+
+### getWidth{#getWidth}
+
+| Nombre | Descripción |
+| --- | --- |
+| getWidth() | Columnas de los píxeles |
+
+ **Result:**
+
+
+
+---
+
+
+### getData{#getData}
+
+| Nombre | Descripción |
+| --- | --- |
+| getData() | Los bytes mapeados de los píxeles. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/plane/_index.md
+++ b/spanish/nodejs-java/aspose.threed/plane/_index.md
@@ -1,0 +1,506 @@
+---
+title: "Plane"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/plane/
+---
+## Plane class
+
+Plano parametrizado.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Inicializa una nueva instancia de Plane con tamaño predeterminado de 1x1. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload(length, width) | Inicializa una nueva instancia del Plano. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| length | Número | Longitud del plano. |
+| ancho | Número | Ancho del plano. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload2(name, length, width, lengthSegments, widthSegments) | Inicializa una nueva instancia del Plano. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| name | Cadena | Nombre. |
+| length | Número | Longitud del plano. |
+| ancho | Número | Ancho del plano. |
+| lengthSegments | Número | Segmentos de longitud. |
+| widthSegments | Número | Segmentos de ancho. |
+
+ **Result:**
+
+
+
+---
+
+
+### getUp{#getUp}
+
+| Nombre | Descripción |
+| --- | --- |
+| getUp() | Obtiene o establece el vector ascendente del plano, el valor predeterminado es (0, 1, 0), esto afecta la generación del plano |
+
+ **Result:**
+
+
+
+---
+
+
+### setUp{#setUp}
+
+| Nombre | Descripción |
+| --- | --- |
+| setUp(value) | Obtiene o establece el vector ascendente del plano, el valor predeterminado es (0, 1, 0), esto afecta la generación del plano |
+
+ **Result:**
+
+
+
+---
+
+
+### getLength{#getLength}
+
+| Nombre | Descripción |
+| --- | --- |
+| getLength() | Obtiene o establece la longitud del plano. La longitud. |
+
+ **Result:**
+
+
+
+---
+
+
+### setLength{#setLength}
+
+| Nombre | Descripción |
+| --- | --- |
+| setLength(value) | Obtiene o establece la longitud del plano. La longitud. |
+
+ **Result:**
+
+
+
+---
+
+
+### getWidth{#getWidth}
+
+| Nombre | Descripción |
+| --- | --- |
+| getWidth() | Obtiene o establece el ancho del plano. El ancho. |
+
+ **Result:**
+
+
+
+---
+
+
+### setWidth{#setWidth}
+
+| Nombre | Descripción |
+| --- | --- |
+| setWidth(value) | Obtiene o establece el ancho del plano. El ancho. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLengthSegments{#getLengthSegments}
+
+| Nombre | Descripción |
+| --- | --- |
+| getLengthSegments() | Obtiene o establece los segmentos de longitud. Los segmentos de longitud. |
+
+ **Result:**
+
+
+
+---
+
+
+### setLengthSegments{#setLengthSegments}
+
+| Nombre | Descripción |
+| --- | --- |
+| setLengthSegments(value) | Obtiene o establece los segmentos de longitud. Los segmentos de longitud. |
+
+ **Result:**
+
+
+
+---
+
+
+### getWidthSegments{#getWidthSegments}
+
+| Nombre | Descripción |
+| --- | --- |
+| getWidthSegments() | Obtiene o establece los segmentos de ancho. Los segmentos de ancho. |
+
+ **Result:**
+
+
+
+---
+
+
+### setWidthSegments{#setWidthSegments}
+
+| Nombre | Descripción |
+| --- | --- |
+| setWidthSegments(value) | Obtiene o establece los segmentos de ancho. Los segmentos de ancho. |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastShadows{#getCastShadows}
+
+| Nombre | Descripción |
+| --- | --- |
+| getCastShadows() | Obtiene o establece si esta geometría puede proyectar sombra |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastShadows{#setCastShadows}
+
+| Nombre | Descripción |
+| --- | --- |
+| setCastShadows(value) | Obtiene o establece si esta geometría puede proyectar sombra |
+
+ **Result:**
+
+
+
+---
+
+
+### getReceiveShadows{#getReceiveShadows}
+
+| Nombre | Descripción |
+| --- | --- |
+| getReceiveShadows() | Obtiene o establece si esta geometría puede recibir sombra. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReceiveShadows{#setReceiveShadows}
+
+| Nombre | Descripción |
+| --- | --- |
+| setReceiveShadows(value) | Obtiene o establece si esta geometría puede recibir sombra. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNodes() | Obtiene todos los nodos padre; una entidad puede estar adjunta a varios nodos padre para la instanciación de geometría. Los nodos. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExcluded() | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExcluded(value) | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNode() | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setParentNode(value) | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Nombre | Descripción |
+| --- | --- |
+| getScene() | Obtiene la escena a la que pertenece este objeto |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### toMesh{#toMesh}
+
+| Nombre | Descripción |
+| --- | --- |
+| toMesh() | Convertir el objeto actual a malla |
+
+ **Result:**
+Malla
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBoundingBox() | Obtiene el cuadro delimitador de la entidad actual en su sistema de coordenadas de espacio de objeto. |
+
+ **Result:**
+Malla
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEntityRendererKey() | Obtiene la clave del renderizador de entidad registrado en el renderizador |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/plyformat/_index.md
+++ b/spanish/nodejs-java/aspose.threed/plyformat/_index.md
@@ -1,0 +1,200 @@
+---
+title: "PlyFormat"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/plyformat/
+---
+## PlyFormat class
+
+El formato PLY.  @hideconstructor
+
+
+## Métodos
+
+### getVersion{#getVersion}
+
+| Nombre | Descripción |
+| --- | --- |
+| getVersion() | Obtiene la versión del formato de archivo |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtension{#getExtension}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExtension() | Obtiene el nombre de la extensión de este tipo. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtensions{#getExtensions}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExtensions() | Obtiene los nombres de las extensiones de este tipo. |
+
+ **Result:**
+
+
+
+---
+
+
+### getContentType{#getContentType}
+
+| Nombre | Descripción |
+| --- | --- |
+| getContentType() | Obtiene el tipo de contenido del formato de archivo. El valor de la propiedad es la constante entera FileContentType. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormatType{#getFileFormatType}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileFormatType() | Obtiene el tipo de formato de archivo |
+
+ **Result:**
+
+
+
+---
+
+
+### encode{#encode}
+
+| Nombre | Descripción |
+| --- | --- |
+| encode(entity, fileName) | Codifique la entidad y guarde el resultado en un archivo externo. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| entidad | Entidad | La entidad a codificar |
+| fileName | Cadena | El archivo al que escribir |
+
+ **Result:**
+
+
+
+---
+
+
+### encode{#encode}
+
+| Nombre | Descripción |
+| --- | --- |
+| encode(entity, fileName, opt) | Codifique la entidad y guarde el resultado en un archivo externo. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| entidad | Entidad | La entidad a codificar |
+| fileName | Cadena | El archivo al que escribir |
+| opt | PlySaveOptions | Opciones de guardado |
+
+ **Result:**
+
+
+
+---
+
+
+### decode{#decode}
+
+| Nombre | Descripción |
+| --- | --- |
+| decode(fileName) | Decodifique una nube de puntos o malla del flujo especificado. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| fileName | Cadena | El flujo de entrada |
+
+ **Result:**
+Geometría
+
+
+---
+
+
+### decode{#decode}
+
+| Nombre | Descripción |
+| --- | --- |
+| decode(fileName, opt) | Decodifique una nube de puntos o malla del flujo especificado. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| fileName | Cadena | El flujo de entrada |
+| opt | PlyLoadOptions | La opción de carga del formato PLY |
+
+ **Result:**
+Geometría
+
+
+---
+
+
+### createLoadOptions{#createLoadOptions}
+
+| Nombre | Descripción |
+| --- | --- |
+| createLoadOptions() | Crea opciones de carga predeterminadas para este formato de archivo |
+
+ **Result:**
+LoadOptions
+
+
+---
+
+
+### createSaveOptions{#createSaveOptions}
+
+| Nombre | Descripción |
+| --- | --- |
+| createSaveOptions() | Crea opciones de guardado predeterminadas para este formato de archivo |
+
+ **Result:**
+SaveOptions
+
+
+---
+
+
+### toString{#toString}
+
+| Nombre | Descripción |
+| --- | --- |
+| toString() | Formatos a cadena |
+
+ **Result:**
+Cadena
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/plyloadoptions/_index.md
+++ b/spanish/nodejs-java/aspose.threed/plyloadoptions/_index.md
@@ -1,0 +1,146 @@
+---
+title: "PlyLoadOptions"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/plyloadoptions/
+---
+## PlyLoadOptions class
+
+Opciones de carga para archivos PLY
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Constructor de PlyLoadOptions |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlipCoordinateSystem{#getFlipCoordinateSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFlipCoordinateSystem() | Obtiene o establece el sistema de coordenadas invertido de los puntos de control/normal durante la importación/exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlipCoordinateSystem{#setFlipCoordinateSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFlipCoordinateSystem(value) | Obtiene o establece el sistema de coordenadas invertido de los puntos de control/normal durante la importación/exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileFormat() | Obtiene el formato de archivo especificado en la opción actual de Guardar/Cargar. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEncoding() | Obtiene o establece la codificación predeterminada para archivos basados en texto. El valor predeterminado es null, lo que significa que el importador/exportador decidirá qué codificación usar. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileSystem() | Permite al usuario manejar cómo gestionar las dependencias externas durante la carga/guardado. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFileSystem(value) | Permite al usuario manejar cómo gestionar las dependencias externas durante la carga/guardado. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| Nombre | Descripción |
+| --- | --- |
+| getLookupPaths() | Algunos archivos como OBJ dependen de archivos externos; las rutas de búsqueda permiten que Aspose.3D busque el archivo externo para cargarlo. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileName() | El nombre de archivo de la escena de exportación/importación. Es opcional, pero útil al serializar recursos externos como el material de OBJ. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFileName(value) | El nombre de archivo de la escena de exportación/importación. Es opcional, pero útil al serializar recursos externos como el material de OBJ. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/plysaveoptions/_index.md
+++ b/spanish/nodejs-java/aspose.threed/plysaveoptions/_index.md
@@ -1,0 +1,347 @@
+---
+title: "PlySaveOptions"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/plysaveoptions/
+---
+## PlySaveOptions class
+
+Opciones de guardado para exportar la escena como archivo PLY.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Constructor de PlySaveOptions |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload(contentType) | Constructor de PlySaveOptions |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| contentType | FileContentType | FileContentType |
+
+ **Result:**
+
+
+
+---
+
+
+### getPointCloud{#getPointCloud}
+
+| Nombre | Descripción |
+| --- | --- |
+| getPointCloud() | Exporta la escena como nube de puntos, el valor predeterminado es false. |
+
+ **Result:**
+
+
+
+---
+
+
+### setPointCloud{#setPointCloud}
+
+| Nombre | Descripción |
+| --- | --- |
+| setPointCloud(value) | Exporta la escena como nube de puntos, el valor predeterminado es false. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlipCoordinate{#getFlipCoordinate}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFlipCoordinate() | Invierte la coordenada al guardar la escena, el valor predeterminado es true. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlipCoordinate{#setFlipCoordinate}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFlipCoordinate(value) | Invierte la coordenada al guardar la escena, el valor predeterminado es true. |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElement{#getVertexElement}
+
+| Nombre | Descripción |
+| --- | --- |
+| getVertexElement() | El nombre del elemento para los datos de vértice, el valor predeterminado es "vertex" |
+
+ **Result:**
+
+
+
+---
+
+
+### setVertexElement{#setVertexElement}
+
+| Nombre | Descripción |
+| --- | --- |
+| setVertexElement(value) | El nombre del elemento para los datos de vértice, el valor predeterminado es "vertex" |
+
+ **Result:**
+
+
+
+---
+
+
+### getPositionComponents{#getPositionComponents}
+
+| Nombre | Descripción |
+| --- | --- |
+| getPositionComponents() | Los nombres de los componentes para los datos de posición, el valor predeterminado es ("x", "y", "z") |
+
+ **Result:**
+
+
+
+---
+
+
+### getNormalComponents{#getNormalComponents}
+
+| Nombre | Descripción |
+| --- | --- |
+| getNormalComponents() | Los nombres de los componentes para los datos normales, el valor predeterminado es ("nx", "ny", "nz") |
+
+ **Result:**
+
+
+
+---
+
+
+### getTextureCoordinateComponents{#getTextureCoordinateComponents}
+
+| Nombre | Descripción |
+| --- | --- |
+| getTextureCoordinateComponents() | Los nombres de los componentes para los datos de coordenadas de textura, el valor predeterminado es ("u", "v") |
+
+ **Result:**
+
+
+
+---
+
+
+### getColorComponents{#getColorComponents}
+
+| Nombre | Descripción |
+| --- | --- |
+| getColorComponents() | Los nombres de los componentes para el color del vértice, el valor predeterminado es ("red", "green", "blue") |
+
+ **Result:**
+
+
+
+---
+
+
+### getFaceElement{#getFaceElement}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFaceElement() | El nombre del elemento para los datos de la cara, el valor predeterminado es "face" |
+
+ **Result:**
+
+
+
+---
+
+
+### setFaceElement{#setFaceElement}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFaceElement(value) | El nombre del elemento para los datos de la cara, el valor predeterminado es "face" |
+
+ **Result:**
+
+
+
+---
+
+
+### getFaceProperty{#getFaceProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFaceProperty() | El nombre de la propiedad para los datos de la cara, el valor predeterminado es "vertex_index" |
+
+ **Result:**
+
+
+
+---
+
+
+### setFaceProperty{#setFaceProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFaceProperty(value) | El nombre de la propiedad para los datos de la cara, el valor predeterminado es "vertex_index" |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportTextures{#getExportTextures}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExportTextures() | Intenta copiar las texturas usadas en la escena al directorio de salida. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextures{#setExportTextures}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExportTextures(value) | Intenta copiar las texturas usadas en la escena al directorio de salida. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileFormat() | Obtiene el formato de archivo especificado en la opción actual de Guardar/Cargar. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEncoding() | Obtiene o establece la codificación predeterminada para archivos basados en texto. El valor predeterminado es null, lo que significa que el importador/exportador decidirá qué codificación usar. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileSystem() | Permite al usuario manejar cómo gestionar las dependencias externas durante la carga/guardado. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFileSystem(value) | Permite al usuario manejar cómo gestionar las dependencias externas durante la carga/guardado. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| Nombre | Descripción |
+| --- | --- |
+| getLookupPaths() | Algunos archivos como OBJ dependen de archivos externos; las rutas de búsqueda permiten que Aspose.3D busque el archivo externo para cargarlo. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileName() | El nombre de archivo de la escena de exportación/importación. Es opcional, pero útil al serializar recursos externos como el material de OBJ. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFileName(value) | El nombre de archivo de la escena de exportación/importación. Es opcional, pero útil al serializar recursos externos como el material de OBJ. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/pointcloud/_index.md
+++ b/spanish/nodejs-java/aspose.threed/pointcloud/_index.md
@@ -1,0 +1,580 @@
+---
+title: "PointCloud"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/pointcloud/
+---
+## PointCloud class
+
+La nube de puntos no contiene información de topología, solo los puntos de control y los elementos de vértice.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor(name) | Constructor de PointCloud |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| name | Cadena | El nombre de esta entidad |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload() | Constructor de PointCloud |
+
+ **Result:**
+
+
+
+---
+
+
+### getVisible{#getVisible}
+
+| Nombre | Descripción |
+| --- | --- |
+| getVisible() | Obtiene o establece si la geometría es visible |
+
+ **Result:**
+
+
+
+---
+
+
+### setVisible{#setVisible}
+
+| Nombre | Descripción |
+| --- | --- |
+| setVisible(value) | Obtiene o establece si la geometría es visible |
+
+ **Result:**
+
+
+
+---
+
+
+### getDeformers{#getDeformers}
+
+| Nombre | Descripción |
+| --- | --- |
+| getDeformers() | Obtiene todos los deformadores asociados con esta geometría. Los deformadores. |
+
+ **Result:**
+
+
+
+---
+
+
+### getControlPoints{#getControlPoints}
+
+| Nombre | Descripción |
+| --- | --- |
+| getControlPoints() | Obtiene todos los puntos de control |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastShadows{#getCastShadows}
+
+| Nombre | Descripción |
+| --- | --- |
+| getCastShadows() | Obtiene o establece si esta geometría puede proyectar sombra |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastShadows{#setCastShadows}
+
+| Nombre | Descripción |
+| --- | --- |
+| setCastShadows(value) | Obtiene o establece si esta geometría puede proyectar sombra |
+
+ **Result:**
+
+
+
+---
+
+
+### getReceiveShadows{#getReceiveShadows}
+
+| Nombre | Descripción |
+| --- | --- |
+| getReceiveShadows() | Obtiene o establece si esta geometría puede recibir sombra. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReceiveShadows{#setReceiveShadows}
+
+| Nombre | Descripción |
+| --- | --- |
+| setReceiveShadows(value) | Obtiene o establece si esta geometría puede recibir sombra. |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElements{#getVertexElements}
+
+| Nombre | Descripción |
+| --- | --- |
+| getVertexElements() | Obtiene todos los elementos de vértice |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNodes() | Obtiene todos los nodos padre; una entidad puede estar adjunta a varios nodos padre para la instanciación de geometría. Los nodos. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExcluded() | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExcluded(value) | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNode() | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setParentNode(value) | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Nombre | Descripción |
+| --- | --- |
+| getScene() | Obtiene la escena a la que pertenece este objeto |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEntityRendererKey() | Obtiene la clave del renderizador de entidad registrado en el renderizador |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### fromGeometry{#fromGeometry}
+
+| Nombre | Descripción |
+| --- | --- |
+| fromGeometry(g) | Crear una nueva instancia de PointCloud a partir de un objeto de geometría |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+|  | Geometría | null |
+
+ **Result:**
+PointCloud
+
+
+---
+
+
+### fromGeometry{#fromGeometry}
+
+| Nombre | Descripción |
+| --- | --- |
+| fromGeometry(g, density) | Crear una nueva instancia de point cloud a partir de un objeto de geometría. La densidad es el número de puntos por triángulo unitario (El triángulo unitario es el triángulo con la mayor superficie de la malla) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| g | Geometría | Malla u otra instancia de geometría |
+| densidad | Número | Número de puntos por triángulo unitario |
+
+ **Result:**
+PointCloud
+
+
+---
+
+
+### getElement{#getElement}
+
+| Nombre | Descripción |
+| --- | --- |
+| getElement(type) | Obtiene un elemento de vértice con el tipo especificado |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| type | VertexElementType | VertexElementType |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### getVertexElementOfUV{#getVertexElementOfUV}
+
+| Nombre | Descripción |
+| --- | --- |
+| getVertexElementOfUV(textureMapping) | Obtiene una instancia de VertexElementUV con el tipo de TextureMapping dado |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| textureMapping | TextureMapping | TextureMapping |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### createElement{#createElement}
+
+| Nombre | Descripción |
+| --- | --- |
+| createElement(type) | Crea un elemento de vértice con el tipo especificado y lo agrega a la geometría. Si el tipo es VertexElementType.UV, se creará un VertexElementUV con el tipo de mapeo de textura a TextureMapping.DIFFUSE. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| type | VertexElementType | VertexElementType |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### addElement{#addElement}
+
+| Nombre | Descripción |
+| --- | --- |
+| addElement(element) | Agrega un elemento de vértice existente a la geometría actual |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| element | VertexElement | El elemento de vértice a agregar |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### createElement{#createElement}
+
+| Nombre | Descripción |
+| --- | --- |
+| createElement(type, mappingMode, referenceMode) | Crea un elemento de vértice con el tipo especificado y lo agrega a la geometría. Si el tipo es VertexElementType.UV, se creará un VertexElementUV con el tipo de mapeo de textura a TextureMapping.DIFFUSE. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| type | VertexElementType | VertexElementType |
+| mappingMode | MappingMode | MappingMode |
+| referenceMode | ReferenceMode | ReferenceMode |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### createElementUV{#createElementUV}
+
+| Nombre | Descripción |
+| --- | --- |
+| createElementUV(uvMapping) | Crea un VertexElementUV con el tipo de mapeo de textura dado. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| uvMapping | TextureMapping | TextureMapping |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### createElementUV{#createElementUV}
+
+| Nombre | Descripción |
+| --- | --- |
+| createElementUV(uvMapping, mappingMode, referenceMode) | Crea un VertexElementUV con el tipo de mapeo de textura dado. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| uvMapping | TextureMapping | TextureMapping |
+| mappingMode | MappingMode | MappingMode |
+| referenceMode | ReferenceMode | ReferenceMode |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBoundingBox() | Obtiene el cuadro delimitador de la entidad actual en su sistema de coordenadas de espacio de objeto. |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/polygonbuilder/_index.md
+++ b/spanish/nodejs-java/aspose.threed/polygonbuilder/_index.md
@@ -1,0 +1,80 @@
+---
+title: "PolygonBuilder"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/polygonbuilder/
+---
+## PolygonBuilder class
+
+Una clase auxiliar para construir polígonos para Mesh
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor(mesh) | Inicializa una nueva instancia de la clase PolygonBuilder. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| mesh | Malla | En qué malla construir el polígono. |
+
+ **Result:**
+
+
+
+---
+
+
+### begin{#begin}
+
+| Nombre | Descripción |
+| --- | --- |
+| begin() | Comienza a agregar un nuevo polígono |
+
+ **Result:**
+
+
+
+---
+
+
+### addVertex{#addVertex}
+
+| Nombre | Descripción |
+| --- | --- |
+| addVertex(index) | Agrega un índice de vértice al polígono |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| inde | Número | null |
+
+ **Result:**
+
+
+
+---
+
+
+### end{#end}
+
+| Nombre | Descripción |
+| --- | --- |
+| end() | Finaliza la creación del polígono |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/polygonmodifier/_index.md
+++ b/spanish/nodejs-java/aspose.threed/polygonmodifier/_index.md
@@ -1,0 +1,266 @@
+---
+title: "PolygonModifier"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/polygonmodifier/
+---
+## PolygonModifier class
+
+Utilidades para modificar polígonos  @hideconstructor
+
+
+## Métodos
+
+### triangulate{#triangulate}
+
+| Nombre | Descripción |
+| --- | --- |
+| triangulate(scene) | Convierte todas las mallas basadas en polígonos en una malla completa de triángulos |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| escena | Scene | La escena a procesar |
+
+ **Result:**
+
+
+
+---
+
+
+### triangulate{#triangulate}
+
+| Nombre | Descripción |
+| --- | --- |
+| triangulate(mesh) | Convierte una malla basada en polígonos en una malla completa de triángulos |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| mesh | Malla | La malla original que no es de triángulos |
+
+ **Result:**
+Malla
+
+
+---
+
+
+### mergeMesh{#mergeMesh}
+
+| Nombre | Descripción |
+| --- | --- |
+| mergeMesh(scene) | Convierte una escena completa en una única malla transformada. Los elementos de vértice como normales/coordenadas de textura aún no son compatibles |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| escena | Scene | La escena a combinar |
+
+ **Result:**
+Malla
+
+
+---
+
+
+### mergeMesh{#mergeMesh}
+
+| Nombre | Descripción |
+| --- | --- |
+| mergeMesh(node) | Convierte un nodo completo en una única malla transformada. Los elementos de vértice como normales/coordenadas de textura aún no son compatibles |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| nodo | Nodo | El nodo a combinar |
+
+ **Result:**
+Malla
+
+
+---
+
+
+### scale{#scale}
+
+| Nombre | Descripción |
+| --- | --- |
+| scale(scene, scale) | Escala todas las geometrías (Escala los puntos de control, no la matriz de transformación) en esta escena |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| escena | Scene | La escena a escalar |
+| escala | Vector3 | El factor de escala |
+
+ **Result:**
+Malla
+
+
+---
+
+
+### scale{#scale}
+
+| Nombre | Descripción |
+| --- | --- |
+| scale(node, scale) | Escala todas las geometrías (Escala los puntos de control, no la matriz de transformación) en este nodo |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| nodo | Nodo | El nodo a escalar |
+| escala | Vector3 | El factor de escala |
+
+ **Result:**
+Malla
+
+
+---
+
+
+### generateNormal{#generateNormal}
+
+| Nombre | Descripción |
+| --- | --- |
+| generateNormal(mesh) | Generar datos normales a partir de la definición de Mesh |
+
+ **Result:**
+VertexElementNormal
+
+
+---
+
+
+### generateUV{#generateUV}
+
+| Nombre | Descripción |
+| --- | --- |
+| generateUV(mesh, normals) | Generar datos UV a partir de la mesh de entrada proporcionada y los datos normales especificados. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| mesh | Malla | La mesh de entrada |
+| normales | VertexElementNormal | Los datos normales |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### generateUV{#generateUV}
+
+| Nombre | Descripción |
+| --- | --- |
+| generateUV(mesh) | Generar datos UV a partir de la mesh de entrada proporcionada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| mesh | Malla | La mesh de entrada |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### splitMesh{#splitMesh}
+
+| Nombre | Descripción |
+| --- | --- |
+| splitMesh(node, policy, createChildNodes, removeOldMesh) | Dividir la mesh en sub-meshes por VertexElementMaterial. Cada sub-mesh usará solo un material. Realizar la división de la mesh en un nodo. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| asentir | Nodo | null |
+| política | SplitMeshPolicy | SplitMeshPolicy |
+| createChildNodes | boolean | Crear nodos hijos para cada sub-mesh. |
+| removeOldMesh | boolean | Eliminar la mesh antigua después de la división; si este parámetro es falso, la mesh antigua y la nueva coexistirán. |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### splitMesh{#splitMesh}
+
+| Nombre | Descripción |
+| --- | --- |
+| splitMesh(scene, policy, removeOldMesh) | Dividir la mesh en sub-meshes por VertexElementMaterial. Cada sub-mesh usará solo un material. Realizar la división de la mesh en todos los nodos de la escena. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| scen | Scene | null |
+| política | SplitMeshPolicy | SplitMeshPolicy |
+| removeOldMes | boolean | null |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### splitMesh{#splitMesh}
+
+| Nombre | Descripción |
+| --- | --- |
+| splitMesh(mesh, policy) | Dividir la mesh en sub-meshes por VertexElementMaterial. Cada sub-mesh usará solo un material. La mesh original no será modificada. |
+
+ **Result:**
+Mesh[]
+
+
+---
+
+
+### buildTangentBinormal{#buildTangentBinormal}
+
+| Nombre | Descripción |
+| --- | --- |
+| buildTangentBinormal(scene) | Esto creará tangente y binormal en todas las meshes de la escena. Se requiere normal; si la normal no existe en la mesh, también se crearán los datos de normal a partir de la posición. También se requiere UV; la mesh será ignorada si no se define UV. |
+
+ **Result:**
+Mesh[]
+
+
+---
+
+
+### buildTangentBinormal{#buildTangentBinormal}
+
+| Nombre | Descripción |
+| --- | --- |
+| buildTangentBinormal(mesh) | Esto creará tangente y binormal en la malla. Se requiere la normal; si la normal no existe en la malla, también se creará la información de la normal a partir de la posición. UV también es necesario, se lanzará una excepción si no se encuentra UV. |
+
+ **Result:**
+Mesh[]
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/pose/_index.md
+++ b/spanish/nodejs-java/aspose.threed/pose/_index.md
@@ -1,0 +1,263 @@
+---
+title: "Pose"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/pose/
+---
+## Pose class
+
+La pose se usa para almacenar la matriz de transformación cuando la geometría está con skinning. La pose es un conjunto de BonePose, cada BonePose guarda la información concreta de transformación del nodo óseo.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor(name) | Inicializa una nueva instancia de la clase Pose. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| name | Cadena | Nombre |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload() | Inicializa una nueva instancia de la clase Pose. |
+
+ **Result:**
+
+
+
+---
+
+
+### getPoseType{#getPoseType}
+
+| Nombre | Descripción |
+| --- | --- |
+| getPoseType() | Obtiene o establece el tipo de la pose. El valor de la propiedad es la constante entera PoseType. El tipo de la pose. |
+
+ **Result:**
+
+
+
+---
+
+
+### setPoseType{#setPoseType}
+
+| Nombre | Descripción |
+| --- | --- |
+| setPoseType(value) | Obtiene o establece el tipo de la pose. El valor de la propiedad es la constante entera PoseType. El tipo de la pose. |
+
+ **Result:**
+
+
+
+---
+
+
+### getBonePoses{#getBonePoses}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBonePoses() | Obtiene todos los BonePose. Los nodos. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### addBonePose{#addBonePose}
+
+| Nombre | Descripción |
+| --- | --- |
+| addBonePose(node, matrix, localMatrix) | Guarda la matriz de transformación de la pose para el nodo óseo dado. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| nodo | Nodo | Nodo óseo. |
+| matrix | Matrix4 | Matriz de transformación. |
+| localMatrix | boolean | Si se establece en |
+
+ **Result:**
+
+
+
+---
+
+
+### addBonePose{#addBonePose}
+
+| Nombre | Descripción |
+| --- | --- |
+| addBonePose(node, matrix) | Guarda la matriz de transformación de pose para el nodo óseo dado. Se implica la matriz de transformación global. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| nodo | Nodo | Nodo óseo. |
+| matrix | Matrix4 | Matriz de transformación. |
+
+ **Result:**
+
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/postprocessing/_index.md
+++ b/spanish/nodejs-java/aspose.threed/postprocessing/_index.md
@@ -1,0 +1,177 @@
+---
+title: "PostProcessing"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/postprocessing/
+---
+## PostProcessing class
+
+Los efectos de post-procesado  @hideconstructor
+
+
+## Métodos
+
+### getInput{#getInput}
+
+| Nombre | Descripción |
+| --- | --- |
+| getInput() | Entrada de este post-procesamiento |
+
+ **Result:**
+
+
+
+---
+
+
+### setInput{#setInput}
+
+| Nombre | Descripción |
+| --- | --- |
+| setInput(value) | Entrada de este post-procesamiento |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/primitive/_index.md
+++ b/spanish/nodejs-java/aspose.threed/primitive/_index.md
@@ -1,0 +1,339 @@
+---
+title: "Primitive"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/primitive/
+---
+## Primitive class
+
+Clase base para todas las primitivas
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor(name) | Inicializa una nueva instancia de la clase Primitive. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| name | Cadena | Nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastShadows{#getCastShadows}
+
+| Nombre | Descripción |
+| --- | --- |
+| getCastShadows() | Obtiene o establece si esta geometría puede proyectar sombra |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastShadows{#setCastShadows}
+
+| Nombre | Descripción |
+| --- | --- |
+| setCastShadows(value) | Obtiene o establece si esta geometría puede proyectar sombra |
+
+ **Result:**
+
+
+
+---
+
+
+### getReceiveShadows{#getReceiveShadows}
+
+| Nombre | Descripción |
+| --- | --- |
+| getReceiveShadows() | Obtiene o establece si esta geometría puede recibir sombra. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReceiveShadows{#setReceiveShadows}
+
+| Nombre | Descripción |
+| --- | --- |
+| setReceiveShadows(value) | Obtiene o establece si esta geometría puede recibir sombra. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNodes() | Obtiene todos los nodos padre; una entidad puede estar adjunta a varios nodos padre para la instanciación de geometría. Los nodos. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExcluded() | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExcluded(value) | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNode() | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setParentNode(value) | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Nombre | Descripción |
+| --- | --- |
+| getScene() | Obtiene la escena a la que pertenece este objeto |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### toMesh{#toMesh}
+
+| Nombre | Descripción |
+| --- | --- |
+| toMesh() | Convertir el objeto actual a malla |
+
+ **Result:**
+Malla
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBoundingBox() | Obtiene el cuadro delimitador de la entidad actual en su sistema de coordenadas de espacio de objeto. |
+
+ **Result:**
+Malla
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEntityRendererKey() | Obtiene la clave del renderizador de entidad registrado en el renderizador |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/profile/_index.md
+++ b/spanish/nodejs-java/aspose.threed/profile/_index.md
@@ -1,0 +1,255 @@
+---
+title: "Profile"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/profile/
+---
+## Profile class
+
+Perfil 2D en el plano xy  @hideconstructor
+
+
+## Métodos
+
+### getParentNodes{#getParentNodes}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNodes() | Obtiene todos los nodos padre; una entidad puede estar adjunta a varios nodos padre para la instanciación de geometría. Los nodos. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExcluded() | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExcluded(value) | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNode() | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setParentNode(value) | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Nombre | Descripción |
+| --- | --- |
+| getScene() | Obtiene la escena a la que pertenece este objeto |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEntityRendererKey() | Obtiene la clave del renderizador de entidad registrado en el renderizador |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBoundingBox() | Obtiene el cuadro delimitador de la entidad actual en su sistema de coordenadas de espacio de objeto. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/property/_index.md
+++ b/spanish/nodejs-java/aspose.threed/property/_index.md
@@ -1,0 +1,230 @@
+---
+title: "Property"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/property/
+---
+## Property class
+
+Clase para contener propiedades definidas por el usuario.  @hideconstructor
+
+
+## Métodos
+
+### getValue{#getValue}
+
+| Nombre | Descripción |
+| --- | --- |
+| getValue() | Obtiene o establece el valor. El valor. |
+
+ **Result:**
+
+
+
+---
+
+
+### setValue{#setValue}
+
+| Nombre | Descripción |
+| --- | --- |
+| setValue(value) | Obtiene o establece el valor. El valor. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getValueType{#getValueType}
+
+| Nombre | Descripción |
+| --- | --- |
+| getValueType() | Obtiene el tipo del valor de la propiedad. El tipo del valor. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### getBindPoint{#getBindPoint}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBindPoint(anim, create) | Obtiene el punto de enlace de la propiedad en la instancia de animación especificada. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| anim | AnimationNode | En qué animación crear el punto de enlace. |
+| crear | boolean | Crear el punto de enlace de la propiedad si no se encuentra. |
+
+ **Result:**
+BindPoint
+
+
+---
+
+
+### getKeyframeSequence{#getKeyframeSequence}
+
+| Nombre | Descripción |
+| --- | --- |
+| getKeyframeSequence(anim, create) | Obtiene la secuencia de fotogramas clave en la instancia de animación especificada. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| anim | AnimationNode | En qué animación crear la secuencia de fotogramas clave. |
+| crear | boolean | Crear la secuencia de fotogramas clave si no se encuentra. |
+
+ **Result:**
+KeyframeSequence
+
+
+---
+
+
+### toString{#toString}
+
+| Nombre | Descripción |
+| --- | --- |
+| toString() | Devuelve una cadena que representa la Propiedad actual. |
+
+ **Result:**
+Cadena
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/propertycollection/_index.md
+++ b/spanish/nodejs-java/aspose.threed/propertycollection/_index.md
@@ -1,0 +1,125 @@
+---
+title: "PropertyCollection"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/propertycollection/
+---
+## PropertyCollection class
+
+La colección de propiedades  @hideconstructor
+
+
+## Métodos
+
+### get{#get}
+
+| Nombre | Descripción |
+| --- | --- |
+| get(idx) |  |
+
+ **Result:**
+
+
+
+---
+
+
+### get{#get}
+
+| Nombre | Descripción |
+| --- | --- |
+| get(property) |  |
+
+ **Result:**
+
+
+
+---
+
+
+### set{#set}
+
+| Nombre | Descripción |
+| --- | --- |
+| set(property, value) |  |
+
+ **Result:**
+
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(property) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### iterator{#iterator}
+
+| Nombre | Descripción |
+| --- | --- |
+| iterator() | Reservado para uso interno. |
+
+ **Result:**
+boolean
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/pushconstant/_index.md
+++ b/spanish/nodejs-java/aspose.threed/pushconstant/_index.md
@@ -1,0 +1,166 @@
+---
+title: "PushConstant"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/pushconstant/
+---
+## PushConstant class
+
+Una utilidad para proporcionar datos al shader mediante push constant.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Constructor del PushConstant |
+
+ **Result:**
+
+
+
+---
+
+
+### write{#write}
+
+| Nombre | Descripción |
+| --- | --- |
+| write(mat) | Escribe la matriz en la constante |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| mat | FMatrix4 | La matriz a escribir |
+
+ **Result:**
+
+
+
+---
+
+
+### write{#write}
+
+| Nombre | Descripción |
+| --- | --- |
+| write(n) | Escribe un valor int a la constante |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+|  | Número | null |
+
+ **Result:**
+
+
+
+---
+
+
+### write{#write}
+
+| Nombre | Descripción |
+| --- | --- |
+| write(f) | Escribe un valor float a la constante |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+|  | Número | null |
+
+ **Result:**
+
+
+
+---
+
+
+### write{#write}
+
+| Nombre | Descripción |
+| --- | --- |
+| write(vec) | Escribe un vector de 4 componentes a la constante |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| ve | FVector4 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### write{#write}
+
+| Nombre | Descripción |
+| --- | --- |
+| write(vec) | Escribe un vector de 3 componentes a la constante |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| ve | FVector3 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### write{#write}
+
+| Nombre | Descripción |
+| --- | --- |
+| write(x, y, z, w) | Escribe un vector de 4 componentes a la constante |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+|  | Número | null |
+|  | Número | null |
+|  | Número | null |
+|  | Número | null |
+
+ **Result:**
+
+
+
+---
+
+
+### commit{#commit}
+
+| Nombre | Descripción |
+| --- | --- |
+| commit(stage, commandList) | Confirma los datos preparados al pipeline gráfico. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| stage | Número | ShaderStage |
+| commandLis | ICommandList | null |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/pyramid/_index.md
+++ b/spanish/nodejs-java/aspose.threed/pyramid/_index.md
@@ -1,0 +1,505 @@
+---
+title: "Pyramid"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/pyramid/
+---
+## Pyramid class
+
+Pirámide parametrizada.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Construye una nueva instancia de pyramid con el área inferior predeterminada (10, 10) y la altura predeterminada (5). |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload(xbottom, ybottom, height) | Construye una nueva instancia de pyramid con el área inferior especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| xbottom | Número | La longitud en la dirección x de la parte inferior |
+| ybottom | Número | La longitud en la dirección y de la parte inferior |
+| height | Número | La altura de la pyramid |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload2(xbottom, ybottom, xtop, ytop, height) | Construye una nueva instancia de pyramid con el área inferior y el área superior especificadas y la altura. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| xbottom | Número | La longitud en la dirección x del área inferior |
+| ybottom | Número | La longitud en la dirección y del área inferior |
+| xtop | Número | La longitud en la dirección x del área superior |
+| ytop | Número | La longitud en la dirección y del área superior |
+| height | Número | La altura de la pyramid |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload3{#constructor_overload3}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload3(name, xbottom, ybottom, xtop, ytop, height) | Construye una nueva instancia de pyramid con el área inferior y el área superior especificadas y la altura. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| name | Cadena | El nombre de la pirámide |
+| xbottom | Número | La longitud en la dirección x del área inferior |
+| ybottom | Número | La longitud en la dirección y del área inferior |
+| xtop | Número | La longitud en la dirección x del área superior |
+| ytop | Número | La longitud en la dirección y del área superior |
+| height | Número | La altura de la pyramid |
+
+ **Result:**
+
+
+
+---
+
+
+### getBottomArea{#getBottomArea}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBottomArea() | Área de la tapa inferior |
+
+ **Result:**
+
+
+
+---
+
+
+### setBottomArea{#setBottomArea}
+
+| Nombre | Descripción |
+| --- | --- |
+| setBottomArea(value) | Área de la tapa inferior |
+
+ **Result:**
+
+
+
+---
+
+
+### getTopArea{#getTopArea}
+
+| Nombre | Descripción |
+| --- | --- |
+| getTopArea() | Área de la tapa superior |
+
+ **Result:**
+
+
+
+---
+
+
+### setTopArea{#setTopArea}
+
+| Nombre | Descripción |
+| --- | --- |
+| setTopArea(value) | Área de la tapa superior |
+
+ **Result:**
+
+
+
+---
+
+
+### getBottomOffset{#getBottomOffset}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBottomOffset() | Desplazamiento para los vértices inferiores |
+
+ **Result:**
+
+
+
+---
+
+
+### setBottomOffset{#setBottomOffset}
+
+| Nombre | Descripción |
+| --- | --- |
+| setBottomOffset(value) | Desplazamiento para los vértices inferiores |
+
+ **Result:**
+
+
+
+---
+
+
+### getHeight{#getHeight}
+
+| Nombre | Descripción |
+| --- | --- |
+| getHeight() | Altura de la pirámide |
+
+ **Result:**
+
+
+
+---
+
+
+### setHeight{#setHeight}
+
+| Nombre | Descripción |
+| --- | --- |
+| setHeight(value) | Altura de la pirámide |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastShadows{#getCastShadows}
+
+| Nombre | Descripción |
+| --- | --- |
+| getCastShadows() | Obtiene o establece si esta geometría puede proyectar sombra |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastShadows{#setCastShadows}
+
+| Nombre | Descripción |
+| --- | --- |
+| setCastShadows(value) | Obtiene o establece si esta geometría puede proyectar sombra |
+
+ **Result:**
+
+
+
+---
+
+
+### getReceiveShadows{#getReceiveShadows}
+
+| Nombre | Descripción |
+| --- | --- |
+| getReceiveShadows() | Obtiene o establece si esta geometría puede recibir sombra. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReceiveShadows{#setReceiveShadows}
+
+| Nombre | Descripción |
+| --- | --- |
+| setReceiveShadows(value) | Obtiene o establece si esta geometría puede recibir sombra. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNodes() | Obtiene todos los nodos padre; una entidad puede estar adjunta a varios nodos padre para la instanciación de geometría. Los nodos. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExcluded() | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExcluded(value) | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNode() | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setParentNode(value) | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Nombre | Descripción |
+| --- | --- |
+| getScene() | Obtiene la escena a la que pertenece este objeto |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### toMesh{#toMesh}
+
+| Nombre | Descripción |
+| --- | --- |
+| toMesh() | Convertir el objeto actual a malla |
+
+ **Result:**
+Malla
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBoundingBox() | Obtiene el cuadro delimitador de la entidad actual en su sistema de coordenadas de espacio de objeto. |
+
+ **Result:**
+Malla
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEntityRendererKey() | Obtiene la clave del renderizador de entidad registrado en el renderizador |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/quaternion/_index.md
+++ b/spanish/nodejs-java/aspose.threed/quaternion/_index.md
@@ -1,0 +1,323 @@
+---
+title: "Cuaternión"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/quaternion/
+---
+## Quaternion class
+
+El cuaternión se usa normalmente para realizar rotaciones en gráficos por computadora.
+
+
+## Propiedades
+
+| Nombre | Descripción |
+| --- | --- |
+| w | El componente w. |
+| x | El componente x. |
+| y | El componente y. |
+| z | El componente z. |
+| IDENTITY | El cuaternión de identidad. |
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload(w, x, y, z) | Inicializa una nueva instancia de la clase Quaternion. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| w | Número | componente w del cuaternión |
+| x | Número | componente x del cuaternión |
+| y | Número | componente y del cuaternión |
+| z | Número | componente z del cuaternión |
+
+ **Result:**
+
+
+
+---
+
+
+### getLength{#getLength}
+
+| Nombre | Descripción |
+| --- | --- |
+| getLength() | Obtiene la longitud del cuaternión |
+
+ **Result:**
+
+
+
+---
+
+
+### equals{#equals}
+
+| Nombre | Descripción |
+| --- | --- |
+| equals(obj) | Comprueba si dos cuaterniones son iguales |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| obj | Objeto | El objeto para comprobar la igualdad. |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### hashCode{#hashCode}
+
+| Nombre | Descripción |
+| --- | --- |
+| hashCode() | Obtiene el código hash de Quaternion |
+
+ **Result:**
+Número
+
+
+---
+
+
+### conjugate{#conjugate}
+
+| Nombre | Descripción |
+| --- | --- |
+| conjugate() | Devuelve un cuaternión conjugado del cuaternión actual |
+
+ **Result:**
+Cuaternión
+
+
+---
+
+
+### inverse{#inverse}
+
+| Nombre | Descripción |
+| --- | --- |
+| inverse() | Devuelve un cuaternión inverso del cuaternión actual |
+
+ **Result:**
+Cuaternión
+
+
+---
+
+
+### dot{#dot}
+
+| Nombre | Descripción |
+| --- | --- |
+| dot(q) | Producto de puntos |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| q | Cuaternión | El cuaternión |
+
+ **Result:**
+Número
+
+
+---
+
+
+### eulerAngles{#eulerAngles}
+
+| Nombre | Descripción |
+| --- | --- |
+| eulerAngles() | Convierte el cuaternión a una rotación representada por ángulos de Euler. Todos los componentes están en radianes |
+
+ **Result:**
+Vector3
+
+
+---
+
+
+### normalize{#normalize}
+
+| Nombre | Descripción |
+| --- | --- |
+| normalize() | Normaliza el cuaternión |
+
+ **Result:**
+Cuaternión
+
+
+---
+
+
+### concat{#concat}
+
+| Nombre | Descripción |
+| --- | --- |
+| concat(rhs) | Concatenar dos cuaterniones |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| rh | Cuaternión | null |
+
+ **Result:**
+Cuaternión
+
+
+---
+
+
+### fromAngleAxis{#fromAngleAxis}
+
+| Nombre | Descripción |
+| --- | --- |
+| fromAngleAxis(a, axis) | Crea un cuaternión alrededor del eje dado y lo rota en sentido horario |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| a | Número | Rotación en sentido horario en radianes |
+| eje | Vector3 | Eje |
+
+ **Result:**
+Cuaternión
+
+
+---
+
+
+### fromRotation{#fromRotation}
+
+| Nombre | Descripción |
+| --- | --- |
+| fromRotation(orig, dest) | Crea un cuaternión que rota de la dirección original a la dirección de destino |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| orig | Vector3 | Dirección original |
+| dest | Vector3 | Dirección de destino |
+
+ **Result:**
+Cuaternión
+
+
+---
+
+
+### fromEulerAngle{#fromEulerAngle}
+
+| Nombre | Descripción |
+| --- | --- |
+| fromEulerAngle(pitch, yaw, roll) | Crea un cuaternión a partir del ángulo de Euler dado |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| pitch | Número | Ángulo de cabeceo en radianes |
+| guiñada | Número | Guiñada en radianes |
+| giro | Número | Giro en radianes |
+
+ **Result:**
+Cuaternión
+
+
+---
+
+
+### fromEulerAngle{#fromEulerAngle}
+
+| Nombre | Descripción |
+| --- | --- |
+| fromEulerAngle(eulerAngle) | Crea un cuaternión a partir del ángulo de Euler dado |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| eulerAngle | Vector3 | Ángulo de Euler en radianes |
+
+ **Result:**
+Cuaternión
+
+
+---
+
+
+### toMatrix{#toMatrix}
+
+| Nombre | Descripción |
+| --- | --- |
+| toMatrix() | Convierte la rotación presentada por el cuaternión a una matriz de transformación. |
+
+ **Result:**
+Matrix4
+
+
+---
+
+
+### toString{#toString}
+
+| Nombre | Descripción |
+| --- | --- |
+| toString() | Obtiene la representación del cuaternión en una cadena |
+
+ **Result:**
+Cadena
+
+
+---
+
+
+### interpolate{#interpolate}
+
+| Nombre | Descripción |
+| --- | --- |
+| interpolate(t, from, to) | Rellena este cuaternión con el valor interpolado entre los argumentos de cuaternión dados para un t entre from y to. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| t | Número | El coeficiente a interpolar. |
+| de | Cuaternión | Cuaternión de origen. |
+| a | Cuaternión | Cuaternión de destino. |
+
+ **Result:**
+Cuaternión
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/rect/_index.md
+++ b/spanish/nodejs-java/aspose.threed/rect/_index.md
@@ -1,0 +1,227 @@
+---
+title: "Rect"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/rect/
+---
+## Rect class
+
+Una clase para representar el rectángulo
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload(x, y, width, height) | Constructor de la clase Rect |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+|  | Número | null |
+|  | Número | null |
+| widt | Número | null |
+| heigh | Número | null |
+
+ **Result:**
+
+
+
+---
+
+
+### getWidth{#getWidth}
+
+| Nombre | Descripción |
+| --- | --- |
+| getWidth() | Obtiene o establece el ancho del tamaño |
+
+ **Result:**
+
+
+
+---
+
+
+### setWidth{#setWidth}
+
+| Nombre | Descripción |
+| --- | --- |
+| setWidth(value) | Obtiene o establece el ancho del tamaño |
+
+ **Result:**
+
+
+
+---
+
+
+### getHeight{#getHeight}
+
+| Nombre | Descripción |
+| --- | --- |
+| getHeight() | Obtiene o establece la altura del tamaño |
+
+ **Result:**
+
+
+
+---
+
+
+### setHeight{#setHeight}
+
+| Nombre | Descripción |
+| --- | --- |
+| setHeight(value) | Obtiene o establece la altura del tamaño |
+
+ **Result:**
+
+
+
+---
+
+
+### getX{#getX}
+
+| Nombre | Descripción |
+| --- | --- |
+| getX() | Obtiene o establece la x del tamaño |
+
+ **Result:**
+
+
+
+---
+
+
+### setX{#setX}
+
+| Nombre | Descripción |
+| --- | --- |
+| setX(value) | Obtiene o establece la x del tamaño |
+
+ **Result:**
+
+
+
+---
+
+
+### getY{#getY}
+
+| Nombre | Descripción |
+| --- | --- |
+| getY() | Obtiene o establece la y del tamaño |
+
+ **Result:**
+
+
+
+---
+
+
+### setY{#setY}
+
+| Nombre | Descripción |
+| --- | --- |
+| setY(value) | Obtiene o establece la y del tamaño |
+
+ **Result:**
+
+
+
+---
+
+
+### getLeft{#getLeft}
+
+| Nombre | Descripción |
+| --- | --- |
+| getLeft() | Obtiene el lado izquierdo del rectángulo |
+
+ **Result:**
+
+
+
+---
+
+
+### getRight{#getRight}
+
+| Nombre | Descripción |
+| --- | --- |
+| getRight() | Obtiene el lado derecho del rectángulo |
+
+ **Result:**
+
+
+
+---
+
+
+### getTop{#getTop}
+
+| Nombre | Descripción |
+| --- | --- |
+| getTop() | Obtiene la parte superior del rectángulo |
+
+ **Result:**
+
+
+
+---
+
+
+### getBottom{#getBottom}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBottom() | Obtiene la parte inferior del rectángulo |
+
+ **Result:**
+
+
+
+---
+
+
+### contains{#contains}
+
+| Nombre | Descripción |
+| --- | --- |
+| contains(x, y) | Devuelve true si el punto dado está dentro del rectángulo. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+|  | Número | null |
+|  | Número | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/rectangleshape/_index.md
+++ b/spanish/nodejs-java/aspose.threed/rectangleshape/_index.md
@@ -1,0 +1,359 @@
+---
+title: "RectangleShape"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/rectangleshape/
+---
+## RectangleShape class
+
+Forma rectangular compatible con IFC con esquinas redondeadas.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Constructor de RectangleShape |
+
+ **Result:**
+
+
+
+---
+
+
+### getRoundingRadius{#getRoundingRadius}
+
+| Nombre | Descripción |
+| --- | --- |
+| getRoundingRadius() | Obtiene o establece el radio de los arcos circulares de las cuatro esquinas, medido en grados. El valor predeterminado es 0.0 |
+
+ **Result:**
+
+
+
+---
+
+
+### setRoundingRadius{#setRoundingRadius}
+
+| Nombre | Descripción |
+| --- | --- |
+| setRoundingRadius(value) | Obtiene o establece el radio de los arcos circulares de las cuatro esquinas, medido en grados. El valor predeterminado es 0.0 |
+
+ **Result:**
+
+
+
+---
+
+
+### getXDim{#getXDim}
+
+| Nombre | Descripción |
+| --- | --- |
+| getXDim() | Obtiene o establece la extensión del rectángulo en la dirección del eje x. El valor predeterminado es 2.0 |
+
+ **Result:**
+
+
+
+---
+
+
+### setXDim{#setXDim}
+
+| Nombre | Descripción |
+| --- | --- |
+| setXDim(value) | Obtiene o establece la extensión del rectángulo en la dirección del eje x. El valor predeterminado es 2.0 |
+
+ **Result:**
+
+
+
+---
+
+
+### getYDim{#getYDim}
+
+| Nombre | Descripción |
+| --- | --- |
+| getYDim() | Obtiene o establece la extensión del rectángulo en la dirección del eje y. El valor predeterminado es 2.0 |
+
+ **Result:**
+
+
+
+---
+
+
+### setYDim{#setYDim}
+
+| Nombre | Descripción |
+| --- | --- |
+| setYDim(value) | Obtiene o establece la extensión del rectángulo en la dirección del eje y. El valor predeterminado es 2.0 |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNodes() | Obtiene todos los nodos padre; una entidad puede estar adjunta a varios nodos padre para la instanciación de geometría. Los nodos. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExcluded() | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExcluded(value) | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNode() | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setParentNode(value) | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Nombre | Descripción |
+| --- | --- |
+| getScene() | Obtiene la escena a la que pertenece este objeto |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtent{#getExtent}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExtent() | Obtiene la extensión en las dimensiones x e y. |
+
+ **Result:**
+Vector2
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEntityRendererKey() | Obtiene la clave del renderizador de entidad registrado en el renderizador |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBoundingBox() | Obtiene el cuadro delimitador de la entidad actual en su sistema de coordenadas de espacio de objeto. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/rectangulartorus/_index.md
+++ b/spanish/nodejs-java/aspose.threed/rectangulartorus/_index.md
@@ -1,0 +1,502 @@
+---
+title: "RectangularTorus"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/rectangulartorus/
+---
+## RectangularTorus class
+
+Toro rectangular parametrizado.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Constructor de RectangularTorus |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload(name) | Constructor de RectangularTorus |
+
+ **Result:**
+
+
+
+---
+
+
+### getInnerRadius{#getInnerRadius}
+
+| Nombre | Descripción |
+| --- | --- |
+| getInnerRadius() | El radio interno del toro rectangular. El valor predeterminado es 17 |
+
+ **Result:**
+
+
+
+---
+
+
+### setInnerRadius{#setInnerRadius}
+
+| Nombre | Descripción |
+| --- | --- |
+| setInnerRadius(value) | El radio interno del toro rectangular. El valor predeterminado es 17 |
+
+ **Result:**
+
+
+
+---
+
+
+### getOuterRadius{#getOuterRadius}
+
+| Nombre | Descripción |
+| --- | --- |
+| getOuterRadius() | El radio externo del toro rectangular. El valor predeterminado es 20 |
+
+ **Result:**
+
+
+
+---
+
+
+### setOuterRadius{#setOuterRadius}
+
+| Nombre | Descripción |
+| --- | --- |
+| setOuterRadius(value) | El radio externo del toro rectangular. El valor predeterminado es 20 |
+
+ **Result:**
+
+
+
+---
+
+
+### getHeight{#getHeight}
+
+| Nombre | Descripción |
+| --- | --- |
+| getHeight() | La altura del toro rectangular. El valor predeterminado es 20 |
+
+ **Result:**
+
+
+
+---
+
+
+### setHeight{#setHeight}
+
+| Nombre | Descripción |
+| --- | --- |
+| setHeight(value) | La altura del toro rectangular. El valor predeterminado es 20 |
+
+ **Result:**
+
+
+
+---
+
+
+### getArc{#getArc}
+
+| Nombre | Descripción |
+| --- | --- |
+| getArc() | El ángulo total del arco, medido en radianes. El valor predeterminado es PI |
+
+ **Result:**
+
+
+
+---
+
+
+### setArc{#setArc}
+
+| Nombre | Descripción |
+| --- | --- |
+| setArc(value) | El ángulo total del arco, medido en radianes. El valor predeterminado es PI |
+
+ **Result:**
+
+
+
+---
+
+
+### getAngleStart{#getAngleStart}
+
+| Nombre | Descripción |
+| --- | --- |
+| getAngleStart() | El ángulo de inicio del arco, medido en radianes. El valor predeterminado es 0 |
+
+ **Result:**
+
+
+
+---
+
+
+### setAngleStart{#setAngleStart}
+
+| Nombre | Descripción |
+| --- | --- |
+| setAngleStart(value) | El ángulo de inicio del arco, medido en radianes. El valor predeterminado es 0 |
+
+ **Result:**
+
+
+
+---
+
+
+### getRadialSegments{#getRadialSegments}
+
+| Nombre | Descripción |
+| --- | --- |
+| getRadialSegments() | Los segmentos radiales, el valor predeterminado es 10 |
+
+ **Result:**
+
+
+
+---
+
+
+### setRadialSegments{#setRadialSegments}
+
+| Nombre | Descripción |
+| --- | --- |
+| setRadialSegments(value) | Los segmentos radiales, el valor predeterminado es 10 |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastShadows{#getCastShadows}
+
+| Nombre | Descripción |
+| --- | --- |
+| getCastShadows() | Obtiene o establece si esta geometría puede proyectar sombra |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastShadows{#setCastShadows}
+
+| Nombre | Descripción |
+| --- | --- |
+| setCastShadows(value) | Obtiene o establece si esta geometría puede proyectar sombra |
+
+ **Result:**
+
+
+
+---
+
+
+### getReceiveShadows{#getReceiveShadows}
+
+| Nombre | Descripción |
+| --- | --- |
+| getReceiveShadows() | Obtiene o establece si esta geometría puede recibir sombra. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReceiveShadows{#setReceiveShadows}
+
+| Nombre | Descripción |
+| --- | --- |
+| setReceiveShadows(value) | Obtiene o establece si esta geometría puede recibir sombra. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNodes() | Obtiene todos los nodos padre; una entidad puede estar adjunta a varios nodos padre para la instanciación de geometría. Los nodos. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExcluded() | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExcluded(value) | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNode() | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setParentNode(value) | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Nombre | Descripción |
+| --- | --- |
+| getScene() | Obtiene la escena a la que pertenece este objeto |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### toMesh{#toMesh}
+
+| Nombre | Descripción |
+| --- | --- |
+| toMesh() |  |
+
+ **Result:**
+Malla
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBoundingBox() | Obtiene el cuadro delimitador de la entidad actual en su sistema de coordenadas de espacio de objeto. |
+
+ **Result:**
+Malla
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEntityRendererKey() | Obtiene la clave del renderizador de entidad registrado en el renderizador |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/relativerectangle/_index.md
+++ b/spanish/nodejs-java/aspose.threed/relativerectangle/_index.md
@@ -1,0 +1,316 @@
+---
+title: "RelativeRectangle"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/relativerectangle/
+---
+## RelativeRectangle class
+
+Rectángulo relativo  La fórmula entre el componente relativo y el valor absoluto es:  Escala  (Ancho de referencia) + desplazamiento  Así que si queremos que represente un valor absoluto, deje todos los campos de escala en cero y use los campos de desplazamiento en su lugar.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload(left, top, width, height) | Construye un RelativeRectangle |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| lef | Número | null |
+| a | Número | null |
+| widt | Número | null |
+| heigh | Número | null |
+
+ **Result:**
+
+
+
+---
+
+
+### getScaleX{#getScaleX}
+
+| Nombre | Descripción |
+| --- | --- |
+| getScaleX() | Coordenada relativa X |
+
+ **Result:**
+
+
+
+---
+
+
+### setScaleX{#setScaleX}
+
+| Nombre | Descripción |
+| --- | --- |
+| setScaleX(value) | Coordenada relativa X |
+
+ **Result:**
+
+
+
+---
+
+
+### getScaleY{#getScaleY}
+
+| Nombre | Descripción |
+| --- | --- |
+| getScaleY() | Coordenada relativa Y |
+
+ **Result:**
+
+
+
+---
+
+
+### setScaleY{#setScaleY}
+
+| Nombre | Descripción |
+| --- | --- |
+| setScaleY(value) | Coordenada relativa Y |
+
+ **Result:**
+
+
+
+---
+
+
+### getScaleWidth{#getScaleWidth}
+
+| Nombre | Descripción |
+| --- | --- |
+| getScaleWidth() | Ancho relativo |
+
+ **Result:**
+
+
+
+---
+
+
+### setScaleWidth{#setScaleWidth}
+
+| Nombre | Descripción |
+| --- | --- |
+| setScaleWidth(value) | Ancho relativo |
+
+ **Result:**
+
+
+
+---
+
+
+### getScaleHeight{#getScaleHeight}
+
+| Nombre | Descripción |
+| --- | --- |
+| getScaleHeight() | Altura relativa |
+
+ **Result:**
+
+
+
+---
+
+
+### setScaleHeight{#setScaleHeight}
+
+| Nombre | Descripción |
+| --- | --- |
+| setScaleHeight(value) | Altura relativa |
+
+ **Result:**
+
+
+
+---
+
+
+### getOffsetX{#getOffsetX}
+
+| Nombre | Descripción |
+| --- | --- |
+| getOffsetX() | Obtiene o establece el desplazamiento para la coordenada X |
+
+ **Result:**
+
+
+
+---
+
+
+### setOffsetX{#setOffsetX}
+
+| Nombre | Descripción |
+| --- | --- |
+| setOffsetX(value) | Obtiene o establece el desplazamiento para la coordenada X |
+
+ **Result:**
+
+
+
+---
+
+
+### getOffsetY{#getOffsetY}
+
+| Nombre | Descripción |
+| --- | --- |
+| getOffsetY() | Obtiene o establece el desplazamiento para la coordenada Y |
+
+ **Result:**
+
+
+
+---
+
+
+### setOffsetY{#setOffsetY}
+
+| Nombre | Descripción |
+| --- | --- |
+| setOffsetY(value) | Obtiene o establece el desplazamiento para la coordenada Y |
+
+ **Result:**
+
+
+
+---
+
+
+### getOffsetWidth{#getOffsetWidth}
+
+| Nombre | Descripción |
+| --- | --- |
+| getOffsetWidth() | Obtiene o establece el desplazamiento para el ancho |
+
+ **Result:**
+
+
+
+---
+
+
+### setOffsetWidth{#setOffsetWidth}
+
+| Nombre | Descripción |
+| --- | --- |
+| setOffsetWidth(value) | Obtiene o establece el desplazamiento para el ancho |
+
+ **Result:**
+
+
+
+---
+
+
+### getOffsetHeight{#getOffsetHeight}
+
+| Nombre | Descripción |
+| --- | --- |
+| getOffsetHeight() | Obtiene o establece el desplazamiento para la altura |
+
+ **Result:**
+
+
+
+---
+
+
+### setOffsetHeight{#setOffsetHeight}
+
+| Nombre | Descripción |
+| --- | --- |
+| setOffsetHeight(value) | Obtiene o establece el desplazamiento para la altura |
+
+ **Result:**
+
+
+
+---
+
+
+### toAbsolute{#toAbsolute}
+
+| Nombre | Descripción |
+| --- | --- |
+| toAbsolute(left, top, width, height) | Convertir el rectángulo relativo a rectángulo absoluto |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| left | Número | Izquierda del rectángulo |
+| top | Número | Superior del rectángulo |
+| ancho | Número | Ancho del rectángulo |
+| height | Número | Altura del rectángulo |
+
+ **Result:**
+Rect
+
+
+---
+
+
+### fromScale{#fromScale}
+
+| Nombre | Descripción |
+| --- | --- |
+| fromScale(scaleX, scaleY, scaleWidth, scaleHeight) | Construir un RelativeRectangle con todos los campos de desplazamiento en cero y los campos de escala a partir de los parámetros proporcionados. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| escala | Número | null |
+| escala | Número | null |
+| scaleWidt | Número | null |
+| scaleHeigh | Número | null |
+
+ **Result:**
+RelativeRectangle
+
+
+---
+
+
+### toString{#toString}
+
+| Nombre | Descripción |
+| --- | --- |
+| toString() | Convierte el valor de esta instancia a un java.lang.String. |
+
+ **Result:**
+RelativeRectangle
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/renderer/_index.md
+++ b/spanish/nodejs-java/aspose.threed/renderer/_index.md
@@ -1,0 +1,398 @@
+---
+title: "Renderizador"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/renderer/
+---
+## Renderer class
+
+El contexto sobre el renderizador.  @hideconstructor
+
+
+## Métodos
+
+### getShaderSet{#getShaderSet}
+
+| Nombre | Descripción |
+| --- | --- |
+| getShaderSet() | Obtiene o establece el conjunto de shaders que se usa para renderizar la escena |
+
+ **Result:**
+
+
+
+---
+
+
+### setShaderSet{#setShaderSet}
+
+| Nombre | Descripción |
+| --- | --- |
+| setShaderSet(value) | Obtiene o establece el conjunto de shaders que se usa para renderizar la escena |
+
+ **Result:**
+
+
+
+---
+
+
+### getVariables{#getVariables}
+
+| Nombre | Descripción |
+| --- | --- |
+| getVariables() | Acceso a las variables internas usadas para el renderizado |
+
+ **Result:**
+
+
+
+---
+
+
+### getPresetShaders{#getPresetShaders}
+
+| Nombre | Descripción |
+| --- | --- |
+| getPresetShaders() | Obtiene o establece el conjunto de shaders predefinido. El valor de la propiedad es la constante entera PresetShaders. |
+
+ **Result:**
+
+
+
+---
+
+
+### setPresetShaders{#setPresetShaders}
+
+| Nombre | Descripción |
+| --- | --- |
+| setPresetShaders(value) | Obtiene o establece el conjunto de shaders predefinido. El valor de la propiedad es la constante entera PresetShaders. |
+
+ **Result:**
+
+
+
+---
+
+
+### getRenderFactory{#getRenderFactory}
+
+| Nombre | Descripción |
+| --- | --- |
+| getRenderFactory() | Obtiene la fábrica para crear objetos relacionados con el renderizado. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAssetDirectories{#getAssetDirectories}
+
+| Nombre | Descripción |
+| --- | --- |
+| getAssetDirectories() | Directorios que almacenan recursos externos |
+
+ **Result:**
+
+
+
+---
+
+
+### getPostProcessings{#getPostProcessings}
+
+| Nombre | Descripción |
+| --- | --- |
+| getPostProcessings() | Cadena de post-procesamiento activa |
+
+ **Result:**
+
+
+
+---
+
+
+### getEnableShadows{#getEnableShadows}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEnableShadows() | Obtiene o establece si se habilitan las sombras. |
+
+ **Result:**
+
+
+
+---
+
+
+### setEnableShadows{#setEnableShadows}
+
+| Nombre | Descripción |
+| --- | --- |
+| setEnableShadows(value) | Obtiene o establece si se habilitan las sombras. |
+
+ **Result:**
+
+
+
+---
+
+
+### getRenderTarget{#getRenderTarget}
+
+| Nombre | Descripción |
+| --- | --- |
+| getRenderTarget() | Especifique el objetivo de renderizado en el que se realizarán las siguientes operaciones de renderizado. |
+
+ **Result:**
+
+
+
+---
+
+
+### getNode{#getNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getNode() | Obtiene o establece la instancia Node utilizada para proporcionar la matriz de transformación mundial. |
+
+ **Result:**
+
+
+
+---
+
+
+### setNode{#setNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setNode(value) | Obtiene o establece la instancia Node utilizada para proporcionar la matriz de transformación mundial. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFrustum{#getFrustum}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFrustum() | Obtiene o establece el frustum que se usa para proporcionar la matriz de vista. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFrustum{#setFrustum}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFrustum(value) | Obtiene o establece el frustum que se usa para proporcionar la matriz de vista. |
+
+ **Result:**
+
+
+
+---
+
+
+### getRenderStage{#getRenderStage}
+
+| Nombre | Descripción |
+| --- | --- |
+| getRenderStage() | Obtiene la etapa de renderizado actual. El valor de la propiedad es la constante entera RenderStage. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMaterial{#getMaterial}
+
+| Nombre | Descripción |
+| --- | --- |
+| getMaterial() | Obtiene o establece el material que se usa para proporcionar la información del material utilizada por los shaders. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMaterial{#setMaterial}
+
+| Nombre | Descripción |
+| --- | --- |
+| setMaterial(value) | Obtiene o establece el material que se usa para proporcionar la información del material utilizada por los shaders. |
+
+ **Result:**
+
+
+
+---
+
+
+### getShader{#getShader}
+
+| Nombre | Descripción |
+| --- | --- |
+| getShader() | Obtiene o establece la instancia del shader utilizada para renderizar la geometría. |
+
+ **Result:**
+
+
+
+---
+
+
+### setShader{#setShader}
+
+| Nombre | Descripción |
+| --- | --- |
+| setShader(value) | Obtiene o establece la instancia del shader utilizada para renderizar la geometría. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFallbackEntityRenderer{#getFallbackEntityRenderer}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFallbackEntityRenderer() | Obtiene o establece el renderizador de entidad de respaldo cuando la entidad no tiene un renderizador especial definido. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFallbackEntityRenderer{#setFallbackEntityRenderer}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFallbackEntityRenderer(value) | Obtiene o establece el renderizador de entidad de respaldo cuando la entidad no tiene un renderizador especial definido. |
+
+ **Result:**
+
+
+
+---
+
+
+### clearCache{#clearCache}
+
+| Nombre | Descripción |
+| --- | --- |
+| clearCache() | Borre manualmente la caché. Aspose.3D almacenará en caché algunos objetos como materiales/geometrías en tipos internos compatibles con la canalización de renderizado. Esto debe llamarse manualmente cuando la escena tenga cambios importantes. |
+
+ **Result:**
+
+
+
+---
+
+
+### getPostProcessing{#getPostProcessing}
+
+| Nombre | Descripción |
+| --- | --- |
+| getPostProcessing(name) | Obtiene un postprocesador incorporado que es compatible con el renderizador. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| nam | Cadena | null |
+
+ **Result:**
+PostProcessing
+
+
+---
+
+
+### execute{#execute}
+
+| Nombre | Descripción |
+| --- | --- |
+| execute(postProcessing, result) | Ejecute un postprocesamiento en el objetivo de renderizado especificado |
+
+ **Result:**
+PostProcessing
+
+
+---
+
+
+### createRenderer{#createRenderer}
+
+| Nombre | Descripción |
+| --- | --- |
+| createRenderer() | Crea un nuevo Renderer con el perfil predeterminado. |
+
+ **Result:**
+Renderizador
+
+
+---
+
+
+### registerEntityRenderer{#registerEntityRenderer}
+
+| Nombre | Descripción |
+| --- | --- |
+| registerEntityRenderer(renderer) | Registra el renderizador de entidad para la entidad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| rendere | EntityRenderer | null |
+
+ **Result:**
+Renderizador
+
+
+---
+
+
+### render{#render}
+
+| Nombre | Descripción |
+| --- | --- |
+| render(renderTarget) | Renderiza el objetivo especificado |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| renderTarge | IRenderTarget | null |
+
+ **Result:**
+Renderizador
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/renderervariablemanager/_index.md
+++ b/spanish/nodejs-java/aspose.threed/renderervariablemanager/_index.md
@@ -1,0 +1,328 @@
+---
+title: "RendererVariableManager"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/renderervariablemanager/
+---
+## RendererVariableManager class
+
+Esta clase gestiona variables usadas en el renderizado  @hideconstructor
+
+
+## Métodos
+
+### getWorldTime{#getWorldTime}
+
+| Nombre | Descripción |
+| --- | --- |
+| getWorldTime() | Tiempo en segundos |
+
+ **Result:**
+
+
+
+---
+
+
+### setWorldTime{#setWorldTime}
+
+| Nombre | Descripción |
+| --- | --- |
+| setWorldTime(value) | Tiempo en segundos |
+
+ **Result:**
+
+
+
+---
+
+
+### getShadowCaster{#getShadowCaster}
+
+| Nombre | Descripción |
+| --- | --- |
+| getShadowCaster() | Posición del emisor de sombras en el sistema de coordenadas mundial |
+
+ **Result:**
+
+
+
+---
+
+
+### setShadowCaster{#setShadowCaster}
+
+| Nombre | Descripción |
+| --- | --- |
+| setShadowCaster(value) | Posición del emisor de sombras en el sistema de coordenadas mundial |
+
+ **Result:**
+
+
+
+---
+
+
+### getShadowmap{#getShadowmap}
+
+| Nombre | Descripción |
+| --- | --- |
+| getShadowmap() | La textura de profundidad utilizada para el mapeo de sombras |
+
+ **Result:**
+
+
+
+---
+
+
+### setShadowmap{#setShadowmap}
+
+| Nombre | Descripción |
+| --- | --- |
+| setShadowmap(value) | La textura de profundidad utilizada para el mapeo de sombras |
+
+ **Result:**
+
+
+
+---
+
+
+### getMatrixLightSpace{#getMatrixLightSpace}
+
+| Nombre | Descripción |
+| --- | --- |
+| getMatrixLightSpace() | Matriz para la transformación del espacio de luz |
+
+ **Result:**
+
+
+
+---
+
+
+### setMatrixLightSpace{#setMatrixLightSpace}
+
+| Nombre | Descripción |
+| --- | --- |
+| setMatrixLightSpace(value) | Matriz para la transformación del espacio de luz |
+
+ **Result:**
+
+
+
+---
+
+
+### getMatrixViewProjection{#getMatrixViewProjection}
+
+| Nombre | Descripción |
+| --- | --- |
+| getMatrixViewProjection() | Matriz para la transformación de vista y proyección. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMatrixWorldViewProjection{#getMatrixWorldViewProjection}
+
+| Nombre | Descripción |
+| --- | --- |
+| getMatrixWorldViewProjection() | Matriz para la transformación de vista y proyección del mundo |
+
+ **Result:**
+
+
+
+---
+
+
+### getMatrixWorld{#getMatrixWorld}
+
+| Nombre | Descripción |
+| --- | --- |
+| getMatrixWorld() | Matriz para la transformación del mundo |
+
+ **Result:**
+
+
+
+---
+
+
+### getMatrixWorldNormal{#getMatrixWorldNormal}
+
+| Nombre | Descripción |
+| --- | --- |
+| getMatrixWorldNormal() | Matriz para convertir la normal del objeto al espacio del mundo. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMatrixProjection{#getMatrixProjection}
+
+| Nombre | Descripción |
+| --- | --- |
+| getMatrixProjection() | Matriz para la transformación de proyección |
+
+ **Result:**
+
+
+
+---
+
+
+### setMatrixProjection{#setMatrixProjection}
+
+| Nombre | Descripción |
+| --- | --- |
+| setMatrixProjection(value) | Matriz para la transformación de proyección |
+
+ **Result:**
+
+
+
+---
+
+
+### getMatrixView{#getMatrixView}
+
+| Nombre | Descripción |
+| --- | --- |
+| getMatrixView() | Matriz para la transformación de vista |
+
+ **Result:**
+
+
+
+---
+
+
+### setMatrixView{#setMatrixView}
+
+| Nombre | Descripción |
+| --- | --- |
+| setMatrixView(value) | Matriz para la transformación de vista |
+
+ **Result:**
+
+
+
+---
+
+
+### getCameraPosition{#getCameraPosition}
+
+| Nombre | Descripción |
+| --- | --- |
+| getCameraPosition() | Posición de la cámara en el sistema de coordenadas del mundo |
+
+ **Result:**
+
+
+
+---
+
+
+### setCameraPosition{#setCameraPosition}
+
+| Nombre | Descripción |
+| --- | --- |
+| setCameraPosition(value) | Posición de la cámara en el sistema de coordenadas del mundo |
+
+ **Result:**
+
+
+
+---
+
+
+### getDepthBias{#getDepthBias}
+
+| Nombre | Descripción |
+| --- | --- |
+| getDepthBias() | Sesgo de profundidad para el mapeo de sombras, el valor predeterminado es 0.001 |
+
+ **Result:**
+
+
+
+---
+
+
+### setDepthBias{#setDepthBias}
+
+| Nombre | Descripción |
+| --- | --- |
+| setDepthBias(value) | Sesgo de profundidad para el mapeo de sombras, el valor predeterminado es 0.001 |
+
+ **Result:**
+
+
+
+---
+
+
+### getViewportSize{#getViewportSize}
+
+| Nombre | Descripción |
+| --- | --- |
+| getViewportSize() | Tamaño del viewport, medido en píxeles |
+
+ **Result:**
+
+
+
+---
+
+
+### setViewportSize{#setViewportSize}
+
+| Nombre | Descripción |
+| --- | --- |
+| setViewportSize(value) | Tamaño del viewport, medido en píxeles |
+
+ **Result:**
+
+
+
+---
+
+
+### getWorldAmbient{#getWorldAmbient}
+
+| Nombre | Descripción |
+| --- | --- |
+| getWorldAmbient() | Color ambiental definido en el viewport. |
+
+ **Result:**
+
+
+
+---
+
+
+### setWorldAmbient{#setWorldAmbient}
+
+| Nombre | Descripción |
+| --- | --- |
+| setWorldAmbient(value) | Color ambiental definido en el viewport. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/renderfactory/_index.md
+++ b/spanish/nodejs-java/aspose.threed/renderfactory/_index.md
@@ -1,0 +1,243 @@
+---
+title: "RenderFactory"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/renderfactory/
+---
+## RenderFactory class
+
+RenderFactory crea todos los recursos que se representan en la canalización de renderizado.  @hideconstructor
+
+
+## Métodos
+
+### createRenderTexture{#createRenderTexture}
+
+| Nombre | Descripción |
+| --- | --- |
+| createRenderTexture(parameters, targets, width, height) | Crear un objetivo de renderizado que renderiza a la textura |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| parámetros | RenderParameters | Parámetros de renderizado para crear la textura de renderizado |
+| objetivos | Número | Cuántos objetivos de salida de color |
+| ancho | Número | El ancho de la textura de renderizado |
+| height | Número | La altura de la textura de renderizado |
+
+ **Result:**
+IRenderTexture
+
+
+---
+
+
+### createRenderTexture{#createRenderTexture}
+
+| Nombre | Descripción |
+| --- | --- |
+| createRenderTexture(parameters, width, height) | Crear un objetivo de renderizado que contiene 1 objetivo y renderiza a la textura |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| parámetros | RenderParameters | Parámetros de renderizado para crear la textura de renderizado |
+| ancho | Número | El ancho de la textura de renderizado |
+| height | Número | La altura de la textura de renderizado |
+
+ **Result:**
+IRenderTexture
+
+
+---
+
+
+### createDescriptorSet{#createDescriptorSet}
+
+| Nombre | Descripción |
+| --- | --- |
+| createDescriptorSet(shader) | Crear el conjunto de descriptores para el programa de shader especificado. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| shader | ShaderProgram | El programa de shader |
+
+ **Result:**
+IDescriptorSet
+
+
+---
+
+
+### createCubeRenderTexture{#createCubeRenderTexture}
+
+| Nombre | Descripción |
+| --- | --- |
+| createCubeRenderTexture(parameters, width, height) | Crear un objetivo de renderizado que contiene 1 textura cúbica |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| parámetros | RenderParameters | Parámetros de renderizado para crear la textura de renderizado |
+| ancho | Número | El ancho de la textura de renderizado |
+| height | Número | La altura de la textura de renderizado |
+
+ **Result:**
+IRenderTexture
+
+
+---
+
+
+### createRenderWindow{#createRenderWindow}
+
+| Nombre | Descripción |
+| --- | --- |
+| createRenderWindow(parameters, handle) | Crear un objetivo de renderizado que renderiza en la ventana nativa. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| parámetros | RenderParameters | Parámetros de renderizado para crear la ventana de renderizado |
+| handle | WindowHandle | El handle de la ventana a renderizar |
+
+ **Result:**
+IRenderWindow
+
+
+---
+
+
+### createVertexBuffer{#createVertexBuffer}
+
+| Nombre | Descripción |
+| --- | --- |
+| createVertexBuffer(declaration) | Crea una instancia de com.aspose.threed.IVertexBuffer para almacenar la información de los vértices del polígono. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| declaración | VertexDeclaration | null |
+
+ **Result:**
+IVertexBuffer
+
+
+---
+
+
+### createIndexBuffer{#createIndexBuffer}
+
+| Nombre | Descripción |
+| --- | --- |
+| createIndexBuffer() | Crea una instancia de com.aspose.threed.IIndexBuffer para almacenar la información de las caras del polígono. |
+
+ **Result:**
+IIndexBuffer
+
+
+---
+
+
+### createTextureUnit{#createTextureUnit}
+
+| Nombre | Descripción |
+| --- | --- |
+| createTextureUnit(textureType) | Crea una unidad de textura que pueda ser accedida por el shader. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| textureType | TextureType | TextureType |
+
+ **Result:**
+ITextureUnit
+
+
+---
+
+
+### createTextureUnit{#createTextureUnit}
+
+| Nombre | Descripción |
+| --- | --- |
+| createTextureUnit() | Crea una unidad de textura 2D que pueda ser accedida por el shader. |
+
+ **Result:**
+ITextureUnit
+
+
+---
+
+
+### createShaderProgram{#createShaderProgram}
+
+| Nombre | Descripción |
+| --- | --- |
+| createShaderProgram(shaderSource) | Crea un objeto ShaderProgram |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| shaderSource | ShaderSource | El código fuente del shader |
+
+ **Result:**
+ShaderProgram
+
+
+---
+
+
+### createPipeline{#createPipeline}
+
+| Nombre | Descripción |
+| --- | --- |
+| createPipeline(shader, renderState, vertexDeclaration, drawOperation) | Crea una canalización gráfica preconfigurada con shader/renderState/vertexDeclaration y operaciones de dibujo preconfiguradas. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| shader | ShaderProgram | El shader usado en la renderización |
+| renderState | RenderState | El estado de renderizado usado en la renderización |
+| vertexDeclaration | VertexDeclaration | La declaración de vértices de los datos de vértices de entrada |
+| drawOperation | DrawOperation | DrawOperation |
+
+ **Result:**
+IPipeline
+
+
+---
+
+
+### createUniformBuffer{#createUniformBuffer}
+
+| Nombre | Descripción |
+| --- | --- |
+| createUniformBuffer(size) | Crear un nuevo búfer uniforme en el lado GPU con tamaño preasignado. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| tamaño | Número | El tamaño del búfer uniforme |
+
+ **Result:**
+IBuffer
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/renderparameters/_index.md
+++ b/spanish/nodejs-java/aspose.threed/renderparameters/_index.md
@@ -1,0 +1,133 @@
+---
+title: "RenderParameters"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/renderparameters/
+---
+## RenderParameters class
+
+Describe los parámetros del objetivo de renderizado
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor(doubleBuffering, colorBits, depthBits, stencilBits) | Inicializar una instancia de PixelFormat |
+
+ **Result:**
+
+
+
+---
+
+
+### getDoubleBuffering{#getDoubleBuffering}
+
+| Nombre | Descripción |
+| --- | --- |
+| getDoubleBuffering() | Obtiene o establece si se usa doble búfer. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDoubleBuffering{#setDoubleBuffering}
+
+| Nombre | Descripción |
+| --- | --- |
+| setDoubleBuffering(value) | Obtiene o establece si se usa doble búfer. |
+
+ **Result:**
+
+
+
+---
+
+
+### getColorBits{#getColorBits}
+
+| Nombre | Descripción |
+| --- | --- |
+| getColorBits() | Obtiene o establece cuántos bits se usarán en el búfer de color. |
+
+ **Result:**
+
+
+
+---
+
+
+### setColorBits{#setColorBits}
+
+| Nombre | Descripción |
+| --- | --- |
+| setColorBits(value) | Obtiene o establece cuántos bits se usarán en el búfer de color. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDepthBits{#getDepthBits}
+
+| Nombre | Descripción |
+| --- | --- |
+| getDepthBits() | Obtiene o establece cuántos bits se usarán en el búfer de profundidad. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDepthBits{#setDepthBits}
+
+| Nombre | Descripción |
+| --- | --- |
+| setDepthBits(value) | Obtiene o establece cuántos bits se usarán en el búfer de profundidad. |
+
+ **Result:**
+
+
+
+---
+
+
+### getStencilBits{#getStencilBits}
+
+| Nombre | Descripción |
+| --- | --- |
+| getStencilBits() | Obtiene o establece cuántos bits se usarán en el búfer de stencil. |
+
+ **Result:**
+
+
+
+---
+
+
+### setStencilBits{#setStencilBits}
+
+| Nombre | Descripción |
+| --- | --- |
+| setStencilBits(value) | Obtiene o establece cuántos bits se usarán en el búfer de stencil. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/renderresource/_index.md
+++ b/spanish/nodejs-java/aspose.threed/renderresource/_index.md
@@ -1,0 +1,13 @@
+---
+title: "RenderResource"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/renderresource/
+---
+## RenderResource class
+
+La clase abstracta de todos los recursos de renderizado  Todos los recursos de renderizado se dispondrán cuando se libere el renderizador.  Clases como Mesh/Texture tendrán un RenderResource correspondiente  @hideconstructor
+
+

--- a/spanish/nodejs-java/aspose.threed/renderstate/_index.md
+++ b/spanish/nodejs-java/aspose.threed/renderstate/_index.md
@@ -1,0 +1,477 @@
+---
+title: "RenderState"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/renderstate/
+---
+## RenderState class
+
+Estado de renderizado para construir la canalización  Los cambios realizados en el estado de renderizado no afectarán a las instancias de la canalización creadas.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Constructor de RenderState |
+
+ **Result:**
+
+
+
+---
+
+
+### getBlend{#getBlend}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBlend() | Habilita o deshabilita la mezcla de fragmentos. |
+
+ **Result:**
+
+
+
+---
+
+
+### setBlend{#setBlend}
+
+| Nombre | Descripción |
+| --- | --- |
+| setBlend(value) | Habilita o deshabilita la mezcla de fragmentos. |
+
+ **Result:**
+
+
+
+---
+
+
+### getBlendColor{#getBlendColor}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBlendColor() | Obtiene o establece el color de mezcla donde se usa en BlendFactor.CONSTANT_COLOR |
+
+ **Result:**
+
+
+
+---
+
+
+### setBlendColor{#setBlendColor}
+
+| Nombre | Descripción |
+| --- | --- |
+| setBlendColor(value) | Obtiene o establece el color de mezcla donde se usa en BlendFactor.CONSTANT_COLOR |
+
+ **Result:**
+
+
+
+---
+
+
+### getSourceBlendFactor{#getSourceBlendFactor}
+
+| Nombre | Descripción |
+| --- | --- |
+| getSourceBlendFactor() | Obtiene o establece cómo se mezcla el color. El valor de la propiedad es una constante entera de BlendFactor. |
+
+ **Result:**
+
+
+
+---
+
+
+### setSourceBlendFactor{#setSourceBlendFactor}
+
+| Nombre | Descripción |
+| --- | --- |
+| setSourceBlendFactor(value) | Obtiene o establece cómo se mezcla el color. El valor de la propiedad es una constante entera de BlendFactor. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDestinationBlendFactor{#getDestinationBlendFactor}
+
+| Nombre | Descripción |
+| --- | --- |
+| getDestinationBlendFactor() | Obtiene o establece cómo se mezcla el color. El valor de la propiedad es una constante entera de BlendFactor. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDestinationBlendFactor{#setDestinationBlendFactor}
+
+| Nombre | Descripción |
+| --- | --- |
+| setDestinationBlendFactor(value) | Obtiene o establece cómo se mezcla el color. El valor de la propiedad es una constante entera de BlendFactor. |
+
+ **Result:**
+
+
+
+---
+
+
+### getCullFace{#getCullFace}
+
+| Nombre | Descripción |
+| --- | --- |
+| getCullFace() | Habilita o deshabilita cull face |
+
+ **Result:**
+
+
+
+---
+
+
+### setCullFace{#setCullFace}
+
+| Nombre | Descripción |
+| --- | --- |
+| setCullFace(value) | Habilita o deshabilita cull face |
+
+ **Result:**
+
+
+
+---
+
+
+### getCullFaceMode{#getCullFaceMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getCullFaceMode() | Obtiene o establece qué cara será descartada. El valor de la propiedad es la constante entera CullFaceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setCullFaceMode{#setCullFaceMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setCullFaceMode(value) | Obtiene o establece qué cara será descartada. El valor de la propiedad es la constante entera CullFaceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFrontFace{#getFrontFace}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFrontFace() | Obtiene o establece cuál es el orden de la cara frontal. El valor de la propiedad es la constante entera FrontFace. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFrontFace{#setFrontFace}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFrontFace(value) | Obtiene o establece cuál es el orden de la cara frontal. El valor de la propiedad es la constante entera FrontFace. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDepthTest{#getDepthTest}
+
+| Nombre | Descripción |
+| --- | --- |
+| getDepthTest() | Habilita o deshabilita la prueba de profundidad. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDepthTest{#setDepthTest}
+
+| Nombre | Descripción |
+| --- | --- |
+| setDepthTest(value) | Habilita o deshabilita la prueba de profundidad. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDepthMask{#getDepthMask}
+
+| Nombre | Descripción |
+| --- | --- |
+| getDepthMask() | Habilita o deshabilita la escritura de profundidad. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDepthMask{#setDepthMask}
+
+| Nombre | Descripción |
+| --- | --- |
+| setDepthMask(value) | Habilita o deshabilita la escritura de profundidad. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDepthFunction{#getDepthFunction}
+
+| Nombre | Descripción |
+| --- | --- |
+| getDepthFunction() | Obtiene o establece la función de comparación utilizada en la prueba de profundidad. El valor de la propiedad es la constante entera CompareFunction. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDepthFunction{#setDepthFunction}
+
+| Nombre | Descripción |
+| --- | --- |
+| setDepthFunction(value) | Obtiene o establece la función de comparación utilizada en la prueba de profundidad. El valor de la propiedad es la constante entera CompareFunction. |
+
+ **Result:**
+
+
+
+---
+
+
+### getStencilTest{#getStencilTest}
+
+| Nombre | Descripción |
+| --- | --- |
+| getStencilTest() | Habilita o deshabilita la prueba de stencil. |
+
+ **Result:**
+
+
+
+---
+
+
+### setStencilTest{#setStencilTest}
+
+| Nombre | Descripción |
+| --- | --- |
+| setStencilTest(value) | Habilita o deshabilita la prueba de stencil. |
+
+ **Result:**
+
+
+
+---
+
+
+### getStencilReference{#getStencilReference}
+
+| Nombre | Descripción |
+| --- | --- |
+| getStencilReference() | Obtiene o establece el valor de referencia para la prueba de stencil. |
+
+ **Result:**
+
+
+
+---
+
+
+### setStencilReference{#setStencilReference}
+
+| Nombre | Descripción |
+| --- | --- |
+| setStencilReference(value) | Obtiene o establece el valor de referencia para la prueba de stencil. |
+
+ **Result:**
+
+
+
+---
+
+
+### getStencilMask{#getStencilMask}
+
+| Nombre | Descripción |
+| --- | --- |
+| getStencilMask() | Obtiene o establece la máscara que se ANDea con la referencia y el valor de stencil almacenado cuando se completa la prueba. |
+
+ **Result:**
+
+
+
+---
+
+
+### getStencilFrontFace{#getStencilFrontFace}
+
+| Nombre | Descripción |
+| --- | --- |
+| getStencilFrontFace() | Obtiene el estado de stencil para la cara frontal. |
+
+ **Result:**
+
+
+
+---
+
+
+### getStencilBackFace{#getStencilBackFace}
+
+| Nombre | Descripción |
+| --- | --- |
+| getStencilBackFace() | Obtiene el estado del stencil para la cara posterior. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScissorTest{#getScissorTest}
+
+| Nombre | Descripción |
+| --- | --- |
+| getScissorTest() | Activar o desactivar la prueba de recorte. |
+
+ **Result:**
+
+
+
+---
+
+
+### setScissorTest{#setScissorTest}
+
+| Nombre | Descripción |
+| --- | --- |
+| setScissorTest(value) | Activar o desactivar la prueba de recorte. |
+
+ **Result:**
+
+
+
+---
+
+
+### getPolygonMode{#getPolygonMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getPolygonMode() | Obtiene o establece el modo de renderizado del polígono. El valor de la propiedad es la constante entera PolygonMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setPolygonMode{#setPolygonMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setPolygonMode(value) | Obtiene o establece el modo de renderizado del polígono. El valor de la propiedad es la constante entera PolygonMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### equals{#equals}
+
+| Nombre | Descripción |
+| --- | --- |
+| equals(obj) | Devuelve un valor que indica si esta instancia es igual a un objeto especificado. |
+
+ **Result:**
+
+
+
+---
+
+
+### hashCode{#hashCode}
+
+| Nombre | Descripción |
+| --- | --- |
+| hashCode() | Devuelve el código hash de esta instancia. |
+
+ **Result:**
+
+
+
+---
+
+
+### compareTo{#compareTo}
+
+| Nombre | Descripción |
+| --- | --- |
+| compareTo(other) | Comparar el estado de renderizado con otra instancia. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| othe | RenderState | null |
+
+ **Result:**
+Número
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/revolvedareasolid/_index.md
+++ b/spanish/nodejs-java/aspose.threed/revolvedareasolid/_index.md
@@ -1,0 +1,411 @@
+---
+title: "RevolvedAreaSolid"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/revolvedareasolid/
+---
+## RevolvedAreaSolid class
+
+Esta clase representa un modelo sólido al girar una sección transversal proporcionada por un perfil alrededor de un eje.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getAngleStart{#getAngleStart}
+
+| Nombre | Descripción |
+| --- | --- |
+| getAngleStart() | Obtiene o establece el ángulo inicial del procedimiento de revolución, medido en radianes, el valor predeterminado es 0. |
+
+ **Result:**
+
+
+
+---
+
+
+### setAngleStart{#setAngleStart}
+
+| Nombre | Descripción |
+| --- | --- |
+| setAngleStart(value) | Obtiene o establece el ángulo inicial del procedimiento de revolución, medido en radianes, el valor predeterminado es 0. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAngleEnd{#getAngleEnd}
+
+| Nombre | Descripción |
+| --- | --- |
+| getAngleEnd() | Obtiene o establece el ángulo final del procedimiento de revolución, medido en radianes, el valor predeterminado es pi. |
+
+ **Result:**
+
+
+
+---
+
+
+### setAngleEnd{#setAngleEnd}
+
+| Nombre | Descripción |
+| --- | --- |
+| setAngleEnd(value) | Obtiene o establece el ángulo final del procedimiento de revolución, medido en radianes, el valor predeterminado es pi. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAxis{#getAxis}
+
+| Nombre | Descripción |
+| --- | --- |
+| getAxis() | Obtiene o establece la dirección del eje, el valor predeterminado es (0, 1, 0). |
+
+ **Result:**
+
+
+
+---
+
+
+### setAxis{#setAxis}
+
+| Nombre | Descripción |
+| --- | --- |
+| setAxis(value) | Obtiene o establece la dirección del eje, el valor predeterminado es (0, 1, 0). |
+
+ **Result:**
+
+
+
+---
+
+
+### getOrigin{#getOrigin}
+
+| Nombre | Descripción |
+| --- | --- |
+| getOrigin() | Obtiene o establece el punto de origen de la revolución, el valor predeterminado es (0, 0, 0). |
+
+ **Result:**
+
+
+
+---
+
+
+### setOrigin{#setOrigin}
+
+| Nombre | Descripción |
+| --- | --- |
+| setOrigin(value) | Obtiene o establece el punto de origen de la revolución, el valor predeterminado es (0, 0, 0). |
+
+ **Result:**
+
+
+
+---
+
+
+### getShape{#getShape}
+
+| Nombre | Descripción |
+| --- | --- |
+| getShape() | Obtiene o establece el perfil base utilizado para la revolución. |
+
+ **Result:**
+
+
+
+---
+
+
+### setShape{#setShape}
+
+| Nombre | Descripción |
+| --- | --- |
+| setShape(value) | Obtiene o establece el perfil base utilizado para la revolución. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNodes() | Obtiene todos los nodos padre; una entidad puede estar adjunta a varios nodos padre para la instanciación de geometría. Los nodos. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExcluded() | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExcluded(value) | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNode() | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setParentNode(value) | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Nombre | Descripción |
+| --- | --- |
+| getScene() | Obtiene la escena a la que pertenece este objeto |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### toMesh{#toMesh}
+
+| Nombre | Descripción |
+| --- | --- |
+| toMesh() | Convierte el RevolvedAreaSolid en una malla. |
+
+ **Result:**
+Malla
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBoundingBox() | Obtiene el cuadro delimitador de la entidad actual en su sistema de coordenadas de espacio de objeto. |
+
+ **Result:**
+Malla
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEntityRendererKey() | Obtiene la clave del renderizador de entidad registrado en el renderizador |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/rvmformat/_index.md
+++ b/spanish/nodejs-java/aspose.threed/rvmformat/_index.md
@@ -1,0 +1,141 @@
+---
+title: "RvmFormat"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/rvmformat/
+---
+## RvmFormat class
+
+El formato RVM  @hideconstructor
+
+
+## Métodos
+
+### getVersion{#getVersion}
+
+| Nombre | Descripción |
+| --- | --- |
+| getVersion() | Obtiene la versión del formato de archivo |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtension{#getExtension}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExtension() | Obtiene el nombre de la extensión de este tipo. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtensions{#getExtensions}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExtensions() | Obtiene los nombres de las extensiones de este tipo. |
+
+ **Result:**
+
+
+
+---
+
+
+### getContentType{#getContentType}
+
+| Nombre | Descripción |
+| --- | --- |
+| getContentType() | Obtiene el tipo de contenido del formato de archivo. El valor de la propiedad es la constante entera FileContentType. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormatType{#getFileFormatType}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileFormatType() | Obtiene el tipo de formato de archivo |
+
+ **Result:**
+
+
+
+---
+
+
+### loadAttributes{#loadAttributes}
+
+| Nombre | Descripción |
+| --- | --- |
+| loadAttributes(scene, fileName, prefix) | Cargue los atributos del nombre de archivo especificado |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| escena | Scene | La escena a la que se aplicarán los atributos |
+| fileName | Cadena | El nombre del archivo que contiene los atributos |
+| prefix | Cadena | El prefijo de los atributos que se usa para evitar conflictos de nombres, el valor predeterminado es "rvm:" |
+
+ **Result:**
+
+
+
+---
+
+
+### createLoadOptions{#createLoadOptions}
+
+| Nombre | Descripción |
+| --- | --- |
+| createLoadOptions() | Crea opciones de carga predeterminadas para este formato de archivo |
+
+ **Result:**
+LoadOptions
+
+
+---
+
+
+### createSaveOptions{#createSaveOptions}
+
+| Nombre | Descripción |
+| --- | --- |
+| createSaveOptions() | Crea opciones de guardado predeterminadas para este formato de archivo |
+
+ **Result:**
+SaveOptions
+
+
+---
+
+
+### toString{#toString}
+
+| Nombre | Descripción |
+| --- | --- |
+| toString() | Formatos a cadena |
+
+ **Result:**
+Cadena
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/rvmloadoptions/_index.md
+++ b/spanish/nodejs-java/aspose.threed/rvmloadoptions/_index.md
@@ -1,0 +1,373 @@
+---
+title: "RvmLoadOptions"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/rvmloadoptions/
+---
+## RvmLoadOptions class
+
+Opciones de carga para el archivo RVM del Sistema de Gestión de Diseño de Plantas AVEVA.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor(contentType) | Construye una instancia de RvmLoadOptions |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| contentType | FileContentType | FileContentType |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload() | Construye una instancia de RvmLoadOptions |
+
+ **Result:**
+
+
+
+---
+
+
+### getGenerateMaterials{#getGenerateMaterials}
+
+| Nombre | Descripción |
+| --- | --- |
+| getGenerateMaterials() | Genera materiales con colores aleatorios para cada objeto en la escena si la tabla de colores no se exporta dentro del archivo RVM. El valor predeterminado es true |
+
+ **Result:**
+
+
+
+---
+
+
+### setGenerateMaterials{#setGenerateMaterials}
+
+| Nombre | Descripción |
+| --- | --- |
+| setGenerateMaterials(value) | Genera materiales con colores aleatorios para cada objeto en la escena si la tabla de colores no se exporta dentro del archivo RVM. El valor predeterminado es true |
+
+ **Result:**
+
+
+
+---
+
+
+### getCylinderRadialSegments{#getCylinderRadialSegments}
+
+| Nombre | Descripción |
+| --- | --- |
+| getCylinderRadialSegments() | Obtiene o establece el número de segmentos radiales del cilindro, el valor predeterminado es 16 |
+
+ **Result:**
+
+
+
+---
+
+
+### setCylinderRadialSegments{#setCylinderRadialSegments}
+
+| Nombre | Descripción |
+| --- | --- |
+| setCylinderRadialSegments(value) | Obtiene o establece el número de segmentos radiales del cilindro, el valor predeterminado es 16 |
+
+ **Result:**
+
+
+
+---
+
+
+### getDishLongitudeSegments{#getDishLongitudeSegments}
+
+| Nombre | Descripción |
+| --- | --- |
+| getDishLongitudeSegments() | Obtiene o establece el número de segmentos de longitud del dish, el valor predeterminado es 12 |
+
+ **Result:**
+
+
+
+---
+
+
+### setDishLongitudeSegments{#setDishLongitudeSegments}
+
+| Nombre | Descripción |
+| --- | --- |
+| setDishLongitudeSegments(value) | Obtiene o establece el número de segmentos de longitud del dish, el valor predeterminado es 12 |
+
+ **Result:**
+
+
+
+---
+
+
+### getDishLatitudeSegments{#getDishLatitudeSegments}
+
+| Nombre | Descripción |
+| --- | --- |
+| getDishLatitudeSegments() | Obtiene o establece el número de segmentos de latitud del dish, el valor predeterminado es 8 |
+
+ **Result:**
+
+
+
+---
+
+
+### setDishLatitudeSegments{#setDishLatitudeSegments}
+
+| Nombre | Descripción |
+| --- | --- |
+| setDishLatitudeSegments(value) | Obtiene o establece el número de segmentos de latitud del dish, el valor predeterminado es 8 |
+
+ **Result:**
+
+
+
+---
+
+
+### getTorusTubularSegments{#getTorusTubularSegments}
+
+| Nombre | Descripción |
+| --- | --- |
+| getTorusTubularSegments() | Obtiene o establece el número de segmentos tubulares del torus, el valor predeterminado es 20 |
+
+ **Result:**
+
+
+
+---
+
+
+### setTorusTubularSegments{#setTorusTubularSegments}
+
+| Nombre | Descripción |
+| --- | --- |
+| setTorusTubularSegments(value) | Obtiene o establece el número de segmentos tubulares del torus, el valor predeterminado es 20 |
+
+ **Result:**
+
+
+
+---
+
+
+### getRectangularTorusSegments{#getRectangularTorusSegments}
+
+| Nombre | Descripción |
+| --- | --- |
+| getRectangularTorusSegments() | Obtiene o establece el número de segmentos radiales del torus rectangular, el valor predeterminado es 20 |
+
+ **Result:**
+
+
+
+---
+
+
+### setRectangularTorusSegments{#setRectangularTorusSegments}
+
+| Nombre | Descripción |
+| --- | --- |
+| setRectangularTorusSegments(value) | Obtiene o establece el número de segmentos radiales del torus rectangular, el valor predeterminado es 20 |
+
+ **Result:**
+
+
+
+---
+
+
+### getCenterScene{#getCenterScene}
+
+| Nombre | Descripción |
+| --- | --- |
+| getCenterScene() | Centrar la escena después de que se cargue. |
+
+ **Result:**
+
+
+
+---
+
+
+### setCenterScene{#setCenterScene}
+
+| Nombre | Descripción |
+| --- | --- |
+| setCenterScene(value) | Centrar la escena después de que se cargue. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAttributePrefix{#getAttributePrefix}
+
+| Nombre | Descripción |
+| --- | --- |
+| getAttributePrefix() | Obtiene o establece el prefijo de los atributos que fueron definidos en archivos de atributos externos, el prefijo se usa para evitar conflictos de nombres, el valor predeterminado es "rvm:" |
+
+ **Result:**
+
+
+
+---
+
+
+### setAttributePrefix{#setAttributePrefix}
+
+| Nombre | Descripción |
+| --- | --- |
+| setAttributePrefix(value) | Obtiene o establece el prefijo de los atributos que fueron definidos en archivos de atributos externos, el prefijo se usa para evitar conflictos de nombres, el valor predeterminado es "rvm:" |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupAttributes{#getLookupAttributes}
+
+| Nombre | Descripción |
+| --- | --- |
+| getLookupAttributes() | Obtiene o establece si se deben cargar los atributos desde un archivo de lista de atributos externo (.att/.attrib/.txt), el valor predeterminado es true. |
+
+ **Result:**
+
+
+
+---
+
+
+### setLookupAttributes{#setLookupAttributes}
+
+| Nombre | Descripción |
+| --- | --- |
+| setLookupAttributes(value) | Obtiene o establece si se deben cargar los atributos desde un archivo de lista de atributos externo (.att/.attrib/.txt), el valor predeterminado es true. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileFormat() | Obtiene el formato de archivo especificado en la opción actual de Guardar/Cargar. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEncoding() | Obtiene o establece la codificación predeterminada para archivos basados en texto. El valor predeterminado es null, lo que significa que el importador/exportador decidirá qué codificación usar. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileSystem() | Permite al usuario manejar cómo gestionar las dependencias externas durante la carga/guardado. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFileSystem(value) | Permite al usuario manejar cómo gestionar las dependencias externas durante la carga/guardado. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| Nombre | Descripción |
+| --- | --- |
+| getLookupPaths() | Algunos archivos como OBJ dependen de archivos externos; las rutas de búsqueda permiten que Aspose.3D busque el archivo externo para cargarlo. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileName() | El nombre de archivo de la escena de exportación/importación. Es opcional, pero útil al serializar recursos externos como el material de OBJ. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFileName(value) | El nombre de archivo de la escena de exportación/importación. Es opcional, pero útil al serializar recursos externos como el material de OBJ. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/rvmsaveoptions/_index.md
+++ b/spanish/nodejs-java/aspose.threed/rvmsaveoptions/_index.md
@@ -1,0 +1,321 @@
+---
+title: "RvmSaveOptions"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/rvmsaveoptions/
+---
+## RvmSaveOptions class
+
+Opciones de guardado para el archivo RVM de Aveva PDMS.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Constructor de RvmSaveOptions |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload(contentType) | Constructor de RvmSaveOptions |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| contentType | FileContentType | FileContentType |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileNote{#getFileNote}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileNote() | Nota del archivo en el encabezado del archivo. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileNote{#setFileNote}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFileNote(value) | Nota del archivo en el encabezado del archivo. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAuthor{#getAuthor}
+
+| Nombre | Descripción |
+| --- | --- |
+| getAuthor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### setAuthor{#setAuthor}
+
+| Nombre | Descripción |
+| --- | --- |
+| setAuthor(value) |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getCreationTime{#getCreationTime}
+
+| Nombre | Descripción |
+| --- | --- |
+| getCreationTime() | La marca de tiempo que exportó este archivo, el valor predeterminado es la hora actual. |
+
+ **Result:**
+
+
+
+---
+
+
+### setCreationTime{#setCreationTime}
+
+| Nombre | Descripción |
+| --- | --- |
+| setCreationTime(value) | La marca de tiempo que exportó este archivo, el valor predeterminado es la hora actual. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAttributePrefix{#getAttributePrefix}
+
+| Nombre | Descripción |
+| --- | --- |
+| getAttributePrefix() | Obtiene o establece el prefijo de los atributos que se exportarán, la propiedad exportada no contendrá prefijo, las propiedades personalizadas con un prefijo diferente no se exportarán, el valor predeterminado es 'rvm:'. Por ejemplo, si una propiedad es rvm:Refno=345, el atributo exportado será Refno = 345, el prefijo se elimina. |
+
+ **Result:**
+
+
+
+---
+
+
+### setAttributePrefix{#setAttributePrefix}
+
+| Nombre | Descripción |
+| --- | --- |
+| setAttributePrefix(value) | Obtiene o establece el prefijo de los atributos que se exportarán, la propiedad exportada no contendrá prefijo, las propiedades personalizadas con un prefijo diferente no se exportarán, el valor predeterminado es 'rvm:'. Por ejemplo, si una propiedad es rvm:Refno=345, el atributo exportado será Refno = 345, el prefijo se elimina. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAttributeListFile{#getAttributeListFile}
+
+| Nombre | Descripción |
+| --- | --- |
+| getAttributeListFile() | Obtiene o establece el nombre de archivo de la lista de atributos, el exportador generará un nombre basado en el nombre del archivo .rvm cuando esta propiedad no esté definida, el valor predeterminado es null. |
+
+ **Result:**
+
+
+
+---
+
+
+### setAttributeListFile{#setAttributeListFile}
+
+| Nombre | Descripción |
+| --- | --- |
+| setAttributeListFile(value) | Obtiene o establece el nombre de archivo de la lista de atributos, el exportador generará un nombre basado en el nombre del archivo .rvm cuando esta propiedad no esté definida, el valor predeterminado es null. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportAttributes{#getExportAttributes}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExportAttributes() | Obtiene o establece si se debe exportar la lista de atributos a un archivo .att externo, el valor predeterminado es false. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportAttributes{#setExportAttributes}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExportAttributes(value) | Obtiene o establece si se debe exportar la lista de atributos a un archivo .att externo, el valor predeterminado es false. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportTextures{#getExportTextures}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExportTextures() | Intenta copiar las texturas usadas en la escena al directorio de salida. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextures{#setExportTextures}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExportTextures(value) | Intenta copiar las texturas usadas en la escena al directorio de salida. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileFormat() | Obtiene el formato de archivo especificado en la opción actual de Guardar/Cargar. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEncoding() | Obtiene o establece la codificación predeterminada para archivos basados en texto. El valor predeterminado es null, lo que significa que el importador/exportador decidirá qué codificación usar. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileSystem() | Permite al usuario manejar cómo gestionar las dependencias externas durante la carga/guardado. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFileSystem(value) | Permite al usuario manejar cómo gestionar las dependencias externas durante la carga/guardado. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| Nombre | Descripción |
+| --- | --- |
+| getLookupPaths() | Algunos archivos como OBJ dependen de archivos externos; las rutas de búsqueda permiten que Aspose.3D busque el archivo externo para cargarlo. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileName() | El nombre de archivo de la escena de exportación/importación. Es opcional, pero útil al serializar recursos externos como el material de OBJ. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFileName(value) | El nombre de archivo de la escena de exportación/importación. Es opcional, pero útil al serializar recursos externos como el material de OBJ. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/saveoptions/_index.md
+++ b/spanish/nodejs-java/aspose.threed/saveoptions/_index.md
@@ -1,0 +1,133 @@
+---
+title: "SaveOptions"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/saveoptions/
+---
+## SaveOptions class
+
+La clase base para configurar opciones al guardar archivos para diferentes tipos  @hideconstructor
+
+
+## Métodos
+
+### getExportTextures{#getExportTextures}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExportTextures() | Intenta copiar las texturas usadas en la escena al directorio de salida. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextures{#setExportTextures}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExportTextures(value) | Intenta copiar las texturas usadas en la escena al directorio de salida. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileFormat() | Obtiene el formato de archivo especificado en la opción actual de Guardar/Cargar. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEncoding() | Obtiene o establece la codificación predeterminada para archivos basados en texto. El valor predeterminado es null, lo que significa que el importador/exportador decidirá qué codificación usar. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileSystem() | Permite al usuario manejar cómo gestionar las dependencias externas durante la carga/guardado. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFileSystem(value) | Permite al usuario manejar cómo gestionar las dependencias externas durante la carga/guardado. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| Nombre | Descripción |
+| --- | --- |
+| getLookupPaths() | Algunos archivos como OBJ dependen de archivos externos; las rutas de búsqueda permiten que Aspose.3D busque el archivo externo para cargarlo. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileName() | El nombre de archivo de la escena de exportación/importación. Es opcional, pero útil al serializar recursos externos como el material de OBJ. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFileName(value) | El nombre de archivo de la escena de exportación/importación. Es opcional, pero útil al serializar recursos externos como el material de OBJ. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/scene/_index.md
+++ b/spanish/nodejs-java/aspose.threed/scene/_index.md
@@ -1,0 +1,626 @@
+---
+title: "Scene"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/scene/
+---
+## Scene class
+
+Una escena es un objeto de nivel superior que contiene los nodos, geometrías, materiales, texturas, animaciones, poses, sub-escenas, etc.  La escena puede tener sub-escenas, funciona como soporte de múltiples documentos en archivos como collada/blender/fbx.  La jerarquía de nodos se puede acceder a través de RootNodeLibrary, que se utiliza para mantener una referencia de objetos no adjuntos durante la serialización (como metadatos u objetos personalizados) para que pueda usarse como una biblioteca.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Inicializa una nueva instancia de la clase Scene. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload(entity) | Inicializa una nueva instancia de la clase Scene con una entidad adjunta a un nuevo nodo. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| entidad | Entidad | La entidad inicial que se adjuntó a la escena |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload2(parentScene, name) | Inicializa una nueva instancia de la clase Scene como una subescena. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| parentScene | Scene | La escena padre. |
+| name | Cadena | Nombre de la escena. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload3{#constructor_overload3}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload3(fileName) | Inicializa una nueva instancia de la clase Scene y abre el archivo inmediatamente. Este es un constructor obsoleto, por favor use #Error Cref: M:Aspose.ThreeD.Scene.FromFile(System.String,System.Threading.CancellationToken). |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| fileName | Cadena | Nombre del archivo a abrir. |
+
+ **Result:**
+
+
+
+---
+
+
+### getSubScenes{#getSubScenes}
+
+| Nombre | Descripción |
+| --- | --- |
+| getSubScenes() | Obtiene todas las subescenas |
+
+ **Result:**
+
+
+
+---
+
+
+### getLibrary{#getLibrary}
+
+| Nombre | Descripción |
+| --- | --- |
+| getLibrary() | Los objetos que no se usan directamente en la jerarquía de la escena pueden definirse en Library. Esto es útil cuando utilizas subescenas y colocas componentes reutilizables bajo subescenas. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAnimationClips{#getAnimationClips}
+
+| Nombre | Descripción |
+| --- | --- |
+| getAnimationClips() | Obtiene todos los AnimationClip definidos en la escena. |
+
+ **Result:**
+
+
+
+---
+
+
+### getCurrentAnimationClip{#getCurrentAnimationClip}
+
+| Nombre | Descripción |
+| --- | --- |
+| getCurrentAnimationClip() | Obtiene o establece el AnimationClip activo |
+
+ **Result:**
+
+
+
+---
+
+
+### setCurrentAnimationClip{#setCurrentAnimationClip}
+
+| Nombre | Descripción |
+| --- | --- |
+| setCurrentAnimationClip(value) | Obtiene o establece el AnimationClip activo |
+
+ **Result:**
+
+
+
+---
+
+
+### getAssetInfo{#getAssetInfo}
+
+| Nombre | Descripción |
+| --- | --- |
+| getAssetInfo() | Obtiene o establece la información del activo de nivel superior, la información del documento. |
+
+ **Result:**
+
+
+
+---
+
+
+### setAssetInfo{#setAssetInfo}
+
+| Nombre | Descripción |
+| --- | --- |
+| setAssetInfo(value) | Obtiene o establece la información del activo de nivel superior, la información del documento. |
+
+ **Result:**
+
+
+
+---
+
+
+### getPoses{#getPoses}
+
+| Nombre | Descripción |
+| --- | --- |
+| getPoses() | Obtiene todas las Pose usadas en esta escena. Las poses. |
+
+ **Result:**
+
+
+
+---
+
+
+### getRootNode{#getRootNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getRootNode() | Obtiene el nodo raíz de la escena. El nodo raíz. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Nombre | Descripción |
+| --- | --- |
+| getScene() | Obtiene la escena a la que pertenece este objeto |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAnimationClip{#getAnimationClip}
+
+| Nombre | Descripción |
+| --- | --- |
+| getAnimationClip(name) | Obtiene un AnimationClip con nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| name | Cadena | El |
+
+ **Result:**
+AnimationClip
+
+
+---
+
+
+### clear{#clear}
+
+| Nombre | Descripción |
+| --- | --- |
+| clear() | Borra el contenido de la escena y restaura la configuración predeterminada. |
+
+ **Result:**
+AnimationClip
+
+
+---
+
+
+### createAnimationClip{#createAnimationClip}
+
+| Nombre | Descripción |
+| --- | --- |
+| createAnimationClip(name) | Una función abreviada para crear y registrar el AnimationClip. El primer AnimationClip será asignado al CurrentAnimationClip |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| name | Cadena | Nombre del clip de animación |
+
+ **Result:**
+AnimationClip
+
+
+---
+
+
+### open{#open}
+
+| Nombre | Descripción |
+| --- | --- |
+| open(fileName, options) | Abre la escena desde la ruta especificada usando el formato de archivo indicado. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| fileName | Cadena | Nombre del archivo. |
+| opciones | LoadOptions | Configuración más detallada para abrir el flujo. |
+
+ **Result:**
+AnimationClip
+
+
+---
+
+
+### open{#open}
+
+| Nombre | Descripción |
+| --- | --- |
+| open(fileName) | Abre la escena desde la ruta especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| fileName | Cadena | Nombre del archivo. |
+
+ **Result:**
+AnimationClip
+
+
+---
+
+
+### fromFile{#fromFile}
+
+| Nombre | Descripción |
+| --- | --- |
+| fromFile(fileName) | Abre la escena desde la ruta especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| fileName | Cadena | Nombre del archivo. |
+
+ **Result:**
+AnimationClip
+
+
+---
+
+
+### save{#save}
+
+| Nombre | Descripción |
+| --- | --- |
+| save(fileName) | Guarda la escena en la ruta especificada usando el formato de archivo indicado. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| fileName | Cadena | Nombre del archivo. |
+
+ **Result:**
+AnimationClip
+
+
+---
+
+
+### save{#save}
+
+| Nombre | Descripción |
+| --- | --- |
+| save(fileName, format) | Guarda la escena en la ruta especificada usando el formato de archivo indicado. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| fileName | Cadena | Nombre del archivo. |
+| format | FileFormat | Formato. |
+
+ **Result:**
+AnimationClip
+
+
+---
+
+
+### save{#save}
+
+| Nombre | Descripción |
+| --- | --- |
+| save(fileName, options) | Guarda la escena en la ruta especificada usando el formato de archivo indicado. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| fileName | Cadena | Nombre del archivo. |
+| opciones | SaveOptions | Configuración más detallada para guardar el flujo. |
+
+ **Result:**
+AnimationClip
+
+
+---
+
+
+### render{#render}
+
+| Nombre | Descripción |
+| --- | --- |
+| render(camera, fileName) | Renderiza la escena a un archivo externo desde la perspectiva de la cámara dada. El tamaño de salida predeterminado es 1024x768 y el formato de salida es png. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| cámara | Cámara | Desde la perspectiva de cuál cámara renderizar la escena |
+| fileName | Cadena | El nombre del archivo de salida |
+
+ **Result:**
+AnimationClip
+
+
+---
+
+
+### render{#render}
+
+| Nombre | Descripción |
+| --- | --- |
+| render(camera, fileName, size, format) | Renderiza la escena a un archivo externo desde la perspectiva de la cámara dada. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| cámara | Cámara | Desde la perspectiva de cuál cámara renderizar la escena |
+| fileName | Cadena | El nombre del archivo de salida |
+| tamaño | Vector2 | El tamaño de la imagen renderizada final |
+| format | Cadena | El formato de imagen del archivo de salida |
+
+ **Result:**
+AnimationClip
+
+
+---
+
+
+### render{#render}
+
+| Nombre | Descripción |
+| --- | --- |
+| render(camera, fileName, size, format, options) | Renderiza la escena a un archivo externo desde la perspectiva de la cámara dada. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| cámara | Cámara | Desde la perspectiva de cuál cámara renderizar la escena |
+| fileName | Cadena | El nombre del archivo de salida |
+| tamaño | Vector2 | El tamaño de la imagen renderizada final |
+| format | Cadena | El formato de imagen del archivo de salida |
+| opciones | ImageRenderOptions | La opción de personalizar algunos ajustes internos. |
+
+ **Result:**
+AnimationClip
+
+
+---
+
+
+### render{#render}
+
+| Nombre | Descripción |
+| --- | --- |
+| render(camera, bitmap) | Renderiza la escena en un bitmap desde la perspectiva de la cámara dada. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| cámara | Cámara | Desde la perspectiva de cuál cámara renderizar la escena |
+| bitmap | TextureData | Objetivo del resultado renderizado |
+
+ **Result:**
+AnimationClip
+
+
+---
+
+
+### render{#render}
+
+| Nombre | Descripción |
+| --- | --- |
+| render(camera, bitmap, options) | Renderiza la escena en un bitmap desde la perspectiva de la cámara dada. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| cámara | Cámara | Desde la perspectiva de cuál cámara renderizar la escena |
+| bitmap | TextureData | Objetivo del resultado renderizado |
+| opciones | ImageRenderOptions | La opción de personalizar algunos ajustes internos. |
+
+ **Result:**
+AnimationClip
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/sceneobject/_index.md
+++ b/spanish/nodejs-java/aspose.threed/sceneobject/_index.md
@@ -1,0 +1,196 @@
+---
+title: "SceneObject"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/sceneobject/
+---
+## SceneObject class
+
+La clase raíz de los objetos que se almacenarán dentro de una escena.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor(name) | Inicializa un SceneObject con un nombre predeterminado |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| name | Cadena | El nombre de esta instancia |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload() | Inicializa un SceneObject. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Nombre | Descripción |
+| --- | --- |
+| getScene() | Obtiene la escena a la que pertenece este objeto |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/shaderexception/_index.md
+++ b/spanish/nodejs-java/aspose.threed/shaderexception/_index.md
@@ -1,0 +1,35 @@
+---
+title: "ShaderException"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/shaderexception/
+---
+## ShaderException class
+
+Excepciones relacionadas con shaders
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor(message) | Constructor de ShaderException |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| messag | Cadena | null |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/shadermaterial/_index.md
+++ b/spanish/nodejs-java/aspose.threed/shadermaterial/_index.md
@@ -1,0 +1,261 @@
+---
+title: "ShaderMaterial"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/shadermaterial/
+---
+## ShaderMaterial class
+
+Un material de shader permite describir el material mediante un motor de renderizado externo o un lenguaje de shader.  ShaderMaterial usa ShaderTechnique para describir los detalles concretos de renderizado, y se utilizará el más adecuado según la plataforma de renderizado final.  Por ejemplo, su instancia de ShaderMaterial puede tener dos técnicas, una definida por HLSL y otra definida por GLSL.  En plataformas sin ventana, se debe usar GLSL en lugar de HLSL.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Inicializa una nueva instancia de la clase ShaderMaterial. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload(name) | Inicializa una nueva instancia de la clase ShaderMaterial. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| name | Cadena | Nombre |
+
+ **Result:**
+
+
+
+---
+
+
+### getTechniques{#getTechniques}
+
+| Nombre | Descripción |
+| --- | --- |
+| getTechniques() | Obtiene todas las técnicas disponibles definidas en este material. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTexture{#getTexture}
+
+| Nombre | Descripción |
+| --- | --- |
+| getTexture(slotName) | Obtiene la textura del slot especificado, puede ser el nombre de una propiedad del material o el nombre de un parámetro del shader |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| slotName | Cadena | Nombre del slot. |
+
+ **Result:**
+TextureBase
+
+
+---
+
+
+### setTexture{#setTexture}
+
+| Nombre | Descripción |
+| --- | --- |
+| setTexture(slotName, texture) | Establece la textura al slot especificado |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| slotName | Cadena | Nombre del slot. |
+| texture | TextureBase | Textura. |
+
+ **Result:**
+TextureBase
+
+
+---
+
+
+### toString{#toString}
+
+| Nombre | Descripción |
+| --- | --- |
+| toString() | Formatea el objeto a cadena |
+
+ **Result:**
+Cadena
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+### iterator{#iterator}
+
+| Nombre | Descripción |
+| --- | --- |
+| iterator() | Reservado para uso interno. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/shaderprogram/_index.md
+++ b/spanish/nodejs-java/aspose.threed/shaderprogram/_index.md
@@ -1,0 +1,13 @@
+---
+title: "ShaderProgram"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/shaderprogram/
+---
+## ShaderProgram class
+
+El programa de shader  @hideconstructor
+
+

--- a/spanish/nodejs-java/aspose.threed/shaderset/_index.md
+++ b/spanish/nodejs-java/aspose.threed/shaderset/_index.md
@@ -1,0 +1,133 @@
+---
+title: "ShaderSet"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/shaderset/
+---
+## ShaderSet class
+
+Programas de shader para cada tipo de material
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Construye la instancia de ShaderSet |
+
+ **Result:**
+
+
+
+---
+
+
+### getLambert{#getLambert}
+
+| Nombre | Descripción |
+| --- | --- |
+| getLambert() | Obtiene o establece el shader que se usa para renderizar el material lambert |
+
+ **Result:**
+
+
+
+---
+
+
+### setLambert{#setLambert}
+
+| Nombre | Descripción |
+| --- | --- |
+| setLambert(value) | Obtiene o establece el shader que se usa para renderizar el material lambert |
+
+ **Result:**
+
+
+
+---
+
+
+### getPhong{#getPhong}
+
+| Nombre | Descripción |
+| --- | --- |
+| getPhong() | Obtiene o establece el shader que se usa para renderizar el material phong |
+
+ **Result:**
+
+
+
+---
+
+
+### setPhong{#setPhong}
+
+| Nombre | Descripción |
+| --- | --- |
+| setPhong(value) | Obtiene o establece el shader que se usa para renderizar el material phong |
+
+ **Result:**
+
+
+
+---
+
+
+### getPbr{#getPbr}
+
+| Nombre | Descripción |
+| --- | --- |
+| getPbr() | Obtiene o establece el shader que se usa para renderizar el material PBR |
+
+ **Result:**
+
+
+
+---
+
+
+### setPbr{#setPbr}
+
+| Nombre | Descripción |
+| --- | --- |
+| setPbr(value) | Obtiene o establece el shader que se usa para renderizar el material PBR |
+
+ **Result:**
+
+
+
+---
+
+
+### getFallback{#getFallback}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFallback() | Obtiene o establece el shader de reserva cuando el shader requerido no está disponible |
+
+ **Result:**
+
+
+
+---
+
+
+### setFallback{#setFallback}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFallback(value) | Obtiene o establece el shader de reserva cuando el shader requerido no está disponible |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/shadersource/_index.md
+++ b/spanish/nodejs-java/aspose.threed/shadersource/_index.md
@@ -1,0 +1,13 @@
+---
+title: "ShaderSource"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/shadersource/
+---
+## ShaderSource class
+
+El código fuente del shader  @hideconstructor
+
+

--- a/spanish/nodejs-java/aspose.threed/shadertechnique/_index.md
+++ b/spanish/nodejs-java/aspose.threed/shadertechnique/_index.md
@@ -1,0 +1,270 @@
+---
+title: "ShaderTechnique"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/shadertechnique/
+---
+## ShaderTechnique class
+
+Una técnica de shader representa una implementación concreta de renderizado.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Inicializa una nueva instancia de la clase ShaderTechnique. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDescription{#getDescription}
+
+| Nombre | Descripción |
+| --- | --- |
+| getDescription() | Obtiene o establece la descripción de esta técnica |
+
+ **Result:**
+
+
+
+---
+
+
+### setDescription{#setDescription}
+
+| Nombre | Descripción |
+| --- | --- |
+| setDescription(value) | Obtiene o establece la descripción de esta técnica |
+
+ **Result:**
+
+
+
+---
+
+
+### getShaderLanguage{#getShaderLanguage}
+
+| Nombre | Descripción |
+| --- | --- |
+| getShaderLanguage() | Obtiene o establece el lenguaje del shader usado por esta técnica. |
+
+ **Result:**
+
+
+
+---
+
+
+### setShaderLanguage{#setShaderLanguage}
+
+| Nombre | Descripción |
+| --- | --- |
+| setShaderLanguage(value) | Obtiene o establece el lenguaje del shader usado por esta técnica. |
+
+ **Result:**
+
+
+
+---
+
+
+### getShaderVersion{#getShaderVersion}
+
+| Nombre | Descripción |
+| --- | --- |
+| getShaderVersion() | Obtiene o establece la versión del shader usada por esta técnica. |
+
+ **Result:**
+
+
+
+---
+
+
+### setShaderVersion{#setShaderVersion}
+
+| Nombre | Descripción |
+| --- | --- |
+| setShaderVersion(value) | Obtiene o establece la versión del shader usada por esta técnica. |
+
+ **Result:**
+
+
+
+---
+
+
+### getShaderFile{#getShaderFile}
+
+| Nombre | Descripción |
+| --- | --- |
+| getShaderFile() | Obtiene o establece el nombre de archivo del shader externo. |
+
+ **Result:**
+
+
+
+---
+
+
+### setShaderFile{#setShaderFile}
+
+| Nombre | Descripción |
+| --- | --- |
+| setShaderFile(value) | Obtiene o establece el nombre de archivo del shader externo. |
+
+ **Result:**
+
+
+
+---
+
+
+### getShaderContent{#getShaderContent}
+
+| Nombre | Descripción |
+| --- | --- |
+| getShaderContent() | Obtiene o establece el contenido de un script de shader incrustado. Puede ser un archivo fuente de shader HLSL/GLSL. |
+
+ **Result:**
+
+
+
+---
+
+
+### setShaderContent{#setShaderContent}
+
+| Nombre | Descripción |
+| --- | --- |
+| setShaderContent(value) | Obtiene o establece el contenido de un script de shader incrustado. Puede ser un archivo fuente de shader HLSL/GLSL. |
+
+ **Result:**
+
+
+
+---
+
+
+### getShaderEntry{#getShaderEntry}
+
+| Nombre | Descripción |
+| --- | --- |
+| getShaderEntry() | Obtiene o establece el punto de entrada del shader; algunos shaders como HLSL pueden tener entradas de shader personalizadas. |
+
+ **Result:**
+
+
+
+---
+
+
+### setShaderEntry{#setShaderEntry}
+
+| Nombre | Descripción |
+| --- | --- |
+| setShaderEntry(value) | Obtiene o establece el punto de entrada del shader; algunos shaders como HLSL pueden tener entradas de shader personalizadas. |
+
+ **Result:**
+
+
+
+---
+
+
+### getRenderAPI{#getRenderAPI}
+
+| Nombre | Descripción |
+| --- | --- |
+| getRenderAPI() | Obtiene o establece la API de renderizado usada por esta técnica |
+
+ **Result:**
+
+
+
+---
+
+
+### setRenderAPI{#setRenderAPI}
+
+| Nombre | Descripción |
+| --- | --- |
+| setRenderAPI(value) | Obtiene o establece la API de renderizado usada por esta técnica |
+
+ **Result:**
+
+
+
+---
+
+
+### getRenderAPIVersion{#getRenderAPIVersion}
+
+| Nombre | Descripción |
+| --- | --- |
+| getRenderAPIVersion() | Obtiene o establece la versión de la API de renderizado. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRenderAPIVersion{#setRenderAPIVersion}
+
+| Nombre | Descripción |
+| --- | --- |
+| setRenderAPIVersion(value) | Obtiene o establece la versión de la API de renderizado. |
+
+ **Result:**
+
+
+
+---
+
+
+### getShaderParameters{#getShaderParameters}
+
+| Nombre | Descripción |
+| --- | --- |
+| getShaderParameters() | Obtiene la definición del parámetro del shader. La clave es el nombre de la propiedad dinámica, y el valor es el nombre del parámetro del shader al que está conectada la propiedad. |
+
+ **Result:**
+
+
+
+---
+
+
+### addBinding{#addBinding}
+
+| Nombre | Descripción |
+| --- | --- |
+| addBinding(property, shaderParameter) | Vincula la propiedad dinámica al parámetro del shader |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | El nombre de la propiedad dinámica. |
+| shaderParameter | Cadena | El nombre del parámetro del shader. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/shadervariable/_index.md
+++ b/spanish/nodejs-java/aspose.threed/shadervariable/_index.md
@@ -1,0 +1,68 @@
+---
+title: "ShaderVariable"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/shadervariable/
+---
+## ShaderVariable class
+
+Variable de shader
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor(name) | Constructor de ShaderVariable |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| nam | Cadena | null |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload(name, shaderStage) | Constructor de ShaderVariable |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| nam | Cadena | null |
+| shaderStage | Número | ShaderStage |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene el nombre de esta variable |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/shape/_index.md
+++ b/spanish/nodejs-java/aspose.threed/shape/_index.md
@@ -1,0 +1,573 @@
+---
+title: "Forma"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/shape/
+---
+## Shape class
+
+La forma describe la deformación en un conjunto de puntos de control, lo cual es similar al deformador de clúster en Maya.  Por ejemplo, podemos añadir una forma a una geometría creada.  Y la forma y la geometría tienen la misma información topológica pero diferentes posiciones de los puntos de control.  Con diferentes niveles de influencia, la geometría produce un efecto de deformación.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Inicializa una nueva instancia de la clase Shape. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload(name) | Inicializa una nueva instancia de la clase Shape. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| name | Cadena | Nombre |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| Nombre | Descripción |
+| --- | --- |
+| getIndices() | Obtiene los índices. Los índices. |
+
+ **Result:**
+
+
+
+---
+
+
+### getVisible{#getVisible}
+
+| Nombre | Descripción |
+| --- | --- |
+| getVisible() | Obtiene o establece si la geometría es visible |
+
+ **Result:**
+
+
+
+---
+
+
+### setVisible{#setVisible}
+
+| Nombre | Descripción |
+| --- | --- |
+| setVisible(value) | Obtiene o establece si la geometría es visible |
+
+ **Result:**
+
+
+
+---
+
+
+### getDeformers{#getDeformers}
+
+| Nombre | Descripción |
+| --- | --- |
+| getDeformers() | Obtiene todos los deformadores asociados con esta geometría. Los deformadores. |
+
+ **Result:**
+
+
+
+---
+
+
+### getControlPoints{#getControlPoints}
+
+| Nombre | Descripción |
+| --- | --- |
+| getControlPoints() | Obtiene todos los puntos de control |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastShadows{#getCastShadows}
+
+| Nombre | Descripción |
+| --- | --- |
+| getCastShadows() | Obtiene o establece si esta geometría puede proyectar sombra |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastShadows{#setCastShadows}
+
+| Nombre | Descripción |
+| --- | --- |
+| setCastShadows(value) | Obtiene o establece si esta geometría puede proyectar sombra |
+
+ **Result:**
+
+
+
+---
+
+
+### getReceiveShadows{#getReceiveShadows}
+
+| Nombre | Descripción |
+| --- | --- |
+| getReceiveShadows() | Obtiene o establece si esta geometría puede recibir sombra. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReceiveShadows{#setReceiveShadows}
+
+| Nombre | Descripción |
+| --- | --- |
+| setReceiveShadows(value) | Obtiene o establece si esta geometría puede recibir sombra. |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElements{#getVertexElements}
+
+| Nombre | Descripción |
+| --- | --- |
+| getVertexElements() | Obtiene todos los elementos de vértice |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNodes() | Obtiene todos los nodos padre; una entidad puede estar adjunta a varios nodos padre para la instanciación de geometría. Los nodos. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExcluded() | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExcluded(value) | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNode() | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setParentNode(value) | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Nombre | Descripción |
+| --- | --- |
+| getScene() | Obtiene la escena a la que pertenece este objeto |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### fromControlPoints{#fromControlPoints}
+
+| Nombre | Descripción |
+| --- | --- |
+| fromControlPoints(controlPoints) | Crea una forma con puntos de control especificados con índices predeterminados. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| controlPoint | Vector3[] | null |
+
+ **Result:**
+Forma
+
+
+---
+
+
+### getElement{#getElement}
+
+| Nombre | Descripción |
+| --- | --- |
+| getElement(type) | Obtiene un elemento de vértice con el tipo especificado |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| type | VertexElementType | VertexElementType |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### getVertexElementOfUV{#getVertexElementOfUV}
+
+| Nombre | Descripción |
+| --- | --- |
+| getVertexElementOfUV(textureMapping) | Obtiene una instancia de VertexElementUV con el tipo de TextureMapping dado |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| textureMapping | TextureMapping | TextureMapping |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### createElement{#createElement}
+
+| Nombre | Descripción |
+| --- | --- |
+| createElement(type) | Crea un elemento de vértice con el tipo especificado y lo agrega a la geometría. Si el tipo es VertexElementType.UV, se creará un VertexElementUV con el tipo de mapeo de textura a TextureMapping.DIFFUSE. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| type | VertexElementType | VertexElementType |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### addElement{#addElement}
+
+| Nombre | Descripción |
+| --- | --- |
+| addElement(element) | Agrega un elemento de vértice existente a la geometría actual |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| element | VertexElement | El elemento de vértice a agregar |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### createElement{#createElement}
+
+| Nombre | Descripción |
+| --- | --- |
+| createElement(type, mappingMode, referenceMode) | Crea un elemento de vértice con el tipo especificado y lo agrega a la geometría. Si el tipo es VertexElementType.UV, se creará un VertexElementUV con el tipo de mapeo de textura a TextureMapping.DIFFUSE. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| type | VertexElementType | VertexElementType |
+| mappingMode | MappingMode | MappingMode |
+| referenceMode | ReferenceMode | ReferenceMode |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### createElementUV{#createElementUV}
+
+| Nombre | Descripción |
+| --- | --- |
+| createElementUV(uvMapping) | Crea un VertexElementUV con el tipo de mapeo de textura dado. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| uvMapping | TextureMapping | TextureMapping |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### createElementUV{#createElementUV}
+
+| Nombre | Descripción |
+| --- | --- |
+| createElementUV(uvMapping, mappingMode, referenceMode) | Crea un VertexElementUV con el tipo de mapeo de textura dado. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| uvMapping | TextureMapping | TextureMapping |
+| mappingMode | MappingMode | MappingMode |
+| referenceMode | ReferenceMode | ReferenceMode |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBoundingBox() | Obtiene el cuadro delimitador de la entidad actual en su sistema de coordenadas de espacio de objeto. |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEntityRendererKey() | Obtiene la clave del renderizador de entidad registrado en el renderizador |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/skeleton/_index.md
+++ b/spanish/nodejs-java/aspose.threed/skeleton/_index.md
@@ -1,0 +1,339 @@
+---
+title: "Esqueleto"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/skeleton/
+---
+## Skeleton class
+
+El esqueleto se usa principalmente en software CAD para ayudar al diseñador a manipular la transformación de la estructura esquelética; suele ser inútil fuera de los softwares CAD. Para que la jerarquía del esqueleto actúe como un solo objeto en el software CAD, es necesario marcar el nodo superior del Skeleton como la raíz estableciendo Type a SkeletonType.SKELETON, y todos los hijos a SkeletonType.BONE.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Inicializa una nueva instancia de la clase Skeleton. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload(name) | Inicializa una nueva instancia de la clase Skeleton. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| name | Cadena | Nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getSize{#getSize}
+
+| Nombre | Descripción |
+| --- | --- |
+| getSize() | Obtiene o establece el tamaño del nodo de extremidad que se usa en el software CAD para representar el tamaño del hueso. |
+
+ **Result:**
+
+
+
+---
+
+
+### setSize{#setSize}
+
+| Nombre | Descripción |
+| --- | --- |
+| setSize(value) | Obtiene o establece el tamaño del nodo de extremidad que se usa en el software CAD para representar el tamaño del hueso. |
+
+ **Result:**
+
+
+
+---
+
+
+### getType{#getType}
+
+| Nombre | Descripción |
+| --- | --- |
+| getType() | Obtiene o establece el tipo del esqueleto. El valor de la propiedad es la constante entera SkeletonType. El tipo del esqueleto. |
+
+ **Result:**
+
+
+
+---
+
+
+### setType{#setType}
+
+| Nombre | Descripción |
+| --- | --- |
+| setType(value) | Obtiene o establece el tipo del esqueleto. El valor de la propiedad es la constante entera SkeletonType. El tipo del esqueleto. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNodes() | Obtiene todos los nodos padre; una entidad puede estar adjunta a varios nodos padre para la instanciación de geometría. Los nodos. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExcluded() | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExcluded(value) | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNode() | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setParentNode(value) | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Nombre | Descripción |
+| --- | --- |
+| getScene() | Obtiene la escena a la que pertenece este objeto |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBoundingBox() | Obtiene el cuadro delimitador de la entidad actual en su sistema de coordenadas de espacio de objeto. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEntityRendererKey() | Obtiene la clave del renderizador de entidad registrado en el renderizador |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/skindeformer/_index.md
+++ b/spanish/nodejs-java/aspose.threed/skindeformer/_index.md
@@ -1,0 +1,209 @@
+---
+title: "SkinDeformer"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/skindeformer/
+---
+## SkinDeformer class
+
+Un deformador de piel contiene múltiples huesos para trabajar, cada hueso mezcla una parte de la geometría mediante los pesos de los puntos de control.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor(name) | Inicializa una nueva instancia de la clase SkinDeformer. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| name | Cadena | Nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload() | Inicializa una nueva instancia de la clase SkinDeformer. |
+
+ **Result:**
+
+
+
+---
+
+
+### getBones{#getBones}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBones() | Obtiene todos los huesos que contiene el deformer de piel |
+
+ **Result:**
+
+
+
+---
+
+
+### getOwner{#getOwner}
+
+| Nombre | Descripción |
+| --- | --- |
+| getOwner() | Obtiene la geometría que posee este deformer |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/sphere/_index.md
+++ b/spanish/nodejs-java/aspose.threed/sphere/_index.md
@@ -1,0 +1,581 @@
+---
+title: "Esfera"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/sphere/
+---
+## Sphere class
+
+Esfera parametrizada.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Inicializa una nueva instancia de Sphere con radio predeterminado 1. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload(radius) | Inicializa una nueva instancia de la clase Sphere con el radio especificado. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| radius | Número | Radio. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload2(radius, widthSegments, heightSegments) | Inicializa una nueva instancia de la clase Sphere con el radio especificado, los segmentos de ancho y los segmentos de altura. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| radius | Número | Radio de la esfera. |
+| widthSegments | Número | Segmentos de ancho. |
+| heightSegments | Número | Segmentos de altura. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload3{#constructor_overload3}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload3(name, radius, widthSegments, heightSegments, phiStart, phiLength, thetaStart, thetaLength) | Inicializa una nueva instancia de la clase Sphere. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| name | Cadena | Nombre. |
+| radius | Número | Radio de la esfera. |
+| widthSegments | Número | Segmentos de ancho. |
+| heightSegments | Número | Segmentos de altura. |
+| phiStart | Número | Inicio de Phi. |
+| phiLength | Número | Longitud de Phi. |
+| thetaStart | Número | Inicio de Theta. |
+| thetaLength | Número | Longitud de Theta. |
+
+ **Result:**
+
+
+
+---
+
+
+### getWidthSegments{#getWidthSegments}
+
+| Nombre | Descripción |
+| --- | --- |
+| getWidthSegments() | Obtiene o establece los segmentos de ancho. Los segmentos de ancho. |
+
+ **Result:**
+
+
+
+---
+
+
+### setWidthSegments{#setWidthSegments}
+
+| Nombre | Descripción |
+| --- | --- |
+| setWidthSegments(value) | Obtiene o establece los segmentos de ancho. Los segmentos de ancho. |
+
+ **Result:**
+
+
+
+---
+
+
+### getHeightSegments{#getHeightSegments}
+
+| Nombre | Descripción |
+| --- | --- |
+| getHeightSegments() | Obtiene o establece los segmentos de altura. Los segmentos de altura. |
+
+ **Result:**
+
+
+
+---
+
+
+### setHeightSegments{#setHeightSegments}
+
+| Nombre | Descripción |
+| --- | --- |
+| setHeightSegments(value) | Obtiene o establece los segmentos de altura. Los segmentos de altura. |
+
+ **Result:**
+
+
+
+---
+
+
+### getPhiStart{#getPhiStart}
+
+| Nombre | Descripción |
+| --- | --- |
+| getPhiStart() | Obtiene o establece el inicio phi. El inicio phi. |
+
+ **Result:**
+
+
+
+---
+
+
+### setPhiStart{#setPhiStart}
+
+| Nombre | Descripción |
+| --- | --- |
+| setPhiStart(value) | Obtiene o establece el inicio phi. El inicio phi. |
+
+ **Result:**
+
+
+
+---
+
+
+### getPhiLength{#getPhiLength}
+
+| Nombre | Descripción |
+| --- | --- |
+| getPhiLength() | Obtiene o establece la longitud del phi. La longitud del phi. |
+
+ **Result:**
+
+
+
+---
+
+
+### setPhiLength{#setPhiLength}
+
+| Nombre | Descripción |
+| --- | --- |
+| setPhiLength(value) | Obtiene o establece la longitud del phi. La longitud del phi. |
+
+ **Result:**
+
+
+
+---
+
+
+### getThetaStart{#getThetaStart}
+
+| Nombre | Descripción |
+| --- | --- |
+| getThetaStart() | Obtiene o establece el inicio theta. El inicio theta. |
+
+ **Result:**
+
+
+
+---
+
+
+### setThetaStart{#setThetaStart}
+
+| Nombre | Descripción |
+| --- | --- |
+| setThetaStart(value) | Obtiene o establece el inicio theta. El inicio theta. |
+
+ **Result:**
+
+
+
+---
+
+
+### getThetaLength{#getThetaLength}
+
+| Nombre | Descripción |
+| --- | --- |
+| getThetaLength() | Obtiene o establece la longitud del theta. La longitud del theta. |
+
+ **Result:**
+
+
+
+---
+
+
+### setThetaLength{#setThetaLength}
+
+| Nombre | Descripción |
+| --- | --- |
+| setThetaLength(value) | Obtiene o establece la longitud del theta. La longitud del theta. |
+
+ **Result:**
+
+
+
+---
+
+
+### getRadius{#getRadius}
+
+| Nombre | Descripción |
+| --- | --- |
+| getRadius() | Obtiene o establece el radio de la esfera. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRadius{#setRadius}
+
+| Nombre | Descripción |
+| --- | --- |
+| setRadius(value) | Obtiene o establece el radio de la esfera. |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastShadows{#getCastShadows}
+
+| Nombre | Descripción |
+| --- | --- |
+| getCastShadows() | Obtiene o establece si esta geometría puede proyectar sombra |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastShadows{#setCastShadows}
+
+| Nombre | Descripción |
+| --- | --- |
+| setCastShadows(value) | Obtiene o establece si esta geometría puede proyectar sombra |
+
+ **Result:**
+
+
+
+---
+
+
+### getReceiveShadows{#getReceiveShadows}
+
+| Nombre | Descripción |
+| --- | --- |
+| getReceiveShadows() | Obtiene o establece si esta geometría puede recibir sombra. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReceiveShadows{#setReceiveShadows}
+
+| Nombre | Descripción |
+| --- | --- |
+| setReceiveShadows(value) | Obtiene o establece si esta geometría puede recibir sombra. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNodes() | Obtiene todos los nodos padre; una entidad puede estar adjunta a varios nodos padre para la instanciación de geometría. Los nodos. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExcluded() | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExcluded(value) | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNode() | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setParentNode(value) | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Nombre | Descripción |
+| --- | --- |
+| getScene() | Obtiene la escena a la que pertenece este objeto |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### toMesh{#toMesh}
+
+| Nombre | Descripción |
+| --- | --- |
+| toMesh() | Convertir el objeto actual a malla |
+
+ **Result:**
+Malla
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBoundingBox() | Obtiene el cuadro delimitador de la entidad actual en su sistema de coordenadas de espacio de objeto. |
+
+ **Result:**
+Malla
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEntityRendererKey() | Obtiene la clave del renderizador de entidad registrado en el renderizador |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/spirvsource/_index.md
+++ b/spanish/nodejs-java/aspose.threed/spirvsource/_index.md
@@ -1,0 +1,159 @@
+---
+title: "SPIRVSource"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/spirvsource/
+---
+## SPIRVSource class
+
+El shader compilado en formato SPIR-V.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Constructor de fuentes de sombreadores basadas en SPIR-V. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMaximumDescriptorSets{#getMaximumDescriptorSets}
+
+| Nombre | Descripción |
+| --- | --- |
+| getMaximumDescriptorSets() | Conjuntos de descriptores máximos, el valor predeterminado es 10 |
+
+ **Result:**
+
+
+
+---
+
+
+### setMaximumDescriptorSets{#setMaximumDescriptorSets}
+
+| Nombre | Descripción |
+| --- | --- |
+| setMaximumDescriptorSets(value) | Conjuntos de descriptores máximos, el valor predeterminado es 10 |
+
+ **Result:**
+
+
+
+---
+
+
+### getComputeShader{#getComputeShader}
+
+| Nombre | Descripción |
+| --- | --- |
+| getComputeShader() | Obtiene o establece el código fuente del sombreador de cómputo. |
+
+ **Result:**
+
+
+
+---
+
+
+### setComputeShader{#setComputeShader}
+
+| Nombre | Descripción |
+| --- | --- |
+| setComputeShader(value) | Obtiene o establece el código fuente del sombreador de cómputo. |
+
+ **Result:**
+
+
+
+---
+
+
+### getGeometryShader{#getGeometryShader}
+
+| Nombre | Descripción |
+| --- | --- |
+| getGeometryShader() | Obtiene o establece el código fuente del sombreador de geometría. |
+
+ **Result:**
+
+
+
+---
+
+
+### setGeometryShader{#setGeometryShader}
+
+| Nombre | Descripción |
+| --- | --- |
+| setGeometryShader(value) | Obtiene o establece el código fuente del sombreador de geometría. |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexShader{#getVertexShader}
+
+| Nombre | Descripción |
+| --- | --- |
+| getVertexShader() | Obtiene o establece el código fuente del sombreador de vértice |
+
+ **Result:**
+
+
+
+---
+
+
+### setVertexShader{#setVertexShader}
+
+| Nombre | Descripción |
+| --- | --- |
+| setVertexShader(value) | Obtiene o establece el código fuente del sombreador de vértice |
+
+ **Result:**
+
+
+
+---
+
+
+### getFragmentShader{#getFragmentShader}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFragmentShader() | Obtiene o establece el código fuente del shader de fragmento. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFragmentShader{#setFragmentShader}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFragmentShader(value) | Obtiene o establece el código fuente del shader de fragmento. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/stencilstate/_index.md
+++ b/spanish/nodejs-java/aspose.threed/stencilstate/_index.md
@@ -1,0 +1,152 @@
+---
+title: "StencilState"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/stencilstate/
+---
+## StencilState class
+
+Estados de stencil por cara.  @hideconstructor
+
+
+## Métodos
+
+### getCompare{#getCompare}
+
+| Nombre | Descripción |
+| --- | --- |
+| getCompare() | Obtiene o establece la función de comparación utilizada en la prueba de stencil. El valor de la propiedad es una constante entera CompareFunction. |
+
+ **Result:**
+
+
+
+---
+
+
+### setCompare{#setCompare}
+
+| Nombre | Descripción |
+| --- | --- |
+| setCompare(value) | Obtiene o establece la función de comparación utilizada en la prueba de stencil. El valor de la propiedad es una constante entera CompareFunction. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFailAction{#getFailAction}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFailAction() | Obtiene o establece la acción de stencil cuando la prueba de stencil falla. El valor de la propiedad es la constante entera StencilAction. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFailAction{#setFailAction}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFailAction(value) | Obtiene o establece la acción de stencil cuando la prueba de stencil falla. El valor de la propiedad es la constante entera StencilAction. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDepthFailAction{#getDepthFailAction}
+
+| Nombre | Descripción |
+| --- | --- |
+| getDepthFailAction() | Obtiene o establece la acción de stencil cuando la prueba de stencil pasa pero la prueba de profundidad falla. El valor de la propiedad es la constante entera StencilAction. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDepthFailAction{#setDepthFailAction}
+
+| Nombre | Descripción |
+| --- | --- |
+| setDepthFailAction(value) | Obtiene o establece la acción de stencil cuando la prueba de stencil pasa pero la prueba de profundidad falla. El valor de la propiedad es la constante entera StencilAction. |
+
+ **Result:**
+
+
+
+---
+
+
+### getPassAction{#getPassAction}
+
+| Nombre | Descripción |
+| --- | --- |
+| getPassAction() | Obtiene o establece la acción de stencil cuando tanto la prueba de stencil como la prueba de profundidad pasan. El valor de la propiedad es la constante entera StencilAction. |
+
+ **Result:**
+
+
+
+---
+
+
+### setPassAction{#setPassAction}
+
+| Nombre | Descripción |
+| --- | --- |
+| setPassAction(value) | Obtiene o establece la acción de stencil cuando tanto la prueba de stencil como la prueba de profundidad pasan. El valor de la propiedad es la constante entera StencilAction. |
+
+ **Result:**
+
+
+
+---
+
+
+### equals{#equals}
+
+| Nombre | Descripción |
+| --- | --- |
+| equals(obj) | Devuelve un valor que indica si esta instancia es igual a un objeto especificado. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| ob | Objeto | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### hashCode{#hashCode}
+
+| Nombre | Descripción |
+| --- | --- |
+| hashCode() | Devuelve el código hash de esta instancia. |
+
+ **Result:**
+boolean
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/stlloadoptions/_index.md
+++ b/spanish/nodejs-java/aspose.threed/stlloadoptions/_index.md
@@ -1,0 +1,191 @@
+---
+title: "StlLoadOptions"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/stlloadoptions/
+---
+## StlLoadOptions class
+
+Opciones de carga para STL
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Inicializa una nueva instancia de StlLoadOptions. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload(contentType) | Inicializa una nueva instancia de StlLoadOptions. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| contentType | FileContentType | FileContentType |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlipCoordinateSystem{#getFlipCoordinateSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFlipCoordinateSystem() | Obtiene o establece si se invierte el sistema de coordenadas de los puntos de control/normal durante la importación. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlipCoordinateSystem{#setFlipCoordinateSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFlipCoordinateSystem(value) | Obtiene o establece si se invierte el sistema de coordenadas de los puntos de control/normal durante la importación. |
+
+ **Result:**
+
+
+
+---
+
+
+### getRecalculateNormal{#getRecalculateNormal}
+
+| Nombre | Descripción |
+| --- | --- |
+| getRecalculateNormal() | Ignorar los datos de normal almacenados en el archivo STL y recalcular los datos de normal basándose en la posición de los vértices. El valor predeterminado es false. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRecalculateNormal{#setRecalculateNormal}
+
+| Nombre | Descripción |
+| --- | --- |
+| setRecalculateNormal(value) | Ignorar los datos de normal almacenados en el archivo STL y recalcular los datos de normal basándose en la posición de los vértices. El valor predeterminado es false. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileFormat() | Obtiene el formato de archivo especificado en la opción actual de Guardar/Cargar. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEncoding() | Obtiene o establece la codificación predeterminada para archivos basados en texto. El valor predeterminado es null, lo que significa que el importador/exportador decidirá qué codificación usar. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileSystem() | Permite al usuario manejar cómo gestionar las dependencias externas durante la carga/guardado. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFileSystem(value) | Permite al usuario manejar cómo gestionar las dependencias externas durante la carga/guardado. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| Nombre | Descripción |
+| --- | --- |
+| getLookupPaths() | Algunos archivos como OBJ dependen de archivos externos; las rutas de búsqueda permiten que Aspose.3D busque el archivo externo para cargarlo. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileName() | El nombre de archivo de la escena de exportación/importación. Es opcional, pero útil al serializar recursos externos como el material de OBJ. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFileName(value) | El nombre de archivo de la escena de exportación/importación. Es opcional, pero útil al serializar recursos externos como el material de OBJ. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/stlsaveoptions/_index.md
+++ b/spanish/nodejs-java/aspose.threed/stlsaveoptions/_index.md
@@ -1,0 +1,191 @@
+---
+title: "StlSaveOptions"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/stlsaveoptions/
+---
+## StlSaveOptions class
+
+Opciones de guardado para STL
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Inicializa una nueva instancia de StlSaveOptions. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload(contentType) | Inicializa una nueva instancia de StlSaveOptions. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| contentType | FileContentType | FileContentType |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlipCoordinateSystem{#getFlipCoordinateSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFlipCoordinateSystem() | Obtiene o establece si se invierte el sistema de coordenadas de los puntos de control/normal durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlipCoordinateSystem{#setFlipCoordinateSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFlipCoordinateSystem(value) | Obtiene o establece si se invierte el sistema de coordenadas de los puntos de control/normal durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportTextures{#getExportTextures}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExportTextures() | Intenta copiar las texturas usadas en la escena al directorio de salida. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextures{#setExportTextures}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExportTextures(value) | Intenta copiar las texturas usadas en la escena al directorio de salida. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileFormat() | Obtiene el formato de archivo especificado en la opción actual de Guardar/Cargar. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEncoding() | Obtiene o establece la codificación predeterminada para archivos basados en texto. El valor predeterminado es null, lo que significa que el importador/exportador decidirá qué codificación usar. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileSystem() | Permite al usuario manejar cómo gestionar las dependencias externas durante la carga/guardado. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFileSystem(value) | Permite al usuario manejar cómo gestionar las dependencias externas durante la carga/guardado. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| Nombre | Descripción |
+| --- | --- |
+| getLookupPaths() | Algunos archivos como OBJ dependen de archivos externos; las rutas de búsqueda permiten que Aspose.3D busque el archivo externo para cargarlo. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileName() | El nombre de archivo de la escena de exportación/importación. Es opcional, pero útil al serializar recursos externos como el material de OBJ. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFileName(value) | El nombre de archivo de la escena de exportación/importación. Es opcional, pero útil al serializar recursos externos como el material de OBJ. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/sweptareasolid/_index.md
+++ b/spanish/nodejs-java/aspose.threed/sweptareasolid/_index.md
@@ -1,0 +1,385 @@
+---
+title: "SweptAreaSolid"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/sweptareasolid/
+---
+## SweptAreaSolid class
+
+Un SweptAreaSolid construye una geometría barrendo un perfil a lo largo de una directriz.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getShape{#getShape}
+
+| Nombre | Descripción |
+| --- | --- |
+| getShape() | El perfil base para construir la geometría. |
+
+ **Result:**
+
+
+
+---
+
+
+### setShape{#setShape}
+
+| Nombre | Descripción |
+| --- | --- |
+| setShape(value) | El perfil base para construir la geometría. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDirectrix{#getDirectrix}
+
+| Nombre | Descripción |
+| --- | --- |
+| getDirectrix() | La directriz a lo largo de la cual se barre el área barrida. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDirectrix{#setDirectrix}
+
+| Nombre | Descripción |
+| --- | --- |
+| setDirectrix(value) | La directriz a lo largo de la cual se barre el área barrida. |
+
+ **Result:**
+
+
+
+---
+
+
+### getStartPoint{#getStartPoint}
+
+| Nombre | Descripción |
+| --- | --- |
+| getStartPoint() | El punto de inicio de la directriz. |
+
+ **Result:**
+
+
+
+---
+
+
+### setStartPoint{#setStartPoint}
+
+| Nombre | Descripción |
+| --- | --- |
+| setStartPoint(value) | El punto de inicio de la directriz. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEndPoint{#getEndPoint}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEndPoint() | El punto final de la directriz. |
+
+ **Result:**
+
+
+
+---
+
+
+### setEndPoint{#setEndPoint}
+
+| Nombre | Descripción |
+| --- | --- |
+| setEndPoint(value) | El punto final de la directriz. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNodes() | Obtiene todos los nodos padre; una entidad puede estar adjunta a varios nodos padre para la instanciación de geometría. Los nodos. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExcluded() | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExcluded(value) | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNode() | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setParentNode(value) | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Nombre | Descripción |
+| --- | --- |
+| getScene() | Obtiene la escena a la que pertenece este objeto |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### toMesh{#toMesh}
+
+| Nombre | Descripción |
+| --- | --- |
+| toMesh() | Convertir el objeto actual a malla |
+
+ **Result:**
+Malla
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBoundingBox() | Obtiene el cuadro delimitador de la entidad actual en su sistema de coordenadas de espacio de objeto. |
+
+ **Result:**
+Malla
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEntityRendererKey() | Obtiene la clave del renderizador de entidad registrado en el renderizador |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/text/_index.md
+++ b/spanish/nodejs-java/aspose.threed/text/_index.md
@@ -1,0 +1,346 @@
+---
+title: "Texto"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/text/
+---
+## Text class
+
+Perfil de texto, este perfil describe contornos usando fuente y texto.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getContent{#getContent}
+
+| Nombre | Descripción |
+| --- | --- |
+| getContent() | Contenido del texto |
+
+ **Result:**
+
+
+
+---
+
+
+### setContent{#setContent}
+
+| Nombre | Descripción |
+| --- | --- |
+| setContent(value) | Contenido del texto |
+
+ **Result:**
+
+
+
+---
+
+
+### getFont{#getFont}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFont() | La fuente del texto. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFont{#setFont}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFont(value) | La fuente del texto. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFontSize{#getFontSize}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFontSize() | Escala del tamaño de fuente. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFontSize{#setFontSize}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFontSize(value) | Escala del tamaño de fuente. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNodes() | Obtiene todos los nodos padre; una entidad puede estar adjunta a varios nodos padre para la instanciación de geometría. Los nodos. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExcluded() | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExcluded(value) | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNode() | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setParentNode(value) | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Nombre | Descripción |
+| --- | --- |
+| getScene() | Obtiene la escena a la que pertenece este objeto |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEntityRendererKey() | Obtiene la clave del renderizador de entidad registrado en el renderizador |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBoundingBox() | Obtiene el cuadro delimitador de la entidad actual en su sistema de coordenadas de espacio de objeto. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/texture/_index.md
+++ b/spanish/nodejs-java/aspose.threed/texture/_index.md
@@ -1,0 +1,607 @@
+---
+title: "Texture"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/texture/
+---
+## Texture class
+
+Esta clase define la textura a partir de un archivo externo.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Inicializa una nueva instancia de la clase Texture. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload(name) | Inicializa una nueva instancia de la clase Texture. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| name | Cadena | Nombre |
+
+ **Result:**
+
+
+
+---
+
+
+### getEnableMipMap{#getEnableMipMap}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEnableMipMap() | Obtiene o establece si el mipmap está habilitado para esta textura |
+
+ **Result:**
+
+
+
+---
+
+
+### setEnableMipMap{#setEnableMipMap}
+
+| Nombre | Descripción |
+| --- | --- |
+| setEnableMipMap(value) | Obtiene o establece si el mipmap está habilitado para esta textura |
+
+ **Result:**
+
+
+
+---
+
+
+### getContent{#getContent}
+
+| Nombre | Descripción |
+| --- | --- |
+| getContent() | Obtiene o establece el contenido binario de la textura. El contenido de textura incrustado es opcional, el usuario debe cargar la textura desde un archivo externo si falta. |
+
+ **Result:**
+
+
+
+---
+
+
+### setContent{#setContent}
+
+| Nombre | Descripción |
+| --- | --- |
+| setContent(value) | Obtiene o establece el contenido binario de la textura. El contenido de textura incrustado es opcional, el usuario debe cargar la textura desde un archivo externo si falta. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileName() | Obtiene o establece el archivo de textura asociado. El nombre del archivo. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFileName(value) | Obtiene o establece el archivo de textura asociado. El nombre del archivo. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAlpha{#getAlpha}
+
+| Nombre | Descripción |
+| --- | --- |
+| getAlpha() | Obtiene o establece el valor alfa predeterminado de la textura. Esto es válido cuando AlphaSource es AlphaSource.PIXEL_ALPHA. El valor predeterminado es 1.0, el rango de valores válidos está entre 0 y 1. |
+
+ **Result:**
+
+
+
+---
+
+
+### setAlpha{#setAlpha}
+
+| Nombre | Descripción |
+| --- | --- |
+| setAlpha(value) | Obtiene o establece el valor alfa predeterminado de la textura. Esto es válido cuando AlphaSource es AlphaSource.PIXEL_ALPHA. El valor predeterminado es 1.0, el rango de valores válidos está entre 0 y 1. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAlphaSource{#getAlphaSource}
+
+| Nombre | Descripción |
+| --- | --- |
+| getAlphaSource() | Obtiene o establece si la textura define el canal alfa. El valor predeterminado es AlphaSource.NONE. El valor de la propiedad es la constante entera AlphaSource. |
+
+ **Result:**
+
+
+
+---
+
+
+### setAlphaSource{#setAlphaSource}
+
+| Nombre | Descripción |
+| --- | --- |
+| setAlphaSource(value) | Obtiene o establece si la textura define el canal alfa. El valor predeterminado es AlphaSource.NONE. El valor de la propiedad es la constante entera AlphaSource. |
+
+ **Result:**
+
+
+
+---
+
+
+### getWrapModeU{#getWrapModeU}
+
+| Nombre | Descripción |
+| --- | --- |
+| getWrapModeU() | Obtiene o establece los modos de envoltura de la textura en U. El valor de la propiedad es la constante entera WrapMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setWrapModeU{#setWrapModeU}
+
+| Nombre | Descripción |
+| --- | --- |
+| setWrapModeU(value) | Obtiene o establece los modos de envoltura de la textura en U. El valor de la propiedad es la constante entera WrapMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getWrapModeV{#getWrapModeV}
+
+| Nombre | Descripción |
+| --- | --- |
+| getWrapModeV() | Obtiene o establece los modos de envoltura de la textura en V. El valor de la propiedad es la constante entera WrapMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setWrapModeV{#setWrapModeV}
+
+| Nombre | Descripción |
+| --- | --- |
+| setWrapModeV(value) | Obtiene o establece los modos de envoltura de la textura en V. El valor de la propiedad es la constante entera WrapMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getWrapModeW{#getWrapModeW}
+
+| Nombre | Descripción |
+| --- | --- |
+| getWrapModeW() | Obtiene o establece los modos de envoltura de la textura en W. El valor de la propiedad es la constante entera WrapMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setWrapModeW{#setWrapModeW}
+
+| Nombre | Descripción |
+| --- | --- |
+| setWrapModeW(value) | Obtiene o establece los modos de envoltura de la textura en W. El valor de la propiedad es la constante entera WrapMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMinFilter{#getMinFilter}
+
+| Nombre | Descripción |
+| --- | --- |
+| getMinFilter() | Obtiene o establece el filtro para la minificación. El valor de la propiedad es la constante entera TextureFilter. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMinFilter{#setMinFilter}
+
+| Nombre | Descripción |
+| --- | --- |
+| setMinFilter(value) | Obtiene o establece el filtro para la minificación. El valor de la propiedad es la constante entera TextureFilter. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMagFilter{#getMagFilter}
+
+| Nombre | Descripción |
+| --- | --- |
+| getMagFilter() | Obtiene o establece el filtro para la ampliación. El valor de la propiedad es una constante entera TextureFilter. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMagFilter{#setMagFilter}
+
+| Nombre | Descripción |
+| --- | --- |
+| setMagFilter(value) | Obtiene o establece el filtro para la ampliación. El valor de la propiedad es una constante entera TextureFilter. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMipFilter{#getMipFilter}
+
+| Nombre | Descripción |
+| --- | --- |
+| getMipFilter() | Obtiene o establece el filtro para el muestreo a nivel de mip. El valor de la propiedad es una constante entera TextureFilter. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMipFilter{#setMipFilter}
+
+| Nombre | Descripción |
+| --- | --- |
+| setMipFilter(value) | Obtiene o establece el filtro para el muestreo a nivel de mip. El valor de la propiedad es una constante entera TextureFilter. |
+
+ **Result:**
+
+
+
+---
+
+
+### getUVRotation{#getUVRotation}
+
+| Nombre | Descripción |
+| --- | --- |
+| getUVRotation() | Obtiene o establece la rotación de la textura |
+
+ **Result:**
+
+
+
+---
+
+
+### setUVRotation{#setUVRotation}
+
+| Nombre | Descripción |
+| --- | --- |
+| setUVRotation(value) | Obtiene o establece la rotación de la textura |
+
+ **Result:**
+
+
+
+---
+
+
+### getUVScale{#getUVScale}
+
+| Nombre | Descripción |
+| --- | --- |
+| getUVScale() | Obtiene o establece la escala UV. La escala UV. |
+
+ **Result:**
+
+
+
+---
+
+
+### setUVScale{#setUVScale}
+
+| Nombre | Descripción |
+| --- | --- |
+| setUVScale(value) | Obtiene o establece la escala UV. La escala UV. |
+
+ **Result:**
+
+
+
+---
+
+
+### getUVTranslation{#getUVTranslation}
+
+| Nombre | Descripción |
+| --- | --- |
+| getUVTranslation() | Obtiene o establece la traslación UV. La traslación UV. |
+
+ **Result:**
+
+
+
+---
+
+
+### setUVTranslation{#setUVTranslation}
+
+| Nombre | Descripción |
+| --- | --- |
+| setUVTranslation(value) | Obtiene o establece la traslación UV. La traslación UV. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTranslation{#setTranslation}
+
+| Nombre | Descripción |
+| --- | --- |
+| setTranslation(u, v) | Establece la traslación UV. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| u | Número | U. |
+| v | Número | V. |
+
+ **Result:**
+
+
+
+---
+
+
+### setScale{#setScale}
+
+| Nombre | Descripción |
+| --- | --- |
+| setScale(u, v) | Establece la escala UV. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| u | Número | U. |
+| v | Número | V. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRotation{#setRotation}
+
+| Nombre | Descripción |
+| --- | --- |
+| setRotation(u, v) | Establece la rotación UV. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| u | Número | U. |
+| v | Número | V. |
+
+ **Result:**
+
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/texturebase/_index.md
+++ b/spanish/nodejs-java/aspose.threed/texturebase/_index.md
@@ -1,0 +1,516 @@
+---
+title: "TextureBase"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/texturebase/
+---
+## TextureBase class
+
+Clase base para todas las texturas concretas.  Texture define el aspecto y la sensación de la superficie de una geometría.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor(name) | Inicializa una nueva instancia de la clase TextureBase. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| name | Cadena | Nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAlpha{#getAlpha}
+
+| Nombre | Descripción |
+| --- | --- |
+| getAlpha() | Obtiene o establece el valor alfa predeterminado de la textura. Esto es válido cuando AlphaSource es AlphaSource.PIXEL_ALPHA. El valor predeterminado es 1.0, el rango de valores válidos está entre 0 y 1. |
+
+ **Result:**
+
+
+
+---
+
+
+### setAlpha{#setAlpha}
+
+| Nombre | Descripción |
+| --- | --- |
+| setAlpha(value) | Obtiene o establece el valor alfa predeterminado de la textura. Esto es válido cuando AlphaSource es AlphaSource.PIXEL_ALPHA. El valor predeterminado es 1.0, el rango de valores válidos está entre 0 y 1. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAlphaSource{#getAlphaSource}
+
+| Nombre | Descripción |
+| --- | --- |
+| getAlphaSource() | Obtiene o establece si la textura define el canal alfa. El valor predeterminado es AlphaSource.NONE. El valor de la propiedad es la constante entera AlphaSource. |
+
+ **Result:**
+
+
+
+---
+
+
+### setAlphaSource{#setAlphaSource}
+
+| Nombre | Descripción |
+| --- | --- |
+| setAlphaSource(value) | Obtiene o establece si la textura define el canal alfa. El valor predeterminado es AlphaSource.NONE. El valor de la propiedad es la constante entera AlphaSource. |
+
+ **Result:**
+
+
+
+---
+
+
+### getWrapModeU{#getWrapModeU}
+
+| Nombre | Descripción |
+| --- | --- |
+| getWrapModeU() | Obtiene o establece los modos de envoltura de la textura en U. El valor de la propiedad es la constante entera WrapMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setWrapModeU{#setWrapModeU}
+
+| Nombre | Descripción |
+| --- | --- |
+| setWrapModeU(value) | Obtiene o establece los modos de envoltura de la textura en U. El valor de la propiedad es la constante entera WrapMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getWrapModeV{#getWrapModeV}
+
+| Nombre | Descripción |
+| --- | --- |
+| getWrapModeV() | Obtiene o establece los modos de envoltura de la textura en V. El valor de la propiedad es la constante entera WrapMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setWrapModeV{#setWrapModeV}
+
+| Nombre | Descripción |
+| --- | --- |
+| setWrapModeV(value) | Obtiene o establece los modos de envoltura de la textura en V. El valor de la propiedad es la constante entera WrapMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getWrapModeW{#getWrapModeW}
+
+| Nombre | Descripción |
+| --- | --- |
+| getWrapModeW() | Obtiene o establece los modos de envoltura de la textura en W. El valor de la propiedad es la constante entera WrapMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setWrapModeW{#setWrapModeW}
+
+| Nombre | Descripción |
+| --- | --- |
+| setWrapModeW(value) | Obtiene o establece los modos de envoltura de la textura en W. El valor de la propiedad es la constante entera WrapMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMinFilter{#getMinFilter}
+
+| Nombre | Descripción |
+| --- | --- |
+| getMinFilter() | Obtiene o establece el filtro para la minificación. El valor de la propiedad es la constante entera TextureFilter. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMinFilter{#setMinFilter}
+
+| Nombre | Descripción |
+| --- | --- |
+| setMinFilter(value) | Obtiene o establece el filtro para la minificación. El valor de la propiedad es la constante entera TextureFilter. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMagFilter{#getMagFilter}
+
+| Nombre | Descripción |
+| --- | --- |
+| getMagFilter() | Obtiene o establece el filtro para la ampliación. El valor de la propiedad es una constante entera TextureFilter. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMagFilter{#setMagFilter}
+
+| Nombre | Descripción |
+| --- | --- |
+| setMagFilter(value) | Obtiene o establece el filtro para la ampliación. El valor de la propiedad es una constante entera TextureFilter. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMipFilter{#getMipFilter}
+
+| Nombre | Descripción |
+| --- | --- |
+| getMipFilter() | Obtiene o establece el filtro para el muestreo a nivel de mip. El valor de la propiedad es una constante entera TextureFilter. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMipFilter{#setMipFilter}
+
+| Nombre | Descripción |
+| --- | --- |
+| setMipFilter(value) | Obtiene o establece el filtro para el muestreo a nivel de mip. El valor de la propiedad es una constante entera TextureFilter. |
+
+ **Result:**
+
+
+
+---
+
+
+### getUVRotation{#getUVRotation}
+
+| Nombre | Descripción |
+| --- | --- |
+| getUVRotation() | Obtiene o establece la rotación de la textura |
+
+ **Result:**
+
+
+
+---
+
+
+### setUVRotation{#setUVRotation}
+
+| Nombre | Descripción |
+| --- | --- |
+| setUVRotation(value) | Obtiene o establece la rotación de la textura |
+
+ **Result:**
+
+
+
+---
+
+
+### getUVScale{#getUVScale}
+
+| Nombre | Descripción |
+| --- | --- |
+| getUVScale() | Obtiene o establece la escala UV. La escala UV. |
+
+ **Result:**
+
+
+
+---
+
+
+### setUVScale{#setUVScale}
+
+| Nombre | Descripción |
+| --- | --- |
+| setUVScale(value) | Obtiene o establece la escala UV. La escala UV. |
+
+ **Result:**
+
+
+
+---
+
+
+### getUVTranslation{#getUVTranslation}
+
+| Nombre | Descripción |
+| --- | --- |
+| getUVTranslation() | Obtiene o establece la traslación UV. La traslación UV. |
+
+ **Result:**
+
+
+
+---
+
+
+### setUVTranslation{#setUVTranslation}
+
+| Nombre | Descripción |
+| --- | --- |
+| setUVTranslation(value) | Obtiene o establece la traslación UV. La traslación UV. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTranslation{#setTranslation}
+
+| Nombre | Descripción |
+| --- | --- |
+| setTranslation(u, v) | Establece la traslación UV. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| u | Número | U. |
+| v | Número | V. |
+
+ **Result:**
+
+
+
+---
+
+
+### setScale{#setScale}
+
+| Nombre | Descripción |
+| --- | --- |
+| setScale(u, v) | Establece la escala UV. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| u | Número | U. |
+| v | Número | V. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRotation{#setRotation}
+
+| Nombre | Descripción |
+| --- | --- |
+| setRotation(u, v) | Establece la rotación UV. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| u | Número | U. |
+| v | Número | V. |
+
+ **Result:**
+
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/texturecodec/_index.md
+++ b/spanish/nodejs-java/aspose.threed/texturecodec/_index.md
@@ -1,0 +1,61 @@
+---
+title: "TextureCodec"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/texturecodec/
+---
+## TextureCodec class
+
+Clase para gestionar codificadores y decodificadores de texturas.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getSupportedEncoderFormats{#getSupportedEncoderFormats}
+
+| Nombre | Descripción |
+| --- | --- |
+| getSupportedEncoderFormats() | Obtiene todos los formatos de codificador compatibles |
+
+ **Result:**
+String[]
+
+
+---
+
+
+### registerCodec{#registerCodec}
+
+| Nombre | Descripción |
+| --- | --- |
+| registerCodec(codec) | Registra un conjunto de codificadores y decodificadores de texturas |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| código | ITextureCodec | null |
+
+ **Result:**
+String[]
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/texturedata/_index.md
+++ b/spanish/nodejs-java/aspose.threed/texturedata/_index.md
@@ -1,0 +1,289 @@
+---
+title: "TextureData"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/texturedata/
+---
+## TextureData class
+
+Esta clase contiene los datos sin procesar y la definición de formato de una textura.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor(width, height, stride, bytesPerPixel, pixelFormat, data) | Constructor de TextureData |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| widt | Número | null |
+| heigh | Número | null |
+| strid | Número | null |
+| bytesPerPixe | Número | null |
+| pixelFormat | PixelFormat | PixelFormat |
+| dat | byte[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload(width, height, pixelFormat) | Construye un nuevo TextureData y asigna datos de píxeles. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| widt | Número | null |
+| heigh | Número | null |
+| pixelFormat | PixelFormat | PixelFormat |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload2() | Constructor de TextureData |
+
+ **Result:**
+
+
+
+---
+
+
+### getData{#getData}
+
+| Nombre | Descripción |
+| --- | --- |
+| getData() | Bytes sin procesar de datos de píxeles |
+
+ **Result:**
+
+
+
+---
+
+
+### getWidth{#getWidth}
+
+| Nombre | Descripción |
+| --- | --- |
+| getWidth() | Número de píxeles horizontales |
+
+ **Result:**
+
+
+
+---
+
+
+### getHeight{#getHeight}
+
+| Nombre | Descripción |
+| --- | --- |
+| getHeight() | Número de píxeles verticales |
+
+ **Result:**
+
+
+
+---
+
+
+### getStride{#getStride}
+
+| Nombre | Descripción |
+| --- | --- |
+| getStride() | Número de bytes de una línea de escaneo. |
+
+ **Result:**
+
+
+
+---
+
+
+### getBytesPerPixel{#getBytesPerPixel}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBytesPerPixel() | Número de bytes de un píxel |
+
+ **Result:**
+
+
+
+---
+
+
+### getPixelFormat{#getPixelFormat}
+
+| Nombre | Descripción |
+| --- | --- |
+| getPixelFormat() | El formato del píxel. El valor de la propiedad es la constante entera PixelFormat. |
+
+ **Result:**
+
+
+
+---
+
+
+### fromFile{#fromFile}
+
+| Nombre | Descripción |
+| --- | --- |
+| fromFile(fileName) | Cargar una textura desde un archivo |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| fileNam | Cadena | null |
+
+ **Result:**
+TextureData
+
+
+---
+
+
+### save{#save}
+
+| Nombre | Descripción |
+| --- | --- |
+| save(fileName) | Guardar datos de textura en un archivo de imagen |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| fileName | Cadena | El nombre del archivo donde se guardará la imagen. |
+
+ **Result:**
+TextureData
+
+
+---
+
+
+### save{#save}
+
+| Nombre | Descripción |
+| --- | --- |
+| save(fileName, format) | Guardar datos de textura en un archivo de imagen |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| fileName | Cadena | El nombre del archivo donde se guardará la imagen. |
+| format | Cadena | Formato de imagen del archivo de salida. |
+
+ **Result:**
+TextureData
+
+
+---
+
+
+### mapPixels{#mapPixels}
+
+| Nombre | Descripción |
+| --- | --- |
+| mapPixels(mapMode) | Mapear todos los píxeles para lectura/escritura |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| mapMode | PixelMapMode | PixelMapMode |
+
+ **Result:**
+PixelMapping
+
+
+---
+
+
+### mapPixels{#mapPixels}
+
+| Nombre | Descripción |
+| --- | --- |
+| mapPixels(mapMode, format) | Mapear todos los píxeles para lectura/escritura en el formato de píxel dado |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| mapMode | PixelMapMode | PixelMapMode |
+| format | PixelFormat | PixelFormat |
+
+ **Result:**
+PixelMapping
+
+
+---
+
+
+### mapPixels{#mapPixels}
+
+| Nombre | Descripción |
+| --- | --- |
+| mapPixels(rect, mapMode, format) | Mapear los píxeles especificados por rect para lectura/escritura en el formato de píxel dado |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| rect | Rect | El área de píxeles a la que se accederá |
+| mapMode | PixelMapMode | PixelMapMode |
+| format | PixelFormat | PixelFormat |
+
+ **Result:**
+PixelMapping
+
+
+---
+
+
+### transformPixelFormat{#transformPixelFormat}
+
+| Nombre | Descripción |
+| --- | --- |
+| transformPixelFormat(pixelFormat) | Transformar la disposición del píxel al nuevo formato de píxel. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| pixelFormat | PixelFormat | PixelFormat |
+
+ **Result:**
+PixelMapping
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/textureslot/_index.md
+++ b/spanish/nodejs-java/aspose.threed/textureslot/_index.md
@@ -1,0 +1,42 @@
+---
+title: "TextureSlot"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/textureslot/
+---
+## TextureSlot class
+
+Ranura de textura en Material, puede enumerarse a través de la instancia del material.  @hideconstructor
+
+
+## Métodos
+
+### getSlotName{#getSlotName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getSlotName() | El nombre del slot que indica a dónde se vinculará esta textura. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTexture{#getTexture}
+
+| Nombre | Descripción |
+| --- | --- |
+| getTexture() | La textura que se vinculará al material. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/torus/_index.md
+++ b/spanish/nodejs-java/aspose.threed/torus/_index.md
@@ -1,0 +1,528 @@
+---
+title: "Torus"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/torus/
+---
+## Torus class
+
+Toro parametrizado.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Inicializa una nueva instancia de la clase Torus. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload(radius, tube) | Inicializa una nueva instancia de la clase Torus. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| radius | Número | El radio del toro. |
+| tube | Número | El radio del tubo del toro. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload2(radius, tube, arc) | Inicializa una nueva instancia de la clase Torus. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| radius | Número | El radio del toro. |
+| tube | Número | El radio del tubo del toro. |
+| arc | Número | Arco. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload3{#constructor_overload3}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload3(name, radius, tube, radialSegments, tubularSegments, arc) | Inicializa una nueva instancia de la clase Torus. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| name | Cadena | Nombre. |
+| radius | Número | El radio del toro. |
+| tube | Número | El radio del tubo del toro. |
+| radialSegments | Número | Segmentos radiales. |
+| tubularSegments | Número | Segmentos tubulares. |
+| arc | Número | Arco. |
+
+ **Result:**
+
+
+
+---
+
+
+### getRadius{#getRadius}
+
+| Nombre | Descripción |
+| --- | --- |
+| getRadius() | Obtiene o establece el radio del toro. El radio. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRadius{#setRadius}
+
+| Nombre | Descripción |
+| --- | --- |
+| setRadius(value) | Obtiene o establece el radio del toro. El radio. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTube{#getTube}
+
+| Nombre | Descripción |
+| --- | --- |
+| getTube() | Obtiene o establece el radio del tubo. El tubo. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTube{#setTube}
+
+| Nombre | Descripción |
+| --- | --- |
+| setTube(value) | Obtiene o establece el radio del tubo. El tubo. |
+
+ **Result:**
+
+
+
+---
+
+
+### getRadialSegments{#getRadialSegments}
+
+| Nombre | Descripción |
+| --- | --- |
+| getRadialSegments() | Obtiene o establece los segmentos radiales. Los segmentos radiales. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRadialSegments{#setRadialSegments}
+
+| Nombre | Descripción |
+| --- | --- |
+| setRadialSegments(value) | Obtiene o establece los segmentos radiales. Los segmentos radiales. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTubularSegments{#getTubularSegments}
+
+| Nombre | Descripción |
+| --- | --- |
+| getTubularSegments() | Obtiene o establece los segmentos tubulares. Los segmentos tubulares. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTubularSegments{#setTubularSegments}
+
+| Nombre | Descripción |
+| --- | --- |
+| setTubularSegments(value) | Obtiene o establece los segmentos tubulares. Los segmentos tubulares. |
+
+ **Result:**
+
+
+
+---
+
+
+### getArc{#getArc}
+
+| Nombre | Descripción |
+| --- | --- |
+| getArc() | Obtiene o establece el arco. El arco. |
+
+ **Result:**
+
+
+
+---
+
+
+### setArc{#setArc}
+
+| Nombre | Descripción |
+| --- | --- |
+| setArc(value) | Obtiene o establece el arco. El arco. |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastShadows{#getCastShadows}
+
+| Nombre | Descripción |
+| --- | --- |
+| getCastShadows() | Obtiene o establece si esta geometría puede proyectar sombra |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastShadows{#setCastShadows}
+
+| Nombre | Descripción |
+| --- | --- |
+| setCastShadows(value) | Obtiene o establece si esta geometría puede proyectar sombra |
+
+ **Result:**
+
+
+
+---
+
+
+### getReceiveShadows{#getReceiveShadows}
+
+| Nombre | Descripción |
+| --- | --- |
+| getReceiveShadows() | Obtiene o establece si esta geometría puede recibir sombra. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReceiveShadows{#setReceiveShadows}
+
+| Nombre | Descripción |
+| --- | --- |
+| setReceiveShadows(value) | Obtiene o establece si esta geometría puede recibir sombra. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNodes() | Obtiene todos los nodos padre; una entidad puede estar adjunta a varios nodos padre para la instanciación de geometría. Los nodos. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExcluded() | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExcluded(value) | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNode() | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setParentNode(value) | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Nombre | Descripción |
+| --- | --- |
+| getScene() | Obtiene la escena a la que pertenece este objeto |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### toMesh{#toMesh}
+
+| Nombre | Descripción |
+| --- | --- |
+| toMesh() | Convertir el objeto actual a malla |
+
+ **Result:**
+Malla
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBoundingBox() | Obtiene el cuadro delimitador de la entidad actual en su sistema de coordenadas de espacio de objeto. |
+
+ **Result:**
+Malla
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEntityRendererKey() | Obtiene la clave del renderizador de entidad registrado en el renderizador |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/transform/_index.md
+++ b/spanish/nodejs-java/aspose.threed/transform/_index.md
@@ -1,0 +1,561 @@
+---
+title: "Transform"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/transform/
+---
+## Transform class
+
+Una transformación contiene información que permite acceder a la traslación/escala/rotación del objeto o a la matriz de transformación con el coste mínimo.  Esto se usa en la transformación local.  @hideconstructor
+
+
+## Métodos
+
+### getGeometricTranslation{#getGeometricTranslation}
+
+| Nombre | Descripción |
+| --- | --- |
+| getGeometricTranslation() | Obtiene o establece la traslación geométrica. La transformación geométrica solo afecta a las entidades adjuntas y deja sin efecto a los nodos hijos. Se combinará como transformación local cuando exporte la transformación geométrica a tipos de archivo que no la soportan. |
+
+ **Result:**
+
+
+
+---
+
+
+### setGeometricTranslation{#setGeometricTranslation}
+
+| Nombre | Descripción |
+| --- | --- |
+| setGeometricTranslation(value) | Obtiene o establece la traslación geométrica. La transformación geométrica solo afecta a las entidades adjuntas y deja sin efecto a los nodos hijos. Se combinará como transformación local cuando exporte la transformación geométrica a tipos de archivo que no la soportan. |
+
+ **Result:**
+
+
+
+---
+
+
+### getGeometricScaling{#getGeometricScaling}
+
+| Nombre | Descripción |
+| --- | --- |
+| getGeometricScaling() | Obtiene o establece el escalado geométrico. La transformación geométrica solo afecta a las entidades adjuntas y deja sin efecto a los nodos hijos. Se combinará como transformación local cuando exporte la transformación geométrica a tipos de archivo que no la soportan. |
+
+ **Result:**
+
+
+
+---
+
+
+### setGeometricScaling{#setGeometricScaling}
+
+| Nombre | Descripción |
+| --- | --- |
+| setGeometricScaling(value) | Obtiene o establece el escalado geométrico. La transformación geométrica solo afecta a las entidades adjuntas y deja sin efecto a los nodos hijos. Se combinará como transformación local cuando exporte la transformación geométrica a tipos de archivo que no la soportan. |
+
+ **Result:**
+
+
+
+---
+
+
+### getGeometricRotation{#getGeometricRotation}
+
+| Nombre | Descripción |
+| --- | --- |
+| getGeometricRotation() | Obtiene o establece la rotación Euler geométrica (medida en grados). La transformación geométrica solo afecta a las entidades adjuntas y deja sin efecto a los nodos hijos. Se combinará como transformación local cuando exporte la transformación geométrica a tipos de archivo que no la soportan. |
+
+ **Result:**
+
+
+
+---
+
+
+### setGeometricRotation{#setGeometricRotation}
+
+| Nombre | Descripción |
+| --- | --- |
+| setGeometricRotation(value) | Obtiene o establece la rotación Euler geométrica (medida en grados). La transformación geométrica solo afecta a las entidades adjuntas y deja sin efecto a los nodos hijos. Se combinará como transformación local cuando exporte la transformación geométrica a tipos de archivo que no la soportan. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTranslation{#getTranslation}
+
+| Nombre | Descripción |
+| --- | --- |
+| getTranslation() | Obtiene o establece la traslación |
+
+ **Result:**
+
+
+
+---
+
+
+### setTranslation{#setTranslation}
+
+| Nombre | Descripción |
+| --- | --- |
+| setTranslation(value) | Obtiene o establece la traslación |
+
+ **Result:**
+
+
+
+---
+
+
+### getScale{#getScale}
+
+| Nombre | Descripción |
+| --- | --- |
+| getScale() | Obtiene o establece la escala |
+
+ **Result:**
+
+
+
+---
+
+
+### setScale{#setScale}
+
+| Nombre | Descripción |
+| --- | --- |
+| setScale(value) | Obtiene o establece la escala |
+
+ **Result:**
+
+
+
+---
+
+
+### getPreRotation{#getPreRotation}
+
+| Nombre | Descripción |
+| --- | --- |
+| getPreRotation() | Obtiene o establece la pre-rotación representada en grados |
+
+ **Result:**
+
+
+
+---
+
+
+### setPreRotation{#setPreRotation}
+
+| Nombre | Descripción |
+| --- | --- |
+| setPreRotation(value) | Obtiene o establece la pre-rotación representada en grados |
+
+ **Result:**
+
+
+
+---
+
+
+### getPostRotation{#getPostRotation}
+
+| Nombre | Descripción |
+| --- | --- |
+| getPostRotation() | Obtiene o establece la post-rotación representada en grados |
+
+ **Result:**
+
+
+
+---
+
+
+### setPostRotation{#setPostRotation}
+
+| Nombre | Descripción |
+| --- | --- |
+| setPostRotation(value) | Obtiene o establece la post-rotación representada en grados |
+
+ **Result:**
+
+
+
+---
+
+
+### getEulerAngles{#getEulerAngles}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEulerAngles() | Obtiene o establece la rotación representada en ángulos de Euler, medida en grados |
+
+ **Result:**
+
+
+
+---
+
+
+### setEulerAngles{#setEulerAngles}
+
+| Nombre | Descripción |
+| --- | --- |
+| setEulerAngles(value) | Obtiene o establece la rotación representada en ángulos de Euler, medida en grados |
+
+ **Result:**
+
+
+
+---
+
+
+### getRotation{#getRotation}
+
+| Nombre | Descripción |
+| --- | --- |
+| getRotation() | Obtiene o establece la rotación representada en cuaternión. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRotation{#setRotation}
+
+| Nombre | Descripción |
+| --- | --- |
+| setRotation(value) | Obtiene o establece la rotación representada en cuaternión. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTransformMatrix{#getTransformMatrix}
+
+| Nombre | Descripción |
+| --- | --- |
+| getTransformMatrix() | Obtiene o establece la matriz de transformación. Asignar a esto restablecerá la Translation, Scale y Rotation, la GeometricRotation, GeometricScaling y GeometricTranslation no se verán afectadas. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTransformMatrix{#setTransformMatrix}
+
+| Nombre | Descripción |
+| --- | --- |
+| setTransformMatrix(value) | Obtiene o establece la matriz de transformación. Asignar a esto restablecerá la Translation, Scale y Rotation, la GeometricRotation, GeometricScaling y GeometricTranslation no se verán afectadas. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### setGeometricTranslation{#setGeometricTranslation}
+
+| Nombre | Descripción |
+| --- | --- |
+| setGeometricTranslation(x, y, z) | Establece la traducción geométrica. La transformación geométrica solo afecta a las entidades adjuntas y deja los nodos hijos sin cambios. Se fusionará como transformación local cuando exportes la transformación geométrica a tipos de archivo que no la soporten. |
+
+ **Result:**
+
+
+
+---
+
+
+### setGeometricScaling{#setGeometricScaling}
+
+| Nombre | Descripción |
+| --- | --- |
+| setGeometricScaling(sx, sy, sz) | Establece el escalado geométrico. La transformación geométrica solo afecta a las entidades adjuntas y deja los nodos hijos sin cambios. Se fusionará como transformación local cuando exportes la transformación geométrica a tipos de archivo que no la soporten. |
+
+ **Result:**
+
+
+
+---
+
+
+### setGeometricRotation{#setGeometricRotation}
+
+| Nombre | Descripción |
+| --- | --- |
+| setGeometricRotation(rx, ry, rz) | Establece la rotación geométrica de Euler (medida en grados). La transformación geométrica solo afecta a las entidades adjuntas y deja los nodos hijos sin cambios. Se fusionará como transformación local cuando exportes la transformación geométrica a tipos de archivo que no la soporten. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTranslation{#setTranslation}
+
+| Nombre | Descripción |
+| --- | --- |
+| setTranslation(tx, ty, tz) | Establece la traslación de la transformación actual. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| t | Número | null |
+| t | Número | null |
+| t | Número | null |
+
+ **Result:**
+Transform
+
+
+---
+
+
+### setScale{#setScale}
+
+| Nombre | Descripción |
+| --- | --- |
+| setScale(sx, sy, sz) | Establece la escala de la transformación actual. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| s | Número | null |
+| s | Número | null |
+| s | Número | null |
+
+ **Result:**
+Transform
+
+
+---
+
+
+### setEulerAngles{#setEulerAngles}
+
+| Nombre | Descripción |
+| --- | --- |
+| setEulerAngles(rx, ry, rz) | Establece los ángulos de Euler en grados de la transformación actual. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| r | Número | null |
+| r | Número | null |
+| r | Número | null |
+
+ **Result:**
+Transform
+
+
+---
+
+
+### setRotation{#setRotation}
+
+| Nombre | Descripción |
+| --- | --- |
+| setRotation(rw, rx, ry, rz) | Establece la rotación (como componentes del cuaternión) de la transformación actual. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| r | Número | null |
+| r | Número | null |
+| r | Número | null |
+| r | Número | null |
+
+ **Result:**
+Transform
+
+
+---
+
+
+### setPreRotation{#setPreRotation}
+
+| Nombre | Descripción |
+| --- | --- |
+| setPreRotation(rx, ry, rz) | Establece la pre-rotación representada en grados |
+
+ **Result:**
+Transform
+
+
+---
+
+
+### setPostRotation{#setPostRotation}
+
+| Nombre | Descripción |
+| --- | --- |
+| setPostRotation(rx, ry, rz) | Establece la post-rotación representada en grados |
+
+ **Result:**
+Transform
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/transformbuilder/_index.md
+++ b/spanish/nodejs-java/aspose.threed/transformbuilder/_index.md
@@ -1,0 +1,457 @@
+---
+title: "TransformBuilder"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/transformbuilder/
+---
+## TransformBuilder class
+
+El TransformBuilder se usa para construir la matriz de transformación mediante una cadena de transformaciones.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor(initial, order) | Construye un TransformBuilder con la matriz de transformación inicial y el orden de composición especificado. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| initia | Matrix4 | null |
+| orden | ComposeOrder | ComposeOrder |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload(order) | Construye un TransformBuilder con la matriz de transformación de identidad inicial y el orden de composición especificado. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| orden | ComposeOrder | ComposeOrder |
+
+ **Result:**
+
+
+
+---
+
+
+### getMatrix{#getMatrix}
+
+| Nombre | Descripción |
+| --- | --- |
+| getMatrix() | Obtiene o establece el valor de la matriz actual. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMatrix{#setMatrix}
+
+| Nombre | Descripción |
+| --- | --- |
+| setMatrix(value) | Obtiene o establece el valor de la matriz actual. |
+
+ **Result:**
+
+
+
+---
+
+
+### getComposeOrder{#getComposeOrder}
+
+| Nombre | Descripción |
+| --- | --- |
+| getComposeOrder() | Obtiene o establece el orden de composición de la cadena. El valor de la propiedad es la constante entera ComposeOrder. |
+
+ **Result:**
+
+
+
+---
+
+
+### setComposeOrder{#setComposeOrder}
+
+| Nombre | Descripción |
+| --- | --- |
+| setComposeOrder(value) | Obtiene o establece el orden de composición de la cadena. El valor de la propiedad es la constante entera ComposeOrder. |
+
+ **Result:**
+
+
+
+---
+
+
+### compose{#compose}
+
+| Nombre | Descripción |
+| --- | --- |
+| compose(m) | Añadir o anteponer el argumento a la matriz interna. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+|  | Matrix4 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### append{#append}
+
+| Nombre | Descripción |
+| --- | --- |
+| append(m) | Añade la nueva matriz de transformación a la cadena de transformaciones. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+|  | Matrix4 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### prepend{#prepend}
+
+| Nombre | Descripción |
+| --- | --- |
+| prepend(m) | Anteponer la nueva matriz de transformación a la cadena de transformaciones. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+|  | Matrix4 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### rearrange{#rearrange}
+
+| Nombre | Descripción |
+| --- | --- |
+| rearrange(newX, newY, newZ) | Reorganizar la disposición del eje. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| newX | Eje | Eje |
+| newY | Eje | Eje |
+| newZ | Eje | Eje |
+
+ **Result:**
+
+
+
+---
+
+
+### scale{#scale}
+
+| Nombre | Descripción |
+| --- | --- |
+| escala(s) | Encadenar una matriz de transformación de escala con un componente escalado por s |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+|  | Número | null |
+
+ **Result:**
+
+
+
+---
+
+
+### scale{#scale}
+
+| Nombre | Descripción |
+| --- | --- |
+| scale(x, y, z) | Encadenar una matriz de transformación de escala |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+|  | Número | null |
+|  | Número | null |
+|  | Número | null |
+
+ **Result:**
+
+
+
+---
+
+
+### scale{#scale}
+
+| Nombre | Descripción |
+| --- | --- |
+| escala(s) | Encadenar una transformación de escala |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+|  | Vector3 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### rotateDegree{#rotateDegree}
+
+| Nombre | Descripción |
+| --- | --- |
+| rotateDegree(angle, axis) | Encadenar una transformación de rotación en grados |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| ángulo | Número | El ángulo a rotar en grados |
+| eje | Vector3 | El eje a rotar |
+
+ **Result:**
+
+
+
+---
+
+
+### rotateRadian{#rotateRadian}
+
+| Nombre | Descripción |
+| --- | --- |
+| rotateRadian(angle, axis) | Encadenar una transformación de rotación en radianes |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| ángulo | Número | El ángulo a rotar en radianes |
+| eje | Vector3 | El eje a rotar |
+
+ **Result:**
+
+
+
+---
+
+
+### rotate{#rotate}
+
+| Nombre | Descripción |
+| --- | --- |
+| rotate(q) | Encadenar una rotación mediante un cuaternión |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+|  | Cuaternión | null |
+
+ **Result:**
+
+
+
+---
+
+
+### rotateEulerDegree{#rotateEulerDegree}
+
+| Nombre | Descripción |
+| --- | --- |
+| rotateEulerDegree(degX, degY, degZ) | Encadenar una rotación mediante ángulos de Euler en grados |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| deg | Número | null |
+| deg | Número | null |
+| deg | Número | null |
+
+ **Result:**
+
+
+
+---
+
+
+### rotateEulerRadian{#rotateEulerRadian}
+
+| Nombre | Descripción |
+| --- | --- |
+| rotateEulerRadian(x, y, z) | Encadenar una rotación mediante ángulos de Euler en radianes |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+|  | Número | null |
+|  | Número | null |
+|  | Número | null |
+
+ **Result:**
+
+
+
+---
+
+
+### rotateEulerRadian{#rotateEulerRadian}
+
+| Nombre | Descripción |
+| --- | --- |
+| rotateEulerRadian(r) | Encadenar una rotación mediante ángulos de Euler en radianes |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+|  | Vector3 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### translate{#translate}
+
+| Nombre | Descripción |
+| --- | --- |
+| translate(tx, ty, tz) | Encadenar una transformación de traslación |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| t | Número | null |
+| t | Número | null |
+| t | Número | null |
+
+ **Result:**
+
+
+
+---
+
+
+### translate{#translate}
+
+| Nombre | Descripción |
+| --- | --- |
+| translate(v) | Encadenar una transformación de traslación |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+|  | Vector3 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### reset{#reset}
+
+| Nombre | Descripción |
+| --- | --- |
+| reset() | Restablecer la transformación a la matriz identidad |
+
+ **Result:**
+
+
+
+---
+
+
+### rotateDegree{#rotateDegree}
+
+| Nombre | Descripción |
+| --- | --- |
+| rotateDegree(rot, order) | Agregar rotación con el orden especificado |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| rot | Vector3 | Rotación en grados |
+| orden | RotationOrder | RotationOrder |
+
+ **Result:**
+
+
+
+---
+
+
+### rotateRadian{#rotateRadian}
+
+| Nombre | Descripción |
+| --- | --- |
+| rotateRadian(rot, order) | Agregar rotación con el orden especificado |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| rot | Vector3 | Rotación en radianes |
+| orden | RotationOrder | RotationOrder |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/transformedcurve/_index.md
+++ b/spanish/nodejs-java/aspose.threed/transformedcurve/_index.md
@@ -1,0 +1,359 @@
+---
+title: "TransformedCurve"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/transformedcurve/
+---
+## TransformedCurve class
+
+Una TransformedCurve asigna una posición a una curva usando una matriz de transformación.  Esto permite realizar una transformación dentro de una TrimmedCurve o CompositeCurve.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | El constructor de TransformedCurve |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload(basisCurve, transformation) | El constructor de TransformedCurve |
+
+ **Result:**
+
+
+
+---
+
+
+### getTransformMatrix{#getTransformMatrix}
+
+| Nombre | Descripción |
+| --- | --- |
+| getTransformMatrix() | La matriz de transformación. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTransformMatrix{#setTransformMatrix}
+
+| Nombre | Descripción |
+| --- | --- |
+| setTransformMatrix(value) | La matriz de transformación. |
+
+ **Result:**
+
+
+
+---
+
+
+### getBasisCurve{#getBasisCurve}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBasisCurve() | La curva base. |
+
+ **Result:**
+
+
+
+---
+
+
+### setBasisCurve{#setBasisCurve}
+
+| Nombre | Descripción |
+| --- | --- |
+| setBasisCurve(value) | La curva base. |
+
+ **Result:**
+
+
+
+---
+
+
+### getColor{#getColor}
+
+| Nombre | Descripción |
+| --- | --- |
+| getColor() | Obtiene o establece el color de la línea, el valor predeterminado es blanco(1, 1, 1) |
+
+ **Result:**
+
+
+
+---
+
+
+### setColor{#setColor}
+
+| Nombre | Descripción |
+| --- | --- |
+| setColor(value) | Obtiene o establece el color de la línea, el valor predeterminado es blanco(1, 1, 1) |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNodes() | Obtiene todos los nodos padre; una entidad puede estar adjunta a varios nodos padre para la instanciación de geometría. Los nodos. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExcluded() | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExcluded(value) | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNode() | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setParentNode(value) | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Nombre | Descripción |
+| --- | --- |
+| getScene() | Obtiene la escena a la que pertenece este objeto |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEntityRendererKey() | Obtiene la clave del renderizador de entidad registrado en el renderizador |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBoundingBox() | Obtiene el cuadro delimitador de la entidad actual en su sistema de coordenadas de espacio de objeto. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/trapeziumshape/_index.md
+++ b/spanish/nodejs-java/aspose.threed/trapeziumshape/_index.md
@@ -1,0 +1,385 @@
+---
+title: "TrapeziumShape"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/trapeziumshape/
+---
+## TrapeziumShape class
+
+Forma de trapecio compatible con IFC definida por parámetros.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Constructor de TrapeziumShape |
+
+ **Result:**
+
+
+
+---
+
+
+### getBottomXDim{#getBottomXDim}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBottomXDim() | Obtiene o establece la extensión de la línea inferior medida a lo largo del eje x. |
+
+ **Result:**
+
+
+
+---
+
+
+### setBottomXDim{#setBottomXDim}
+
+| Nombre | Descripción |
+| --- | --- |
+| setBottomXDim(value) | Obtiene o establece la extensión de la línea inferior medida a lo largo del eje x. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTopXDim{#getTopXDim}
+
+| Nombre | Descripción |
+| --- | --- |
+| getTopXDim() | Obtiene o establece la extensión de la línea superior medida a lo largo del eje x. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTopXDim{#setTopXDim}
+
+| Nombre | Descripción |
+| --- | --- |
+| setTopXDim(value) | Obtiene o establece la extensión de la línea superior medida a lo largo del eje x. |
+
+ **Result:**
+
+
+
+---
+
+
+### getYDim{#getYDim}
+
+| Nombre | Descripción |
+| --- | --- |
+| getYDim() | Obtiene o establece la distancia entre las líneas superior e inferior medida a lo largo del eje y. |
+
+ **Result:**
+
+
+
+---
+
+
+### setYDim{#setYDim}
+
+| Nombre | Descripción |
+| --- | --- |
+| setYDim(value) | Obtiene o establece la distancia entre las líneas superior e inferior medida a lo largo del eje y. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTopXOffset{#getTopXOffset}
+
+| Nombre | Descripción |
+| --- | --- |
+| getTopXOffset() | Obtiene o establece el desplazamiento desde el inicio de la línea superior hasta la línea inferior. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTopXOffset{#setTopXOffset}
+
+| Nombre | Descripción |
+| --- | --- |
+| setTopXOffset(value) | Obtiene o establece el desplazamiento desde el inicio de la línea superior hasta la línea inferior. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNodes() | Obtiene todos los nodos padre; una entidad puede estar adjunta a varios nodos padre para la instanciación de geometría. Los nodos. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExcluded() | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExcluded(value) | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNode() | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setParentNode(value) | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Nombre | Descripción |
+| --- | --- |
+| getScene() | Obtiene la escena a la que pertenece este objeto |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtent{#getExtent}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExtent() | Obtiene la extensión en las dimensiones x e y. |
+
+ **Result:**
+Vector2
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEntityRendererKey() | Obtiene la clave del renderizador de entidad registrado en el renderizador |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBoundingBox() | Obtiene el cuadro delimitador de la entidad actual en su sistema de coordenadas de espacio de objeto. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/trialexception/_index.md
+++ b/spanish/nodejs-java/aspose.threed/trialexception/_index.md
@@ -1,0 +1,61 @@
+---
+title: "TrialException"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/trialexception/
+---
+## TrialException class
+
+Esto se genera en Scene.Open/Scene.Save cuando no se aplican licencias.  Puedes desactivar esta excepción estableciendo SuppressTrialException a true.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor(msg) | Constructor de TrialException |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| ms | Cadena | null |
+
+ **Result:**
+
+
+
+---
+
+
+### getSuppressTrialException{#getSuppressTrialException}
+
+| Nombre | Descripción |
+| --- | --- |
+| getSuppressTrialException() | Establece esto en true para suprimir la TrialException para uso sin licencia, pero las restricciones no se levantarán. Para levantar las restricciones, por favor use una licencia adecuada. Y establecer esto en true también significa que usted es consciente de las restricciones sin licencia. |
+
+ **Result:**
+
+
+
+---
+
+
+### setSuppressTrialException{#setSuppressTrialException}
+
+| Nombre | Descripción |
+| --- | --- |
+| setSuppressTrialException(value) | Establece esto en true para suprimir la TrialException para uso sin licencia, pero las restricciones no se levantarán. Para levantar las restricciones, por favor use una licencia adecuada. Y establecer esto en true también significa que usted es consciente de las restricciones sin licencia. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/trimesh/_index.md
+++ b/spanish/nodejs-java/aspose.threed/trimesh/_index.md
@@ -1,0 +1,679 @@
+---
+title: "TriMesh"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/trimesh/
+---
+## TriMesh class
+
+Un TriMesh contiene datos sin procesar que pueden ser usados directamente por la GPU.  Esta clase es una utilidad para ayudar a construir una malla que solo contiene datos por vértice.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor(name, declaration) | Inicializar una instancia de TriMesh |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| name | Cadena | El nombre de este TriMesh |
+| declaración | VertexDeclaration | La declaración del vértice |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexDeclaration{#getVertexDeclaration}
+
+| Nombre | Descripción |
+| --- | --- |
+| getVertexDeclaration() | La disposición de vértices del TriMesh. |
+
+ **Result:**
+
+
+
+---
+
+
+### getVerticesCount{#getVerticesCount}
+
+| Nombre | Descripción |
+| --- | --- |
+| getVerticesCount() | El número de vértices en este TriMesh |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndicesCount{#getIndicesCount}
+
+| Nombre | Descripción |
+| --- | --- |
+| getIndicesCount() | El número de índices en este TriMesh |
+
+ **Result:**
+
+
+
+---
+
+
+### getUnmergedVerticesCount{#getUnmergedVerticesCount}
+
+| Nombre | Descripción |
+| --- | --- |
+| getUnmergedVerticesCount() | El número de vértices no fusionados que se pasaron mediante beginVertex() y endVertex(). |
+
+ **Result:**
+
+
+
+---
+
+
+### getCapacity{#getCapacity}
+
+| Nombre | Descripción |
+| --- | --- |
+| getCapacity() | La capacidad de los vértices preasignados. |
+
+ **Result:**
+
+
+
+---
+
+
+### getVerticesSizeInBytes{#getVerticesSizeInBytes}
+
+| Nombre | Descripción |
+| --- | --- |
+| getVerticesSizeInBytes() | El tamaño total de todos los vértices en bytes |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNodes() | Obtiene todos los nodos padre; una entidad puede estar adjunta a varios nodos padre para la instanciación de geometría. Los nodos. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExcluded() | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExcluded(value) | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNode() | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setParentNode(value) | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Nombre | Descripción |
+| --- | --- |
+| getScene() | Obtiene la escena a la que pertenece este objeto |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### fromMesh{#fromMesh}
+
+| Nombre | Descripción |
+| --- | --- |
+| fromMesh(declaration, mesh) | Crea un TriMesh a partir del objeto mesh dado con la disposición de vértices especificada. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| declaración | VertexDeclaration | null |
+| malla | Malla | null |
+
+ **Result:**
+TriMesh
+
+
+---
+
+
+### copyFrom{#copyFrom}
+
+| Nombre | Descripción |
+| --- | --- |
+| copyFrom(input, vd) | Copia el TriMesh de la entrada con una nueva disposición de vértices |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| input | TriMesh | El TriMesh de entrada para copiar |
+| vd | VertexDeclaration | La nueva declaración de vértices del TriMesh de salida |
+
+ **Result:**
+TriMesh
+
+
+---
+
+
+### fromMesh{#fromMesh}
+
+| Nombre | Descripción |
+| --- | --- |
+| fromMesh(mesh, useFloat) | Crea un TriMesh a partir del objeto mesh dado, la declaración de vértices se basa en la estructura del mesh de entrada. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| malla | Malla | null |
+| useFloat | boolean | Utiliza el tipo float en lugar del tipo double para cada componente del elemento de vértice. |
+
+ **Result:**
+TriMesh
+
+
+---
+
+
+### beginVertex{#beginVertex}
+
+| Nombre | Descripción |
+| --- | --- |
+| beginVertex() | Comienza a agregar vértice |
+
+ **Result:**
+Vértice
+
+
+---
+
+
+### endVertex{#endVertex}
+
+| Nombre | Descripción |
+| --- | --- |
+| endVertex() | Finalizar la adición del vértice |
+
+ **Result:**
+Vértice
+
+
+---
+
+
+### verticesToArray{#verticesToArray}
+
+| Nombre | Descripción |
+| --- | --- |
+| verticesToArray() | Convertir los datos de los vértices a un arreglo de bytes |
+
+ **Result:**
+byte[]
+
+
+---
+
+
+### toString{#toString}
+
+| Nombre | Descripción |
+| --- | --- |
+| toString() |  |
+
+ **Result:**
+Cadena
+
+
+---
+
+
+### fromRawData{#fromRawData}
+
+| Nombre | Descripción |
+| --- | --- |
+| fromRawData(vd, vertices, indices, generateVertexMapping) | Crear TriMesh a partir de datos sin procesar. El TriMesh devuelto no copiará el arreglo de bytes de entrada por rendimiento; los cambios externos en el arreglo se reflejarán en esta instancia. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| vd | VertexDeclaration | Declaración de vértice, debe contener al menos un campo. |
+| vertices | byte[] | Los datos de vértice de entrada, la longitud mínima de los vértices debe ser mayor o igual al tamaño de la declaración de vértice. |
+| indices | Number[] | Los índices de triángulo |
+| generateVertexMapping | boolean | Generar |
+
+ **Result:**
+TriMesh
+
+
+---
+
+
+### loadVerticesFromBytes{#loadVerticesFromBytes}
+
+| Nombre | Descripción |
+| --- | --- |
+| loadVerticesFromBytes(verticesInBytes) | Cargar vértices desde bytes, la longitud de los bytes debe ser un múltiplo entero del tamaño del vértice. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| verticesInByte | byte[] | null |
+
+ **Result:**
+TriMesh
+
+
+---
+
+
+### readVector4{#readVector4}
+
+| Nombre | Descripción |
+| --- | --- |
+| readVector4(idx, field) | Leer el campo vector4 |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| idx | Número | El índice del vértice a leer |
+| field | VertexField | El campo con un tipo de datos Vector4/FVector4 |
+
+ **Result:**
+Vector4
+
+
+---
+
+
+### readFVector4{#readFVector4}
+
+| Nombre | Descripción |
+| --- | --- |
+| readFVector4(idx, field) | Leer el campo vector4 |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| idx | Número | El índice del vértice a leer |
+| field | VertexField | El campo con un tipo de datos Vector4/FVector4 |
+
+ **Result:**
+FVector4
+
+
+---
+
+
+### readVector3{#readVector3}
+
+| Nombre | Descripción |
+| --- | --- |
+| readVector3(idx, field) | Leer el campo vector3 |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| idx | Número | El índice del vértice a leer |
+| field | VertexField | El campo con un tipo de datos Vector3/FVector3 |
+
+ **Result:**
+Vector3
+
+
+---
+
+
+### readFVector3{#readFVector3}
+
+| Nombre | Descripción |
+| --- | --- |
+| readFVector3(idx, field) | Leer el campo vector3 |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| idx | Número | El índice del vértice a leer |
+| field | VertexField | El campo con un tipo de datos Vector3/FVector3 |
+
+ **Result:**
+FVector3
+
+
+---
+
+
+### readVector2{#readVector2}
+
+| Nombre | Descripción |
+| --- | --- |
+| readVector2(idx, field) | Leer el campo vector2 |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| idx | Número | El índice del vértice a leer |
+| field | VertexField | El campo con un tipo de datos Vector2/FVector2 |
+
+ **Result:**
+Vector2
+
+
+---
+
+
+### readFVector2{#readFVector2}
+
+| Nombre | Descripción |
+| --- | --- |
+| readFVector2(idx, field) | Leer el campo vector2 |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| idx | Número | El índice del vértice a leer |
+| field | VertexField | El campo con un tipo de datos Vector2/FVector2 |
+
+ **Result:**
+FVector2
+
+
+---
+
+
+### readDouble{#readDouble}
+
+| Nombre | Descripción |
+| --- | --- |
+| readDouble(idx, field) | Leer el campo double |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| idx | Número | El índice del vértice a leer |
+| field | VertexField | El campo con un tipo de datos compatible con float/double |
+
+ **Result:**
+Número
+
+
+---
+
+
+### readFloat{#readFloat}
+
+| Nombre | Descripción |
+| --- | --- |
+| readFloat(idx, field) | Leer el campo float |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| idx | Número | El índice del vértice a leer |
+| field | VertexField | El campo con un tipo de datos compatible con float/double |
+
+ **Result:**
+Número
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBoundingBox() | Obtiene el cuadro delimitador de la entidad actual en su sistema de coordenadas de espacio de objeto. |
+
+ **Result:**
+Número
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEntityRendererKey() | Obtiene la clave del renderizador de entidad registrado en el renderizador |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+### iterator{#iterator}
+
+| Nombre | Descripción |
+| --- | --- |
+| iterator() | Reservado para uso interno. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/trimmedcurve/_index.md
+++ b/spanish/nodejs-java/aspose.threed/trimmedcurve/_index.md
@@ -1,0 +1,398 @@
+---
+title: "TrimmedCurve"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/trimmedcurve/
+---
+## TrimmedCurve class
+
+Una curva acotada que recorta la curva base en ambos extremos.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Constructor de TrimmedCurve |
+
+ **Result:**
+
+
+
+---
+
+
+### getBasisCurve{#getBasisCurve}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBasisCurve() | La curva base que se recortará. |
+
+ **Result:**
+
+
+
+---
+
+
+### setBasisCurve{#setBasisCurve}
+
+| Nombre | Descripción |
+| --- | --- |
+| setBasisCurve(value) | La curva base que se recortará. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFirst{#getFirst}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFirst() | El primer punto final a recortar, puede ser un punto cartesiano o un parámetro real. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFirst{#setFirst}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFirst(value) | El primer punto final a recortar, puede ser un punto cartesiano o un parámetro real. |
+
+ **Result:**
+
+
+
+---
+
+
+### getSecond{#getSecond}
+
+| Nombre | Descripción |
+| --- | --- |
+| getSecond() | El segundo punto final a recortar, puede ser un punto cartesiano o un parámetro real. |
+
+ **Result:**
+
+
+
+---
+
+
+### setSecond{#setSecond}
+
+| Nombre | Descripción |
+| --- | --- |
+| setSecond(value) | El segundo punto final a recortar, puede ser un punto cartesiano o un parámetro real. |
+
+ **Result:**
+
+
+
+---
+
+
+### getSameDirection{#getSameDirection}
+
+| Nombre | Descripción |
+| --- | --- |
+| getSameDirection() | Obtiene o establece si el resultado recortado utiliza la misma dirección de la curva base. |
+
+ **Result:**
+
+
+
+---
+
+
+### setSameDirection{#setSameDirection}
+
+| Nombre | Descripción |
+| --- | --- |
+| setSameDirection(value) | Obtiene o establece si el resultado recortado utiliza la misma dirección de la curva base. |
+
+ **Result:**
+
+
+
+---
+
+
+### getColor{#getColor}
+
+| Nombre | Descripción |
+| --- | --- |
+| getColor() | Obtiene o establece el color de la línea, el valor predeterminado es blanco(1, 1, 1) |
+
+ **Result:**
+
+
+
+---
+
+
+### setColor{#setColor}
+
+| Nombre | Descripción |
+| --- | --- |
+| setColor(value) | Obtiene o establece el color de la línea, el valor predeterminado es blanco(1, 1, 1) |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNodes() | Obtiene todos los nodos padre; una entidad puede estar adjunta a varios nodos padre para la instanciación de geometría. Los nodos. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExcluded() | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExcluded(value) | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNode() | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setParentNode(value) | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Nombre | Descripción |
+| --- | --- |
+| getScene() | Obtiene la escena a la que pertenece este objeto |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEntityRendererKey() | Obtiene la clave del renderizador de entidad registrado en el renderizador |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBoundingBox() | Obtiene el cuadro delimitador de la entidad actual en su sistema de coordenadas de espacio de objeto. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/tshape/_index.md
+++ b/spanish/nodejs-java/aspose.threed/tshape/_index.md
@@ -1,0 +1,463 @@
+---
+title: "TShape"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/tshape/
+---
+## TShape class
+
+Forma en T compatible con IFC definida por parámetros.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Constructor de TShape |
+
+ **Result:**
+
+
+
+---
+
+
+### getDepth{#getDepth}
+
+| Nombre | Descripción |
+| --- | --- |
+| getDepth() | Obtiene o establece la longitud del web. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDepth{#setDepth}
+
+| Nombre | Descripción |
+| --- | --- |
+| setDepth(value) | Obtiene o establece la longitud del web. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlangeWidth{#getFlangeWidth}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFlangeWidth() | Obtiene o establece la longitud del flange. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlangeWidth{#setFlangeWidth}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFlangeWidth(value) | Obtiene o establece la longitud del flange. |
+
+ **Result:**
+
+
+
+---
+
+
+### getWebThickness{#getWebThickness}
+
+| Nombre | Descripción |
+| --- | --- |
+| getWebThickness() | Obtiene o establece el espesor de la pared del web. |
+
+ **Result:**
+
+
+
+---
+
+
+### setWebThickness{#setWebThickness}
+
+| Nombre | Descripción |
+| --- | --- |
+| setWebThickness(value) | Obtiene o establece el espesor de la pared del web. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlangeThickness{#getFlangeThickness}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFlangeThickness() | Obtiene o establece el espesor de la pared del flange. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlangeThickness{#setFlangeThickness}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFlangeThickness(value) | Obtiene o establece el espesor de la pared del flange. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFilletRadius{#getFilletRadius}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFilletRadius() | Obtiene o establece el radio del filete entre el alma y el flanco. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFilletRadius{#setFilletRadius}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFilletRadius(value) | Obtiene o establece el radio del filete entre el alma y el flanco. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlangeEdgeRadius{#getFlangeEdgeRadius}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFlangeEdgeRadius() | Obtiene o establece el radio del borde del flanco. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlangeEdgeRadius{#setFlangeEdgeRadius}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFlangeEdgeRadius(value) | Obtiene o establece el radio del borde del flanco. |
+
+ **Result:**
+
+
+
+---
+
+
+### getWebEdgeRadius{#getWebEdgeRadius}
+
+| Nombre | Descripción |
+| --- | --- |
+| getWebEdgeRadius() | Obtiene o establece el radio del borde del alma. |
+
+ **Result:**
+
+
+
+---
+
+
+### setWebEdgeRadius{#setWebEdgeRadius}
+
+| Nombre | Descripción |
+| --- | --- |
+| setWebEdgeRadius(value) | Obtiene o establece el radio del borde del alma. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNodes() | Obtiene todos los nodos padre; una entidad puede estar adjunta a varios nodos padre para la instanciación de geometría. Los nodos. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExcluded() | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExcluded(value) | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNode() | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setParentNode(value) | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Nombre | Descripción |
+| --- | --- |
+| getScene() | Obtiene la escena a la que pertenece este objeto |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtent{#getExtent}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExtent() | Obtiene la extensión en las dimensiones x e y. |
+
+ **Result:**
+Vector2
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEntityRendererKey() | Obtiene la clave del renderizador de entidad registrado en el renderizador |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBoundingBox() | Obtiene el cuadro delimitador de la entidad actual en su sistema de coordenadas de espacio de objeto. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/u3dloadoptions/_index.md
+++ b/spanish/nodejs-java/aspose.threed/u3dloadoptions/_index.md
@@ -1,0 +1,146 @@
+---
+title: "U3dLoadOptions"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/u3dloadoptions/
+---
+## U3dLoadOptions class
+
+Opciones de carga para universal 3d
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Constructor de U3dLoadOptions |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlipCoordinateSystem{#getFlipCoordinateSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFlipCoordinateSystem() | Obtiene o establece si se invierte el sistema de coordenadas de los puntos de control/normal durante la importación/exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlipCoordinateSystem{#setFlipCoordinateSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFlipCoordinateSystem(value) | Obtiene o establece si se invierte el sistema de coordenadas de los puntos de control/normal durante la importación/exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileFormat() | Obtiene el formato de archivo especificado en la opción actual de Guardar/Cargar. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEncoding() | Obtiene o establece la codificación predeterminada para archivos basados en texto. El valor predeterminado es null, lo que significa que el importador/exportador decidirá qué codificación usar. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileSystem() | Permite al usuario manejar cómo gestionar las dependencias externas durante la carga/guardado. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFileSystem(value) | Permite al usuario manejar cómo gestionar las dependencias externas durante la carga/guardado. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| Nombre | Descripción |
+| --- | --- |
+| getLookupPaths() | Algunos archivos como OBJ dependen de archivos externos; las rutas de búsqueda permiten que Aspose.3D busque el archivo externo para cargarlo. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileName() | El nombre de archivo de la escena de exportación/importación. Es opcional, pero útil al serializar recursos externos como el material de OBJ. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFileName(value) | El nombre de archivo de la escena de exportación/importación. Es opcional, pero útil al serializar recursos externos como el material de OBJ. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/u3dsaveoptions/_index.md
+++ b/spanish/nodejs-java/aspose.threed/u3dsaveoptions/_index.md
@@ -1,0 +1,328 @@
+---
+title: "U3dSaveOptions"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/u3dsaveoptions/
+---
+## U3dSaveOptions class
+
+Opciones de guardado para universal 3d
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Constructor de U3dSaveOptions |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlipCoordinateSystem{#getFlipCoordinateSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFlipCoordinateSystem() | Obtiene o establece si se invierte el sistema de coordenadas de los puntos de control/normal durante la importación/exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlipCoordinateSystem{#setFlipCoordinateSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFlipCoordinateSystem(value) | Obtiene o establece si se invierte el sistema de coordenadas de los puntos de control/normal durante la importación/exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMeshCompression{#getMeshCompression}
+
+| Nombre | Descripción |
+| --- | --- |
+| getMeshCompression() | Obtiene o establece si se debe habilitar la compresión de datos de malla. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMeshCompression{#setMeshCompression}
+
+| Nombre | Descripción |
+| --- | --- |
+| setMeshCompression(value) | Obtiene o establece si se debe habilitar la compresión de datos de malla. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportNormals{#getExportNormals}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExportNormals() | Obtiene o establece si se deben exportar los datos de normales. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportNormals{#setExportNormals}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExportNormals(value) | Obtiene o establece si se deben exportar los datos de normales. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportTextureCoordinates{#getExportTextureCoordinates}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExportTextureCoordinates() | Obtiene o establece si se deben exportar las coordenadas de textura. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextureCoordinates{#setExportTextureCoordinates}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExportTextureCoordinates(value) | Obtiene o establece si se deben exportar las coordenadas de textura. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportVertexDiffuse{#getExportVertexDiffuse}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExportVertexDiffuse() | Obtiene o establece si se exporta el color difuso del vértice. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportVertexDiffuse{#setExportVertexDiffuse}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExportVertexDiffuse(value) | Obtiene o establece si se exporta el color difuso del vértice. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportVertexSpecular{#getExportVertexSpecular}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExportVertexSpecular() | Obtiene o establece si se exporta el color especular del vértice. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportVertexSpecular{#setExportVertexSpecular}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExportVertexSpecular(value) | Obtiene o establece si se exporta el color especular del vértice. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEmbedTextures{#getEmbedTextures}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEmbedTextures() | Incrusta las texturas externas en el archivo U3D, el valor predeterminado es false. |
+
+ **Result:**
+
+
+
+---
+
+
+### setEmbedTextures{#setEmbedTextures}
+
+| Nombre | Descripción |
+| --- | --- |
+| setEmbedTextures(value) | Incrusta las texturas externas en el archivo U3D, el valor predeterminado es false. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportTextures{#getExportTextures}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExportTextures() | Intenta copiar las texturas usadas en la escena al directorio de salida. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextures{#setExportTextures}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExportTextures(value) | Intenta copiar las texturas usadas en la escena al directorio de salida. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileFormat() | Obtiene el formato de archivo especificado en la opción actual de Guardar/Cargar. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEncoding() | Obtiene o establece la codificación predeterminada para archivos basados en texto. El valor predeterminado es null, lo que significa que el importador/exportador decidirá qué codificación usar. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileSystem() | Permite al usuario manejar cómo gestionar las dependencias externas durante la carga/guardado. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFileSystem(value) | Permite al usuario manejar cómo gestionar las dependencias externas durante la carga/guardado. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| Nombre | Descripción |
+| --- | --- |
+| getLookupPaths() | Algunos archivos como OBJ dependen de archivos externos; las rutas de búsqueda permiten que Aspose.3D busque el archivo externo para cargarlo. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileName() | El nombre de archivo de la escena de exportación/importación. Es opcional, pero útil al serializar recursos externos como el material de OBJ. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFileName(value) | El nombre de archivo de la escena de exportación/importación. Es opcional, pero útil al serializar recursos externos como el material de OBJ. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/usdsaveoptions/_index.md
+++ b/spanish/nodejs-java/aspose.threed/usdsaveoptions/_index.md
@@ -1,0 +1,237 @@
+---
+title: "UsdSaveOptions"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/usdsaveoptions/
+---
+## UsdSaveOptions class
+
+Opciones de guardado para formatos USD/USDZ.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Inicializa una nueva UsdSaveOptions con el formato FileFormat.USD. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload(fileFormat) | Inicializa una nueva UsdSaveOptions con el formato USD/USDZ especificado. |
+
+ **Result:**
+
+
+
+---
+
+
+### getPrimitiveToMesh{#getPrimitiveToMesh}
+
+| Nombre | Descripción |
+| --- | --- |
+| getPrimitiveToMesh() | Convierte las entidades primitivas a malla durante la exportación. O codifica directamente las primitivas al archivo de salida (se usará la definición de extensión de Aspose para primitivas no oficiales como Dish, Torus). El valor predeterminado es true. |
+
+ **Result:**
+
+
+
+---
+
+
+### setPrimitiveToMesh{#setPrimitiveToMesh}
+
+| Nombre | Descripción |
+| --- | --- |
+| setPrimitiveToMesh(value) | Convierte las entidades primitivas a malla durante la exportación. O codifica directamente las primitivas al archivo de salida (se usará la definición de extensión de Aspose para primitivas no oficiales como Dish, Torus). El valor predeterminado es true. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportMetaData{#getExportMetaData}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExportMetaData() | Exporta las propiedades del nodo a través del campo customData de USD. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportMetaData{#setExportMetaData}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExportMetaData(value) | Exporta las propiedades del nodo a través del campo customData de USD. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMaterialConverter{#getMaterialConverter}
+
+| Nombre | Descripción |
+| --- | --- |
+| getMaterialConverter() | Convertidor personalizado para convertir el material de la geometría a material PBR. Si no está asignado, el exportador USD convertirá automáticamente el material estándar a material PBR. El valor predeterminado es null |
+
+ **Result:**
+
+
+
+---
+
+
+### setMaterialConverter{#setMaterialConverter}
+
+| Nombre | Descripción |
+| --- | --- |
+| setMaterialConverter(value) | Convertidor personalizado para convertir el material de la geometría a material PBR. Si no está asignado, el exportador USD convertirá automáticamente el material estándar a material PBR. El valor predeterminado es null |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportTextures{#getExportTextures}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExportTextures() | Intenta copiar las texturas usadas en la escena al directorio de salida. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextures{#setExportTextures}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExportTextures(value) | Intenta copiar las texturas usadas en la escena al directorio de salida. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileFormat() | Obtiene el formato de archivo especificado en la opción actual de Guardar/Cargar. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEncoding() | Obtiene o establece la codificación predeterminada para archivos basados en texto. El valor predeterminado es null, lo que significa que el importador/exportador decidirá qué codificación usar. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileSystem() | Permite al usuario manejar cómo gestionar las dependencias externas durante la carga/guardado. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFileSystem(value) | Permite al usuario manejar cómo gestionar las dependencias externas durante la carga/guardado. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| Nombre | Descripción |
+| --- | --- |
+| getLookupPaths() | Algunos archivos como OBJ dependen de archivos externos; las rutas de búsqueda permiten que Aspose.3D busque el archivo externo para cargarlo. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileName() | El nombre de archivo de la escena de exportación/importación. Es opcional, pero útil al serializar recursos externos como el material de OBJ. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFileName(value) | El nombre de archivo de la escena de exportación/importación. Es opcional, pero útil al serializar recursos externos como el material de OBJ. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/ushape/_index.md
+++ b/spanish/nodejs-java/aspose.threed/ushape/_index.md
@@ -1,0 +1,437 @@
+---
+title: "UShape"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/ushape/
+---
+## UShape class
+
+Forma en U compatible con IFC definida por parámetros.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Constructor de UShape |
+
+ **Result:**
+
+
+
+---
+
+
+### getDepth{#getDepth}
+
+| Nombre | Descripción |
+| --- | --- |
+| getDepth() | Obtiene o establece la longitud del web. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDepth{#setDepth}
+
+| Nombre | Descripción |
+| --- | --- |
+| setDepth(value) | Obtiene o establece la longitud del web. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlangeWidth{#getFlangeWidth}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFlangeWidth() | Obtiene o establece la longitud del flange. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlangeWidth{#setFlangeWidth}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFlangeWidth(value) | Obtiene o establece la longitud del flange. |
+
+ **Result:**
+
+
+
+---
+
+
+### getWebThickness{#getWebThickness}
+
+| Nombre | Descripción |
+| --- | --- |
+| getWebThickness() | Obtiene o establece el grosor de la malla. |
+
+ **Result:**
+
+
+
+---
+
+
+### setWebThickness{#setWebThickness}
+
+| Nombre | Descripción |
+| --- | --- |
+| setWebThickness(value) | Obtiene o establece el grosor de la malla. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlangeThickness{#getFlangeThickness}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFlangeThickness() | Obtiene o establece el grosor del flange. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlangeThickness{#setFlangeThickness}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFlangeThickness(value) | Obtiene o establece el grosor del flange. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFilletRadius{#getFilletRadius}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFilletRadius() | Obtiene o establece el radio del filete entre el flange y el web. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFilletRadius{#setFilletRadius}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFilletRadius(value) | Obtiene o establece el radio del filete entre el flange y el web. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEdgeRadius{#getEdgeRadius}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEdgeRadius() | Obtiene o establece el radio del borde en el borde de la brida. |
+
+ **Result:**
+
+
+
+---
+
+
+### setEdgeRadius{#setEdgeRadius}
+
+| Nombre | Descripción |
+| --- | --- |
+| setEdgeRadius(value) | Obtiene o establece el radio del borde en el borde de la brida. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNodes() | Obtiene todos los nodos padre; una entidad puede estar adjunta a varios nodos padre para la instanciación de geometría. Los nodos. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExcluded() | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExcluded(value) | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNode() | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setParentNode(value) | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Nombre | Descripción |
+| --- | --- |
+| getScene() | Obtiene la escena a la que pertenece este objeto |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtent{#getExtent}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExtent() | Obtiene la extensión en las dimensiones x e y. |
+
+ **Result:**
+Vector2
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEntityRendererKey() | Obtiene la clave del renderizador de entidad registrado en el renderizador |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBoundingBox() | Obtiene el cuadro delimitador de la entidad actual en su sistema de coordenadas de espacio de objeto. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/vector2/_index.md
+++ b/spanish/nodejs-java/aspose.threed/vector2/_index.md
@@ -1,0 +1,293 @@
+---
+title: "Vector2"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/vector2/
+---
+## Vector2 class
+
+Un vector con dos componentes.
+
+
+## Propiedades
+
+| Nombre | Descripción |
+| --- | --- |
+| x | El componente x. |
+| y | El componente y. |
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload(s) | Inicializa una nueva instancia de la estructura Vector2. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| s | Número | S. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload2(vec) | Inicializa una nueva instancia de la estructura Vector2. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| vec | FVector2 | Vector en float. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload3{#constructor_overload3}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload3(x, y) | Inicializa una nueva instancia de la estructura Vector2. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| x | Número | La coordenada x. |
+| y | Número | La coordenada y. |
+
+ **Result:**
+
+
+
+---
+
+
+### getU{#getU}
+
+| Nombre | Descripción |
+| --- | --- |
+| getU() | Obtiene o establece el componente U si el Vector2 se usa como una coordenada de mapeo. Es un alias del componente x. |
+
+ **Result:**
+
+
+
+---
+
+
+### setU{#setU}
+
+| Nombre | Descripción |
+| --- | --- |
+| setU(value) | Obtiene o establece el componente U si el Vector2 se usa como una coordenada de mapeo. Es un alias del componente x. |
+
+ **Result:**
+
+
+
+---
+
+
+### getV{#getV}
+
+| Nombre | Descripción |
+| --- | --- |
+| getV() | Obtiene o establece el componente V si el Vector2 se usa como una coordenada de mapeo. Es un alias del componente y. |
+
+ **Result:**
+
+
+
+---
+
+
+### setV{#setV}
+
+| Nombre | Descripción |
+| --- | --- |
+| setV(value) | Obtiene o establece el componente V si el Vector2 se usa como una coordenada de mapeo. Es un alias del componente y. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLength{#getLength}
+
+| Nombre | Descripción |
+| --- | --- |
+| getLength() | Obtiene la longitud. La longitud. |
+
+ **Result:**
+
+
+
+---
+
+
+### dot{#dot}
+
+| Nombre | Descripción |
+| --- | --- |
+| dot(rhs) | Obtiene el producto punto de dos vectores |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| rhs | Vector2 | Valor del lado derecho. |
+
+ **Result:**
+Número
+
+
+---
+
+
+### equals{#equals}
+
+| Nombre | Descripción |
+| --- | --- |
+| equals(rhs) | Comprueba si dos vector2 son iguales |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| rhs | Vector2 | El valor del lado derecho. |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### hashCode{#hashCode}
+
+| Nombre | Descripción |
+| --- | --- |
+| hashCode() | Obtiene el código hash de Vector2 |
+
+ **Result:**
+Número
+
+
+---
+
+
+### equals{#equals}
+
+| Nombre | Descripción |
+| --- | --- |
+| equals(obj) | Comprueba si dos vector2 son iguales |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| obj | Objeto | El objeto a comparar. |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### toString{#toString}
+
+| Nombre | Descripción |
+| --- | --- |
+| toString() | Devuelve un java.lang.String que representa el Vector2 actual. |
+
+ **Result:**
+Cadena
+
+
+---
+
+
+### cross{#cross}
+
+| Nombre | Descripción |
+| --- | --- |
+| cross(v) | Producto cruz de dos vectores |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+|  | Vector2 | null |
+
+ **Result:**
+Número
+
+
+---
+
+
+### normalize{#normalize}
+
+| Nombre | Descripción |
+| --- | --- |
+| normalize() | Normaliza esta instancia. |
+
+ **Result:**
+Vector2
+
+
+---
+
+
+### compareTo{#compareTo}
+
+| Nombre | Descripción |
+| --- | --- |
+| compareTo(other) | Compara el vector actual con otra instancia. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| othe | Vector2 | null |
+
+ **Result:**
+Número
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/vector3/_index.md
+++ b/spanish/nodejs-java/aspose.threed/vector3/_index.md
@@ -1,0 +1,347 @@
+---
+title: "Vector3"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/vector3/
+---
+## Vector3 class
+
+Un vector con tres componentes.
+
+
+## Propiedades
+
+| Nombre | Descripción |
+| --- | --- |
+| x | El componente x. |
+| y | El componente y. |
+| z | El componente z. |
+| ORIGIN | Obtiene la posición de origen. El origen. |
+| UNIT_SCALE | Obtiene el vector de escala de unidad. |
+| X_AXIS | Obtiene el eje X. El eje X. |
+| Y_AXIS | Obtiene el eje Y. El eje Y. |
+| Z_AXIS | Obtiene el eje Z. El eje Z. |
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload(x, y, z) | Inicializa una nueva instancia de la estructura Vector3. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| x | Número | La coordenada x. |
+| y | Número | La coordenada y. |
+| z | Número | La coordenada z. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload2(vec) | Inicializa una nueva instancia de la estructura Vector3. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| vec | FVector3 | La coordenada x. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload3{#constructor_overload3}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload3(v) | Inicializa una nueva instancia de la estructura Vector3. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| v | Número | V. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload4{#constructor_overload4}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload4(vec4) | Inicializa una nueva instancia de la estructura Vector3. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| vec4 | Vector4 | Vec4. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLength2{#getLength2}
+
+| Nombre | Descripción |
+| --- | --- |
+| getLength2() | Obtiene el cuadrado de la longitud. La longitud2. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLength{#getLength}
+
+| Nombre | Descripción |
+| --- | --- |
+| getLength() | Obtiene la longitud de este vector. La longitud. |
+
+ **Result:**
+
+
+
+---
+
+
+### equals{#equals}
+
+| Nombre | Descripción |
+| --- | --- |
+| equals(obj) | Comprueba si dos vector3 son iguales |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| obj | Objeto | El objeto para comprobar la igualdad. |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### hashCode{#hashCode}
+
+| Nombre | Descripción |
+| --- | --- |
+| hashCode() | Obtiene el código hash de Vector3 |
+
+ **Result:**
+Número
+
+
+---
+
+
+### dot{#dot}
+
+| Nombre | Descripción |
+| --- | --- |
+| dot(rhs) | Obtiene el producto punto de dos vectores |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| rhs | Vector3 | Valor del lado derecho. |
+
+ **Result:**
+Número
+
+
+---
+
+
+### normalize{#normalize}
+
+| Nombre | Descripción |
+| --- | --- |
+| normalize() | Normaliza esta instancia. |
+
+ **Result:**
+Vector3
+
+
+---
+
+
+### sin{#sin}
+
+| Nombre | Descripción |
+| --- | --- |
+| sin() | Calcula el seno en cada componente |
+
+ **Result:**
+Vector3
+
+
+---
+
+
+### cos{#cos}
+
+| Nombre | Descripción |
+| --- | --- |
+| cos() | Calcula el coseno en cada componente |
+
+ **Result:**
+Vector3
+
+
+---
+
+
+### cross{#cross}
+
+| Nombre | Descripción |
+| --- | --- |
+| cross(rhs) | Producto cruz de dos vectores |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| rhs | Vector3 | Valor del lado derecho. |
+
+ **Result:**
+Vector3
+
+
+---
+
+
+### set{#set}
+
+| Nombre | Descripción |
+| --- | --- |
+| set(newX, newY, newZ) | Establece los componentes x/y/z en una sola llamada. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| newX | Número | El componente x. |
+| newY | Número | El componente y. |
+| newZ | Número | El componente z. |
+
+ **Result:**
+Vector3
+
+
+---
+
+
+### toString{#toString}
+
+| Nombre | Descripción |
+| --- | --- |
+| toString() | Devuelve un java.lang.String que representa el Vector3 actual. |
+
+ **Result:**
+Cadena
+
+
+---
+
+
+### angleBetween{#angleBetween}
+
+| Nombre | Descripción |
+| --- | --- |
+| angleBetween(dir, up) | Calcula el ángulo interno entre dos direcciones. Dos direcciones pueden ser vectores no normalizados. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| dir | Vector3 | El vector de dirección con el que comparar. |
+| up | Vector3 | El vector up del plano compartido de las dos direcciones. |
+
+ **Result:**
+Número
+
+
+---
+
+
+### angleBetween{#angleBetween}
+
+| Nombre | Descripción |
+| --- | --- |
+| angleBetween(dir) | Calcula el ángulo interno entre dos direcciones. Dos direcciones pueden ser vectores no normalizados. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| dir | Vector3 | El vector de dirección con el que comparar. |
+
+ **Result:**
+Número
+
+
+---
+
+
+### compareTo{#compareTo}
+
+| Nombre | Descripción |
+| --- | --- |
+| compareTo(other) | Compara el vector actual con otra instancia. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| othe | Vector3 | null |
+
+ **Result:**
+Número
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/vector4/_index.md
+++ b/spanish/nodejs-java/aspose.threed/vector4/_index.md
@@ -1,0 +1,246 @@
+---
+title: "Vector4"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/vector4/
+---
+## Vector4 class
+
+Un vector con cuatro componentes.
+
+
+## Propiedades
+
+| Nombre | Descripción |
+| --- | --- |
+| x | El componente x. |
+| y | El componente y. |
+| z | El componente z. |
+| w | El componente w. |
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload(vec, w) | Inicializa una nueva instancia de la estructura Vector4. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| vec | Vector3 | Vec. |
+| w | Número | El ancho. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload2(vec) | Inicializa una nueva instancia de la estructura Vector4. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| vec | Vector3 | Vec. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload3{#constructor_overload3}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload3(vec) | Inicializa una nueva instancia de la estructura Vector4. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| vec | FVector4 | Vec. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload4{#constructor_overload4}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload4(x, y, z) | Inicializa una nueva instancia de la estructura Vector4. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| x | Número | La coordenada x. |
+| y | Número | La coordenada y. |
+| z | Número | La coordenada z. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload5{#constructor_overload5}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload5(x, y, z, w) | Inicializa una nueva instancia de la estructura Vector4. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| x | Número | La coordenada x. |
+| y | Número | La coordenada y. |
+| z | Número | La coordenada z. |
+| w | Número | El ancho. |
+
+ **Result:**
+
+
+
+---
+
+
+### set{#set}
+
+| Nombre | Descripción |
+| --- | --- |
+| set(newX, newY, newZ) | Establece los componentes xyz del vector a la vez, w se establecerá en 1 |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| newX | Número | Nuevo componente X. |
+| newY | Número | Nuevo componente Y. |
+| newZ | Número | Nuevo componente Z. |
+
+ **Result:**
+
+
+
+---
+
+
+### equals{#equals}
+
+| Nombre | Descripción |
+| --- | --- |
+| equals(obj) | Comprueba si dos vectores son iguales |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| ob | Objeto | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### hashCode{#hashCode}
+
+| Nombre | Descripción |
+| --- | --- |
+| hashCode() | Obtiene el código hash de este vector |
+
+ **Result:**
+Número
+
+
+---
+
+
+### set{#set}
+
+| Nombre | Descripción |
+| --- | --- |
+| set(newX, newY, newZ, newW) | Establece todos los componentes del vector a la vez |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| newX | Número | Nuevo componente X. |
+| newY | Número | Nuevo componente Y. |
+| newZ | Número | Nuevo componente Z. |
+| newW | Número | Nuevo componente W. |
+
+ **Result:**
+Número
+
+
+---
+
+
+### toString{#toString}
+
+| Nombre | Descripción |
+| --- | --- |
+| toString() | Devuelve un java.lang.String que representa el Vector4 actual. |
+
+ **Result:**
+Cadena
+
+
+---
+
+
+### compareTo{#compareTo}
+
+| Nombre | Descripción |
+| --- | --- |
+| compareTo(other) | Compara el vector actual con otra instancia. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| othe | Vector4 | null |
+
+ **Result:**
+Número
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/vertex/_index.md
+++ b/spanish/nodejs-java/aspose.threed/vertex/_index.md
@@ -1,0 +1,187 @@
+---
+title: "Vértice"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/vertex/
+---
+## Vertex class
+
+Referencia de vértice, utilizada para acceder al vértice sin procesar en TriMesh.  @hideconstructor
+
+
+## Métodos
+
+### compareTo{#compareTo}
+
+| Nombre | Descripción |
+| --- | --- |
+| compareTo(other) | Compara el vértice con otra instancia de vértice |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| othe | Vértice | null |
+
+ **Result:**
+Número
+
+
+---
+
+
+### readVector4{#readVector4}
+
+| Nombre | Descripción |
+| --- | --- |
+| readVector4(field) | Leer el campo vector4 |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| field | VertexField | El campo con un tipo de datos Vector4/FVector4 |
+
+ **Result:**
+Vector4
+
+
+---
+
+
+### readFVector4{#readFVector4}
+
+| Nombre | Descripción |
+| --- | --- |
+| readFVector4(field) | Leer el campo vector4 |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| field | VertexField | El campo con un tipo de datos Vector4/FVector4 |
+
+ **Result:**
+FVector4
+
+
+---
+
+
+### readVector3{#readVector3}
+
+| Nombre | Descripción |
+| --- | --- |
+| readVector3(field) | Leer el campo vector3 |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| field | VertexField | El campo con un tipo de datos Vector3/FVector3 |
+
+ **Result:**
+Vector3
+
+
+---
+
+
+### readFVector3{#readFVector3}
+
+| Nombre | Descripción |
+| --- | --- |
+| readFVector3(field) | Leer el campo vector3 |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| field | VertexField | El campo con un tipo de datos Vector3/FVector3 |
+
+ **Result:**
+FVector3
+
+
+---
+
+
+### readVector2{#readVector2}
+
+| Nombre | Descripción |
+| --- | --- |
+| readVector2(field) | Leer el campo vector2 |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| field | VertexField | El campo con un tipo de datos Vector2/FVector2 |
+
+ **Result:**
+Vector2
+
+
+---
+
+
+### readFVector2{#readFVector2}
+
+| Nombre | Descripción |
+| --- | --- |
+| readFVector2(field) | Leer el campo vector2 |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| field | VertexField | El campo con un tipo de datos Vector2/FVector2 |
+
+ **Result:**
+FVector2
+
+
+---
+
+
+### readDouble{#readDouble}
+
+| Nombre | Descripción |
+| --- | --- |
+| readDouble(field) | Leer el campo double |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| field | VertexField | El campo con un tipo de datos compatible con float/double |
+
+ **Result:**
+Número
+
+
+---
+
+
+### readFloat{#readFloat}
+
+| Nombre | Descripción |
+| --- | --- |
+| readFloat(field) | Leer el campo float |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| field | VertexField | El campo con un tipo de datos compatible con float/double |
+
+ **Result:**
+Número
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/vertexdeclaration/_index.md
+++ b/spanish/nodejs-java/aspose.threed/vertexdeclaration/_index.md
@@ -1,0 +1,201 @@
+---
+title: "VertexDeclaration"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/vertexdeclaration/
+---
+## VertexDeclaration class
+
+La declaración de la estructura de un vértice definido de forma personalizada
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getSealed{#getSealed}
+
+| Nombre | Descripción |
+| --- | --- |
+| getSealed() | Una VertexDeclaration se sellará cuando haya sido usada por com.aspose.threed.TriMesh`1 o TriMesh, no se permiten más modificaciones. |
+
+ **Result:**
+
+
+
+---
+
+
+### getCount{#getCount}
+
+| Nombre | Descripción |
+| --- | --- |
+| getCount() | Obtiene el recuento de todos los campos definidos en esta VertexDeclaration. |
+
+ **Result:**
+
+
+
+---
+
+
+### getSize{#getSize}
+
+| Nombre | Descripción |
+| --- | --- |
+| getSize() | El tamaño en bytes de la estructura del vértice. |
+
+ **Result:**
+
+
+
+---
+
+
+### get{#get}
+
+| Nombre | Descripción |
+| --- | --- |
+| get(index) |  |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| Nombre | Descripción |
+| --- | --- |
+| clear() | Borrar todos los campos. |
+
+ **Result:**
+
+
+
+---
+
+
+### addField{#addField}
+
+| Nombre | Descripción |
+| --- | --- |
+| addField(dataType, semantic, index, alias) | Agregar un nuevo campo de vértice |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| dataType | Número | VertexFieldDataType |
+| semantic | VertexFieldSemantic | VertexFieldSemantic |
+| index | Número | El índice para el mismo semántico de campo, -1 para generación automática |
+| alias | Cadena | El nombre alias del campo |
+
+ **Result:**
+
+
+
+---
+
+
+### fromGeometry{#fromGeometry}
+
+| Nombre | Descripción |
+| --- | --- |
+| fromGeometry(geometry, useFloat) | Crear una VertexDeclaration basada en la disposición de una Geometry. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| geometría | Geometría | null |
+| useFloat | boolean | Usar float en lugar del tipo double |
+
+ **Result:**
+VertexDeclaration
+
+
+---
+
+
+### compareTo{#compareTo}
+
+| Nombre | Descripción |
+| --- | --- |
+| compareTo(other) | Compara esta instancia con un objeto especificado y devuelve una indicación de sus valores relativos. |
+
+ **Result:**
+VertexDeclaration
+
+
+---
+
+
+### toString{#toString}
+
+| Nombre | Descripción |
+| --- | --- |
+| toString() |  |
+
+ **Result:**
+Cadena
+
+
+---
+
+
+### hashCode{#hashCode}
+
+| Nombre | Descripción |
+| --- | --- |
+| hashCode() |  |
+
+ **Result:**
+Número
+
+
+---
+
+
+### equals{#equals}
+
+| Nombre | Descripción |
+| --- | --- |
+| equals(obj) | Determina si esta instancia y un objeto especificado, que también debe ser un objeto VertexDeclaration, tienen el mismo valor. |
+
+ **Result:**
+Número
+
+
+---
+
+
+### iterator{#iterator}
+
+| Nombre | Descripción |
+| --- | --- |
+| iterator() | Reservado para uso interno. |
+
+ **Result:**
+Número
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/vertexelement/_index.md
+++ b/spanish/nodejs-java/aspose.threed/vertexelement/_index.md
@@ -1,0 +1,165 @@
+---
+title: "VertexElement"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/vertexelement/
+---
+## VertexElement class
+
+Clase base de elementos de vértice.  Un tipo de elemento de vértice se identifica mediante VertexElementType.  Un VertexElement describe cómo el elemento de vértice se asigna a una superficie geométrica y cómo la información de asignación se organiza en memoria.  Un VertexElement contiene Normales, UVs u otro tipo de información.  @hideconstructor
+
+
+## Métodos
+
+### getVertexElementType{#getVertexElementType}
+
+| Nombre | Descripción |
+| --- | --- |
+| getVertexElementType() | Obtiene el tipo del VertexElement. El valor de la propiedad es la constante entera VertexElementType. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getMappingMode() | Obtiene o establece cómo se asigna el elemento. El valor de la propiedad es la constante entera MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setMappingMode(value) | Obtiene o establece cómo se asigna el elemento. El valor de la propiedad es la constante entera MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getReferenceMode() | Obtiene o establece cómo se referencia el elemento. El valor de la propiedad es la constante entera ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setReferenceMode(value) | Obtiene o establece cómo se referencia el elemento. El valor de la propiedad es la constante entera ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| Nombre | Descripción |
+| --- | --- |
+| getIndices() | Obtiene los datos de los índices. La matriz de índices. |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| Nombre | Descripción |
+| --- | --- |
+| setIndices(data) | Cargar índices |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| dat | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| Nombre | Descripción |
+| --- | --- |
+| clear() | Borra todos los datos de este elemento de vértice. |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| Nombre | Descripción |
+| --- | --- |
+| toString() | Representación en cadena del elemento de vértice. |
+
+ **Result:**
+Cadena
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/vertexelementbinormal/_index.md
+++ b/spanish/nodejs-java/aspose.threed/vertexelementbinormal/_index.md
@@ -1,0 +1,229 @@
+---
+title: "VertexElementBinormal"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/vertexelementbinormal/
+---
+## VertexElementBinormal class
+
+Define los vectores binormales para los componentes especificados.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Inicializa una nueva instancia de la clase VertexElementBinormal. |
+
+ **Result:**
+
+
+
+---
+
+
+### getData{#getData}
+
+| Nombre | Descripción |
+| --- | --- |
+| getData() | Obtiene los datos del vértice |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| Nombre | Descripción |
+| --- | --- |
+| getVertexElementType() | Obtiene el tipo del VertexElement. El valor de la propiedad es la constante entera VertexElementType. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getMappingMode() | Obtiene o establece cómo se asigna el elemento. El valor de la propiedad es la constante entera MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setMappingMode(value) | Obtiene o establece cómo se asigna el elemento. El valor de la propiedad es la constante entera MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getReferenceMode() | Obtiene o establece cómo se referencia el elemento. El valor de la propiedad es la constante entera ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setReferenceMode(value) | Obtiene o establece cómo se referencia el elemento. El valor de la propiedad es la constante entera ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| Nombre | Descripción |
+| --- | --- |
+| getIndices() | Obtiene los datos de los índices. La matriz de índices. |
+
+ **Result:**
+
+
+
+---
+
+
+### copyTo{#copyTo}
+
+| Nombre | Descripción |
+| --- | --- |
+| copyTo(target) | Copia datos al elemento especificado |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| target | VertexElementVector4 | Target. |
+
+ **Result:**
+
+
+
+---
+
+
+### setData{#setData}
+
+| Nombre | Descripción |
+| --- | --- |
+| setData(data) | Cargar datos |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| dat | Vector4[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| Nombre | Descripción |
+| --- | --- |
+| clear() | Elimina todos los elementos de los arreglos directos y de índices. |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| Nombre | Descripción |
+| --- | --- |
+| setIndices(data) | Cargar índices |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| dat | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| Nombre | Descripción |
+| --- | --- |
+| toString() | Representación en cadena del elemento de vértice. |
+
+ **Result:**
+Cadena
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/vertexelementdoublestemplate/_index.md
+++ b/spanish/nodejs-java/aspose.threed/vertexelementdoublestemplate/_index.md
@@ -1,0 +1,216 @@
+---
+title: "VertexElementDoublesTemplate"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/vertexelementdoublestemplate/
+---
+## VertexElementDoublesTemplate class
+
+Una clase auxiliar para definir implementaciones concretas de VertexElement.  @hideconstructor
+
+
+## Métodos
+
+### getData{#getData}
+
+| Nombre | Descripción |
+| --- | --- |
+| getData() | Obtiene los datos del vértice |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| Nombre | Descripción |
+| --- | --- |
+| getVertexElementType() | Obtiene el tipo del VertexElement. El valor de la propiedad es la constante entera VertexElementType. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getMappingMode() | Obtiene o establece cómo se asigna el elemento. El valor de la propiedad es la constante entera MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setMappingMode(value) | Obtiene o establece cómo se asigna el elemento. El valor de la propiedad es la constante entera MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getReferenceMode() | Obtiene o establece cómo se referencia el elemento. El valor de la propiedad es la constante entera ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setReferenceMode(value) | Obtiene o establece cómo se referencia el elemento. El valor de la propiedad es la constante entera ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| Nombre | Descripción |
+| --- | --- |
+| getIndices() | Obtiene los datos de los índices. La matriz de índices. |
+
+ **Result:**
+
+
+
+---
+
+
+### copyTo{#copyTo}
+
+| Nombre | Descripción |
+| --- | --- |
+| copyTo(target) | Copia datos al elemento especificado |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| target | VertexElementDoublesTemplate | Target. |
+
+ **Result:**
+
+
+
+---
+
+
+### setData{#setData}
+
+| Nombre | Descripción |
+| --- | --- |
+| setData(data) | Cargar datos |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| dat | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| Nombre | Descripción |
+| --- | --- |
+| clear() | Elimina todos los elementos de los arreglos directos y de índices. |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| Nombre | Descripción |
+| --- | --- |
+| setIndices(data) | Cargar índices |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| dat | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| Nombre | Descripción |
+| --- | --- |
+| toString() | Representación en cadena del elemento de vértice. |
+
+ **Result:**
+Cadena
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/vertexelementedgecrease/_index.md
+++ b/spanish/nodejs-java/aspose.threed/vertexelementedgecrease/_index.md
@@ -1,0 +1,229 @@
+---
+title: "VertexElementEdgeCrease"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/vertexelementedgecrease/
+---
+## VertexElementEdgeCrease class
+
+Define el pliegue del borde para los componentes especificados
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Inicializa una nueva instancia de la clase VertexElementEdgeCrease. |
+
+ **Result:**
+
+
+
+---
+
+
+### getData{#getData}
+
+| Nombre | Descripción |
+| --- | --- |
+| getData() | Obtiene los datos del vértice |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| Nombre | Descripción |
+| --- | --- |
+| getVertexElementType() | Obtiene el tipo del VertexElement. El valor de la propiedad es la constante entera VertexElementType. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getMappingMode() | Obtiene o establece cómo se asigna el elemento. El valor de la propiedad es la constante entera MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setMappingMode(value) | Obtiene o establece cómo se asigna el elemento. El valor de la propiedad es la constante entera MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getReferenceMode() | Obtiene o establece cómo se referencia el elemento. El valor de la propiedad es la constante entera ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setReferenceMode(value) | Obtiene o establece cómo se referencia el elemento. El valor de la propiedad es la constante entera ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| Nombre | Descripción |
+| --- | --- |
+| getIndices() | Obtiene los datos de los índices. La matriz de índices. |
+
+ **Result:**
+
+
+
+---
+
+
+### copyTo{#copyTo}
+
+| Nombre | Descripción |
+| --- | --- |
+| copyTo(target) | Copia datos al elemento especificado |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| target | VertexElementDoublesTemplate | Target. |
+
+ **Result:**
+
+
+
+---
+
+
+### setData{#setData}
+
+| Nombre | Descripción |
+| --- | --- |
+| setData(data) | Cargar datos |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| dat | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| Nombre | Descripción |
+| --- | --- |
+| clear() | Elimina todos los elementos de los arreglos directos y de índices. |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| Nombre | Descripción |
+| --- | --- |
+| setIndices(data) | Cargar índices |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| dat | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| Nombre | Descripción |
+| --- | --- |
+| toString() | Representación en cadena del elemento de vértice. |
+
+ **Result:**
+Cadena
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/vertexelementhole/_index.md
+++ b/spanish/nodejs-java/aspose.threed/vertexelementhole/_index.md
@@ -1,0 +1,191 @@
+---
+title: "VertexElementHole"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/vertexelementhole/
+---
+## VertexElementHole class
+
+Define si el polígono especificado es un agujero
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Inicializa una nueva instancia de la clase VertexElementHole. |
+
+ **Result:**
+
+
+
+---
+
+
+### getData{#getData}
+
+| Nombre | Descripción |
+| --- | --- |
+| getData() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| Nombre | Descripción |
+| --- | --- |
+| getVertexElementType() | Obtiene el tipo del VertexElement. El valor de la propiedad es la constante entera VertexElementType. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getMappingMode() | Obtiene o establece cómo se asigna el elemento. El valor de la propiedad es la constante entera MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setMappingMode(value) | Obtiene o establece cómo se asigna el elemento. El valor de la propiedad es la constante entera MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getReferenceMode() | Obtiene o establece cómo se referencia el elemento. El valor de la propiedad es la constante entera ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setReferenceMode(value) | Obtiene o establece cómo se referencia el elemento. El valor de la propiedad es la constante entera ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| Nombre | Descripción |
+| --- | --- |
+| getIndices() | Obtiene los datos de los índices. La matriz de índices. |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| Nombre | Descripción |
+| --- | --- |
+| clear() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| Nombre | Descripción |
+| --- | --- |
+| setIndices(data) | Cargar índices |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| dat | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| Nombre | Descripción |
+| --- | --- |
+| toString() | Representación en cadena del elemento de vértice. |
+
+ **Result:**
+Cadena
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/vertexelementintstemplate/_index.md
+++ b/spanish/nodejs-java/aspose.threed/vertexelementintstemplate/_index.md
@@ -1,0 +1,216 @@
+---
+title: "VertexElementIntsTemplate"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/vertexelementintstemplate/
+---
+## VertexElementIntsTemplate class
+
+Una clase auxiliar para definir implementaciones concretas de VertexElement.  @hideconstructor
+
+
+## Métodos
+
+### getData{#getData}
+
+| Nombre | Descripción |
+| --- | --- |
+| getData() | Obtiene los datos del vértice |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| Nombre | Descripción |
+| --- | --- |
+| getVertexElementType() | Obtiene el tipo del VertexElement. El valor de la propiedad es la constante entera VertexElementType. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getMappingMode() | Obtiene o establece cómo se asigna el elemento. El valor de la propiedad es la constante entera MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setMappingMode(value) | Obtiene o establece cómo se asigna el elemento. El valor de la propiedad es la constante entera MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getReferenceMode() | Obtiene o establece cómo se referencia el elemento. El valor de la propiedad es la constante entera ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setReferenceMode(value) | Obtiene o establece cómo se referencia el elemento. El valor de la propiedad es la constante entera ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| Nombre | Descripción |
+| --- | --- |
+| getIndices() | Obtiene los datos de los índices. La matriz de índices. |
+
+ **Result:**
+
+
+
+---
+
+
+### copyTo{#copyTo}
+
+| Nombre | Descripción |
+| --- | --- |
+| copyTo(target) | Copia datos al elemento especificado |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| target | VertexElementIntsTemplate | Target. |
+
+ **Result:**
+
+
+
+---
+
+
+### setData{#setData}
+
+| Nombre | Descripción |
+| --- | --- |
+| setData(data) | Cargar datos |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| dat | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| Nombre | Descripción |
+| --- | --- |
+| clear() | Elimina todos los elementos de los arreglos directos y de índices. |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| Nombre | Descripción |
+| --- | --- |
+| setIndices(data) | Cargar índices |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| dat | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| Nombre | Descripción |
+| --- | --- |
+| toString() | Representación en cadena del elemento de vértice. |
+
+ **Result:**
+Cadena
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/vertexelementmaterial/_index.md
+++ b/spanish/nodejs-java/aspose.threed/vertexelementmaterial/_index.md
@@ -1,0 +1,178 @@
+---
+title: "VertexElementMaterial"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/vertexelementmaterial/
+---
+## VertexElementMaterial class
+
+Define el índice de material para los componentes especificados.  Un nodo puede tener múltiples materiales, el VertexElementMaterial se utiliza para renderizar diferentes partes de la geometría con diferentes materiales.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Inicializa una nueva instancia de la clase VertexElementMaterial. |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| Nombre | Descripción |
+| --- | --- |
+| getVertexElementType() | Obtiene el tipo del VertexElement. El valor de la propiedad es la constante entera VertexElementType. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getMappingMode() | Obtiene o establece cómo se asigna el elemento. El valor de la propiedad es la constante entera MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setMappingMode(value) | Obtiene o establece cómo se asigna el elemento. El valor de la propiedad es la constante entera MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getReferenceMode() | Obtiene o establece cómo se referencia el elemento. El valor de la propiedad es la constante entera ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setReferenceMode(value) | Obtiene o establece cómo se referencia el elemento. El valor de la propiedad es la constante entera ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| Nombre | Descripción |
+| --- | --- |
+| getIndices() | Obtiene los datos de los índices. La matriz de índices. |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| Nombre | Descripción |
+| --- | --- |
+| clear() | Elimina todos los elementos de los arreglos directos y de índices. |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| Nombre | Descripción |
+| --- | --- |
+| setIndices(data) | Cargar índices |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| dat | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| Nombre | Descripción |
+| --- | --- |
+| toString() | Representación en cadena del elemento de vértice. |
+
+ **Result:**
+Cadena
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/vertexelementnormal/_index.md
+++ b/spanish/nodejs-java/aspose.threed/vertexelementnormal/_index.md
@@ -1,0 +1,229 @@
+---
+title: "VertexElementNormal"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/vertexelementnormal/
+---
+## VertexElementNormal class
+
+Define los vectores normales para los componentes especificados.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Inicializa una nueva instancia de la clase VertexElementNormal. |
+
+ **Result:**
+
+
+
+---
+
+
+### getData{#getData}
+
+| Nombre | Descripción |
+| --- | --- |
+| getData() | Obtiene los datos del vértice |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| Nombre | Descripción |
+| --- | --- |
+| getVertexElementType() | Obtiene el tipo del VertexElement. El valor de la propiedad es la constante entera VertexElementType. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getMappingMode() | Obtiene o establece cómo se asigna el elemento. El valor de la propiedad es la constante entera MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setMappingMode(value) | Obtiene o establece cómo se asigna el elemento. El valor de la propiedad es la constante entera MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getReferenceMode() | Obtiene o establece cómo se referencia el elemento. El valor de la propiedad es la constante entera ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setReferenceMode(value) | Obtiene o establece cómo se referencia el elemento. El valor de la propiedad es la constante entera ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| Nombre | Descripción |
+| --- | --- |
+| getIndices() | Obtiene los datos de los índices. La matriz de índices. |
+
+ **Result:**
+
+
+
+---
+
+
+### copyTo{#copyTo}
+
+| Nombre | Descripción |
+| --- | --- |
+| copyTo(target) | Copia datos al elemento especificado |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| target | VertexElementVector4 | Target. |
+
+ **Result:**
+
+
+
+---
+
+
+### setData{#setData}
+
+| Nombre | Descripción |
+| --- | --- |
+| setData(data) | Cargar datos |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| dat | Vector4[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| Nombre | Descripción |
+| --- | --- |
+| clear() | Elimina todos los elementos de los arreglos directos y de índices. |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| Nombre | Descripción |
+| --- | --- |
+| setIndices(data) | Cargar índices |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| dat | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| Nombre | Descripción |
+| --- | --- |
+| toString() | Representación en cadena del elemento de vértice. |
+
+ **Result:**
+Cadena
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/vertexelementpolygongroup/_index.md
+++ b/spanish/nodejs-java/aspose.threed/vertexelementpolygongroup/_index.md
@@ -1,0 +1,229 @@
+---
+title: "VertexElementPolygonGroup"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/vertexelementpolygongroup/
+---
+## VertexElementPolygonGroup class
+
+Define el grupo de polígonos para los componentes especificados para agrupar polígonos relacionados juntos.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Inicializa una nueva instancia de la clase VertexElementPolygonGroup. |
+
+ **Result:**
+
+
+
+---
+
+
+### getData{#getData}
+
+| Nombre | Descripción |
+| --- | --- |
+| getData() | Obtiene los datos del vértice |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| Nombre | Descripción |
+| --- | --- |
+| getVertexElementType() | Obtiene el tipo del VertexElement. El valor de la propiedad es la constante entera VertexElementType. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getMappingMode() | Obtiene o establece cómo se asigna el elemento. El valor de la propiedad es la constante entera MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setMappingMode(value) | Obtiene o establece cómo se asigna el elemento. El valor de la propiedad es la constante entera MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getReferenceMode() | Obtiene o establece cómo se referencia el elemento. El valor de la propiedad es la constante entera ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setReferenceMode(value) | Obtiene o establece cómo se referencia el elemento. El valor de la propiedad es la constante entera ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| Nombre | Descripción |
+| --- | --- |
+| getIndices() | Obtiene los datos de los índices. La matriz de índices. |
+
+ **Result:**
+
+
+
+---
+
+
+### copyTo{#copyTo}
+
+| Nombre | Descripción |
+| --- | --- |
+| copyTo(target) | Copia datos al elemento especificado |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| target | VertexElementIntsTemplate | Target. |
+
+ **Result:**
+
+
+
+---
+
+
+### setData{#setData}
+
+| Nombre | Descripción |
+| --- | --- |
+| setData(data) | Cargar datos |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| dat | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| Nombre | Descripción |
+| --- | --- |
+| clear() | Elimina todos los elementos de los arreglos directos y de índices. |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| Nombre | Descripción |
+| --- | --- |
+| setIndices(data) | Cargar índices |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| dat | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| Nombre | Descripción |
+| --- | --- |
+| toString() | Representación en cadena del elemento de vértice. |
+
+ **Result:**
+Cadena
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/vertexelementsmoothinggroup/_index.md
+++ b/spanish/nodejs-java/aspose.threed/vertexelementsmoothinggroup/_index.md
@@ -1,0 +1,229 @@
+---
+title: "VertexElementSmoothingGroup"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/vertexelementsmoothinggroup/
+---
+## VertexElementSmoothingGroup class
+
+Un grupo de suavizado es un conjunto de polígonos en una malla de polígonos que debería aparecer como una superficie lisa.  Algunos softwares de modelado 3D tempranos, como 3D Studio Max para DOS, utilizaban grupos de suavizado para evitar almacenar el vector normal para cada vértice de la malla.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Inicializa una nueva instancia de la clase VertexElementSmoothingGroup. |
+
+ **Result:**
+
+
+
+---
+
+
+### getData{#getData}
+
+| Nombre | Descripción |
+| --- | --- |
+| getData() | Obtiene los datos del vértice |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| Nombre | Descripción |
+| --- | --- |
+| getVertexElementType() | Obtiene el tipo del VertexElement. El valor de la propiedad es la constante entera VertexElementType. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getMappingMode() | Obtiene o establece cómo se asigna el elemento. El valor de la propiedad es la constante entera MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setMappingMode(value) | Obtiene o establece cómo se asigna el elemento. El valor de la propiedad es la constante entera MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getReferenceMode() | Obtiene o establece cómo se referencia el elemento. El valor de la propiedad es la constante entera ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setReferenceMode(value) | Obtiene o establece cómo se referencia el elemento. El valor de la propiedad es la constante entera ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| Nombre | Descripción |
+| --- | --- |
+| getIndices() | Obtiene los datos de los índices. La matriz de índices. |
+
+ **Result:**
+
+
+
+---
+
+
+### copyTo{#copyTo}
+
+| Nombre | Descripción |
+| --- | --- |
+| copyTo(target) | Copia datos al elemento especificado |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| target | VertexElementIntsTemplate | Target. |
+
+ **Result:**
+
+
+
+---
+
+
+### setData{#setData}
+
+| Nombre | Descripción |
+| --- | --- |
+| setData(data) | Cargar datos |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| dat | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| Nombre | Descripción |
+| --- | --- |
+| clear() | Elimina todos los elementos de los arreglos directos y de índices. |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| Nombre | Descripción |
+| --- | --- |
+| setIndices(data) | Cargar índices |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| dat | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| Nombre | Descripción |
+| --- | --- |
+| toString() | Representación en cadena del elemento de vértice. |
+
+ **Result:**
+Cadena
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/vertexelementspecular/_index.md
+++ b/spanish/nodejs-java/aspose.threed/vertexelementspecular/_index.md
@@ -1,0 +1,229 @@
+---
+title: "VertexElementSpecular"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/vertexelementspecular/
+---
+## VertexElementSpecular class
+
+Define el color especular para los componentes especificados.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Inicializa una nueva instancia de la clase VertexElementSpecular. |
+
+ **Result:**
+
+
+
+---
+
+
+### getData{#getData}
+
+| Nombre | Descripción |
+| --- | --- |
+| getData() | Obtiene los datos del vértice |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| Nombre | Descripción |
+| --- | --- |
+| getVertexElementType() | Obtiene el tipo del VertexElement. El valor de la propiedad es la constante entera VertexElementType. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getMappingMode() | Obtiene o establece cómo se asigna el elemento. El valor de la propiedad es la constante entera MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setMappingMode(value) | Obtiene o establece cómo se asigna el elemento. El valor de la propiedad es la constante entera MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getReferenceMode() | Obtiene o establece cómo se referencia el elemento. El valor de la propiedad es la constante entera ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setReferenceMode(value) | Obtiene o establece cómo se referencia el elemento. El valor de la propiedad es la constante entera ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| Nombre | Descripción |
+| --- | --- |
+| getIndices() | Obtiene los datos de los índices. La matriz de índices. |
+
+ **Result:**
+
+
+
+---
+
+
+### copyTo{#copyTo}
+
+| Nombre | Descripción |
+| --- | --- |
+| copyTo(target) | Copia datos al elemento especificado |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| target | VertexElementVector4 | Target. |
+
+ **Result:**
+
+
+
+---
+
+
+### setData{#setData}
+
+| Nombre | Descripción |
+| --- | --- |
+| setData(data) | Cargar datos |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| dat | Vector4[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| Nombre | Descripción |
+| --- | --- |
+| clear() | Elimina todos los elementos de los arreglos directos y de índices. |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| Nombre | Descripción |
+| --- | --- |
+| setIndices(data) | Cargar índices |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| dat | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| Nombre | Descripción |
+| --- | --- |
+| toString() | Representación en cadena del elemento de vértice. |
+
+ **Result:**
+Cadena
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/vertexelementtangent/_index.md
+++ b/spanish/nodejs-java/aspose.threed/vertexelementtangent/_index.md
@@ -1,0 +1,229 @@
+---
+title: "VertexElementTangent"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/vertexelementtangent/
+---
+## VertexElementTangent class
+
+Define los vectores tangentes para los componentes especificados.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Inicializa una nueva instancia de la clase VertexElementTangent. |
+
+ **Result:**
+
+
+
+---
+
+
+### getData{#getData}
+
+| Nombre | Descripción |
+| --- | --- |
+| getData() | Obtiene los datos del vértice |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| Nombre | Descripción |
+| --- | --- |
+| getVertexElementType() | Obtiene el tipo del VertexElement. El valor de la propiedad es la constante entera VertexElementType. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getMappingMode() | Obtiene o establece cómo se asigna el elemento. El valor de la propiedad es la constante entera MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setMappingMode(value) | Obtiene o establece cómo se asigna el elemento. El valor de la propiedad es la constante entera MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getReferenceMode() | Obtiene o establece cómo se referencia el elemento. El valor de la propiedad es la constante entera ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setReferenceMode(value) | Obtiene o establece cómo se referencia el elemento. El valor de la propiedad es la constante entera ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| Nombre | Descripción |
+| --- | --- |
+| getIndices() | Obtiene los datos de los índices. La matriz de índices. |
+
+ **Result:**
+
+
+
+---
+
+
+### copyTo{#copyTo}
+
+| Nombre | Descripción |
+| --- | --- |
+| copyTo(target) | Copia datos al elemento especificado |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| target | VertexElementVector4 | Target. |
+
+ **Result:**
+
+
+
+---
+
+
+### setData{#setData}
+
+| Nombre | Descripción |
+| --- | --- |
+| setData(data) | Cargar datos |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| dat | Vector4[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| Nombre | Descripción |
+| --- | --- |
+| clear() | Elimina todos los elementos de los arreglos directos y de índices. |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| Nombre | Descripción |
+| --- | --- |
+| setIndices(data) | Cargar índices |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| dat | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| Nombre | Descripción |
+| --- | --- |
+| toString() | Representación en cadena del elemento de vértice. |
+
+ **Result:**
+Cadena
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/vertexelementuserdata/_index.md
+++ b/spanish/nodejs-java/aspose.threed/vertexelementuserdata/_index.md
@@ -1,0 +1,204 @@
+---
+title: "VertexElementUserData"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/vertexelementuserdata/
+---
+## VertexElementUserData class
+
+Define datos de usuario personalizados para los componentes especificados.  Normalmente son datos específicos de la aplicación para un propósito especial.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Inicializa una nueva instancia de la clase VertexElementUserData. |
+
+ **Result:**
+
+
+
+---
+
+
+### getData{#getData}
+
+| Nombre | Descripción |
+| --- | --- |
+| getData() | Los datos de usuario adjuntos en este elemento |
+
+ **Result:**
+
+
+
+---
+
+
+### setData{#setData}
+
+| Nombre | Descripción |
+| --- | --- |
+| setData(value) | Los datos de usuario adjuntos en este elemento |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| Nombre | Descripción |
+| --- | --- |
+| getVertexElementType() | Obtiene el tipo del VertexElement. El valor de la propiedad es la constante entera VertexElementType. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getMappingMode() | Obtiene o establece cómo se asigna el elemento. El valor de la propiedad es la constante entera MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setMappingMode(value) | Obtiene o establece cómo se asigna el elemento. El valor de la propiedad es la constante entera MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getReferenceMode() | Obtiene o establece cómo se referencia el elemento. El valor de la propiedad es la constante entera ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setReferenceMode(value) | Obtiene o establece cómo se referencia el elemento. El valor de la propiedad es la constante entera ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| Nombre | Descripción |
+| --- | --- |
+| getIndices() | Obtiene los datos de los índices. La matriz de índices. |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| Nombre | Descripción |
+| --- | --- |
+| clear() | Borra todos los datos de este elemento de vértice. |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| Nombre | Descripción |
+| --- | --- |
+| setIndices(data) | Cargar índices |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| dat | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| Nombre | Descripción |
+| --- | --- |
+| toString() | Representación en cadena del elemento de vértice. |
+
+ **Result:**
+Cadena
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/vertexelementuv/_index.md
+++ b/spanish/nodejs-java/aspose.threed/vertexelementuv/_index.md
@@ -1,0 +1,248 @@
+---
+title: "VertexElementUV"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/vertexelementuv/
+---
+## VertexElementUV class
+
+Define las coordenadas UV para los componentes especificados.  Una geometría puede tener múltiples elementos VertexElementUV, y cada uno tiene diferentes TextureMappings.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Inicializa una nueva instancia de la clase VertexElementUV. El tipo de mapeo de textura predeterminado es TextureMapping.DIFFUSE |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor_overload(textureMapping) | Inicializa una nueva instancia de la clase VertexElementUV. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| textureMapping | TextureMapping | TextureMapping |
+
+ **Result:**
+
+
+
+---
+
+
+### getData{#getData}
+
+| Nombre | Descripción |
+| --- | --- |
+| getData() | Obtiene los datos del vértice |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| Nombre | Descripción |
+| --- | --- |
+| getVertexElementType() | Obtiene el tipo del VertexElement. El valor de la propiedad es la constante entera VertexElementType. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getMappingMode() | Obtiene o establece cómo se asigna el elemento. El valor de la propiedad es la constante entera MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setMappingMode(value) | Obtiene o establece cómo se asigna el elemento. El valor de la propiedad es la constante entera MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getReferenceMode() | Obtiene o establece cómo se referencia el elemento. El valor de la propiedad es la constante entera ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setReferenceMode(value) | Obtiene o establece cómo se referencia el elemento. El valor de la propiedad es la constante entera ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| Nombre | Descripción |
+| --- | --- |
+| getIndices() | Obtiene los datos de los índices. La matriz de índices. |
+
+ **Result:**
+
+
+
+---
+
+
+### copyTo{#copyTo}
+
+| Nombre | Descripción |
+| --- | --- |
+| copyTo(target) | Copia datos al elemento especificado |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| target | VertexElementVector4 | Target. |
+
+ **Result:**
+
+
+
+---
+
+
+### setData{#setData}
+
+| Nombre | Descripción |
+| --- | --- |
+| setData(data) | Cargar datos |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| dat | Vector4[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| Nombre | Descripción |
+| --- | --- |
+| clear() | Elimina todos los elementos de los arreglos directos y de índices. |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| Nombre | Descripción |
+| --- | --- |
+| setIndices(data) | Cargar índices |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| dat | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| Nombre | Descripción |
+| --- | --- |
+| toString() | Representación en cadena del elemento de vértice. |
+
+ **Result:**
+Cadena
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/vertexelementvector4/_index.md
+++ b/spanish/nodejs-java/aspose.threed/vertexelementvector4/_index.md
@@ -1,0 +1,216 @@
+---
+title: "VertexElementVector4"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/vertexelementvector4/
+---
+## VertexElementVector4 class
+
+Una clase auxiliar para definir implementaciones concretas de VertexElement.  @hideconstructor
+
+
+## Métodos
+
+### getData{#getData}
+
+| Nombre | Descripción |
+| --- | --- |
+| getData() | Obtiene los datos del vértice |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| Nombre | Descripción |
+| --- | --- |
+| getVertexElementType() | Obtiene el tipo del VertexElement. El valor de la propiedad es la constante entera VertexElementType. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getMappingMode() | Obtiene o establece cómo se asigna el elemento. El valor de la propiedad es la constante entera MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setMappingMode(value) | Obtiene o establece cómo se asigna el elemento. El valor de la propiedad es la constante entera MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getReferenceMode() | Obtiene o establece cómo se referencia el elemento. El valor de la propiedad es la constante entera ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setReferenceMode(value) | Obtiene o establece cómo se referencia el elemento. El valor de la propiedad es la constante entera ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| Nombre | Descripción |
+| --- | --- |
+| getIndices() | Obtiene los datos de los índices. La matriz de índices. |
+
+ **Result:**
+
+
+
+---
+
+
+### copyTo{#copyTo}
+
+| Nombre | Descripción |
+| --- | --- |
+| copyTo(target) | Copia datos al elemento especificado |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| target | VertexElementVector4 | Target. |
+
+ **Result:**
+
+
+
+---
+
+
+### setData{#setData}
+
+| Nombre | Descripción |
+| --- | --- |
+| setData(data) | Cargar datos |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| dat | Vector4[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| Nombre | Descripción |
+| --- | --- |
+| clear() | Elimina todos los elementos de los arreglos directos y de índices. |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| Nombre | Descripción |
+| --- | --- |
+| setIndices(data) | Cargar índices |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| dat | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| Nombre | Descripción |
+| --- | --- |
+| toString() | Representación en cadena del elemento de vértice. |
+
+ **Result:**
+Cadena
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/vertexelementvertexcolor/_index.md
+++ b/spanish/nodejs-java/aspose.threed/vertexelementvertexcolor/_index.md
@@ -1,0 +1,229 @@
+---
+title: "VertexElementVertexColor"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/vertexelementvertexcolor/
+---
+## VertexElementVertexColor class
+
+Define el color del vértice para los componentes especificados
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Inicializa una nueva instancia de la clase VertexElementVertexColor. |
+
+ **Result:**
+
+
+
+---
+
+
+### getData{#getData}
+
+| Nombre | Descripción |
+| --- | --- |
+| getData() | Obtiene los datos del vértice |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| Nombre | Descripción |
+| --- | --- |
+| getVertexElementType() | Obtiene el tipo del VertexElement. El valor de la propiedad es la constante entera VertexElementType. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getMappingMode() | Obtiene o establece cómo se asigna el elemento. El valor de la propiedad es la constante entera MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setMappingMode(value) | Obtiene o establece cómo se asigna el elemento. El valor de la propiedad es la constante entera MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getReferenceMode() | Obtiene o establece cómo se referencia el elemento. El valor de la propiedad es la constante entera ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setReferenceMode(value) | Obtiene o establece cómo se referencia el elemento. El valor de la propiedad es la constante entera ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| Nombre | Descripción |
+| --- | --- |
+| getIndices() | Obtiene los datos de los índices. La matriz de índices. |
+
+ **Result:**
+
+
+
+---
+
+
+### copyTo{#copyTo}
+
+| Nombre | Descripción |
+| --- | --- |
+| copyTo(target) | Copia datos al elemento especificado |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| target | VertexElementVector4 | Target. |
+
+ **Result:**
+
+
+
+---
+
+
+### setData{#setData}
+
+| Nombre | Descripción |
+| --- | --- |
+| setData(data) | Cargar datos |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| dat | Vector4[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| Nombre | Descripción |
+| --- | --- |
+| clear() | Elimina todos los elementos de los arreglos directos y de índices. |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| Nombre | Descripción |
+| --- | --- |
+| setIndices(data) | Cargar índices |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| dat | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| Nombre | Descripción |
+| --- | --- |
+| toString() | Representación en cadena del elemento de vértice. |
+
+ **Result:**
+Cadena
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/vertexelementvertexcrease/_index.md
+++ b/spanish/nodejs-java/aspose.threed/vertexelementvertexcrease/_index.md
@@ -1,0 +1,229 @@
+---
+title: "VertexElementVertexCrease"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/vertexelementvertexcrease/
+---
+## VertexElementVertexCrease class
+
+Define el pliegue del vértice para los componentes especificados
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Inicializa una nueva instancia de la clase VertexElementVertexCrease. |
+
+ **Result:**
+
+
+
+---
+
+
+### getData{#getData}
+
+| Nombre | Descripción |
+| --- | --- |
+| getData() | Obtiene los datos del vértice |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| Nombre | Descripción |
+| --- | --- |
+| getVertexElementType() | Obtiene el tipo del VertexElement. El valor de la propiedad es la constante entera VertexElementType. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getMappingMode() | Obtiene o establece cómo se asigna el elemento. El valor de la propiedad es la constante entera MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setMappingMode(value) | Obtiene o establece cómo se asigna el elemento. El valor de la propiedad es la constante entera MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getReferenceMode() | Obtiene o establece cómo se referencia el elemento. El valor de la propiedad es la constante entera ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setReferenceMode(value) | Obtiene o establece cómo se referencia el elemento. El valor de la propiedad es la constante entera ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| Nombre | Descripción |
+| --- | --- |
+| getIndices() | Obtiene los datos de los índices. La matriz de índices. |
+
+ **Result:**
+
+
+
+---
+
+
+### copyTo{#copyTo}
+
+| Nombre | Descripción |
+| --- | --- |
+| copyTo(target) | Copia datos al elemento especificado |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| target | VertexElementDoublesTemplate | Target. |
+
+ **Result:**
+
+
+
+---
+
+
+### setData{#setData}
+
+| Nombre | Descripción |
+| --- | --- |
+| setData(data) | Cargar datos |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| dat | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| Nombre | Descripción |
+| --- | --- |
+| clear() | Elimina todos los elementos de los arreglos directos y de índices. |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| Nombre | Descripción |
+| --- | --- |
+| setIndices(data) | Cargar índices |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| dat | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| Nombre | Descripción |
+| --- | --- |
+| toString() | Representación en cadena del elemento de vértice. |
+
+ **Result:**
+Cadena
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/vertexelementvisibility/_index.md
+++ b/spanish/nodejs-java/aspose.threed/vertexelementvisibility/_index.md
@@ -1,0 +1,191 @@
+---
+title: "VertexElementVisibility"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/vertexelementvisibility/
+---
+## VertexElementVisibility class
+
+Define si los componentes especificados son visibles
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Inicializa una nueva instancia de la clase VertexElementVisibility. |
+
+ **Result:**
+
+
+
+---
+
+
+### getData{#getData}
+
+| Nombre | Descripción |
+| --- | --- |
+| getData() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| Nombre | Descripción |
+| --- | --- |
+| getVertexElementType() | Obtiene el tipo del VertexElement. El valor de la propiedad es la constante entera VertexElementType. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getMappingMode() | Obtiene o establece cómo se asigna el elemento. El valor de la propiedad es la constante entera MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setMappingMode(value) | Obtiene o establece cómo se asigna el elemento. El valor de la propiedad es la constante entera MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getReferenceMode() | Obtiene o establece cómo se referencia el elemento. El valor de la propiedad es la constante entera ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setReferenceMode(value) | Obtiene o establece cómo se referencia el elemento. El valor de la propiedad es la constante entera ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| Nombre | Descripción |
+| --- | --- |
+| getIndices() | Obtiene los datos de los índices. La matriz de índices. |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| Nombre | Descripción |
+| --- | --- |
+| clear() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| Nombre | Descripción |
+| --- | --- |
+| setIndices(data) | Cargar índices |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| dat | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| Nombre | Descripción |
+| --- | --- |
+| toString() | Representación en cadena del elemento de vértice. |
+
+ **Result:**
+Cadena
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/vertexelementweight/_index.md
+++ b/spanish/nodejs-java/aspose.threed/vertexelementweight/_index.md
@@ -1,0 +1,229 @@
+---
+title: "VertexElementWeight"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/vertexelementweight/
+---
+## VertexElementWeight class
+
+Define el peso de mezcla para los componentes especificados.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Inicializa una nueva instancia de la clase VertexElementWeight. |
+
+ **Result:**
+
+
+
+---
+
+
+### getData{#getData}
+
+| Nombre | Descripción |
+| --- | --- |
+| getData() | Obtiene los datos del vértice |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| Nombre | Descripción |
+| --- | --- |
+| getVertexElementType() | Obtiene el tipo del VertexElement. El valor de la propiedad es la constante entera VertexElementType. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getMappingMode() | Obtiene o establece cómo se asigna el elemento. El valor de la propiedad es la constante entera MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setMappingMode(value) | Obtiene o establece cómo se asigna el elemento. El valor de la propiedad es la constante entera MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getReferenceMode() | Obtiene o establece cómo se referencia el elemento. El valor de la propiedad es la constante entera ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setReferenceMode(value) | Obtiene o establece cómo se referencia el elemento. El valor de la propiedad es la constante entera ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| Nombre | Descripción |
+| --- | --- |
+| getIndices() | Obtiene los datos de los índices. La matriz de índices. |
+
+ **Result:**
+
+
+
+---
+
+
+### copyTo{#copyTo}
+
+| Nombre | Descripción |
+| --- | --- |
+| copyTo(target) | Copia datos al elemento especificado |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| target | VertexElementDoublesTemplate | Target. |
+
+ **Result:**
+
+
+
+---
+
+
+### setData{#setData}
+
+| Nombre | Descripción |
+| --- | --- |
+| setData(data) | Cargar datos |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| dat | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| Nombre | Descripción |
+| --- | --- |
+| clear() | Elimina todos los elementos de los arreglos directos y de índices. |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| Nombre | Descripción |
+| --- | --- |
+| setIndices(data) | Cargar índices |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| dat | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| Nombre | Descripción |
+| --- | --- |
+| toString() | Representación en cadena del elemento de vértice. |
+
+ **Result:**
+Cadena
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/vertexfield/_index.md
+++ b/spanish/nodejs-java/aspose.threed/vertexfield/_index.md
@@ -1,0 +1,146 @@
+---
+title: "VertexField"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/vertexfield/
+---
+## VertexField class
+
+Descripción del diseño de memoria del campo del vértice.  @hideconstructor
+
+
+## Métodos
+
+### getDataType{#getDataType}
+
+| Nombre | Descripción |
+| --- | --- |
+| getDataType() | Tipo de datos de este campo. El valor de la propiedad es la constante entera VertexFieldDataType. |
+
+ **Result:**
+
+
+
+---
+
+
+### getSemantic{#getSemantic}
+
+| Nombre | Descripción |
+| --- | --- |
+| getSemantic() | La semántica de uso de este campo. El valor de la propiedad es la constante entera VertexFieldSemantic. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAlias{#getAlias}
+
+| Nombre | Descripción |
+| --- | --- |
+| getAlias() | Alias anotado por el atributo com.aspose.threed.SemanticAttribute |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndex{#getIndex}
+
+| Nombre | Descripción |
+| --- | --- |
+| getIndex() | Índice de este campo en el diseño del vértice con la misma semántica. |
+
+ **Result:**
+
+
+
+---
+
+
+### getOffset{#getOffset}
+
+| Nombre | Descripción |
+| --- | --- |
+| getOffset() | El desplazamiento en bytes de este campo. |
+
+ **Result:**
+
+
+
+---
+
+
+### getSize{#getSize}
+
+| Nombre | Descripción |
+| --- | --- |
+| getSize() | El tamaño en bytes de este campo |
+
+ **Result:**
+
+
+
+---
+
+
+### hashCode{#hashCode}
+
+| Nombre | Descripción |
+| --- | --- |
+| hashCode() |  |
+
+ **Result:**
+Número
+
+
+---
+
+
+### equals{#equals}
+
+| Nombre | Descripción |
+| --- | --- |
+| equals(obj) | Determina si esta instancia y un objeto especificado, que también debe ser un objeto VertexField, tienen el mismo valor. |
+
+ **Result:**
+Número
+
+
+---
+
+
+### compareTo{#compareTo}
+
+| Nombre | Descripción |
+| --- | --- |
+| compareTo(other) | Compara esta instancia con un objeto especificado y devuelve una indicación de sus valores relativos. |
+
+ **Result:**
+Número
+
+
+---
+
+
+### toString{#toString}
+
+| Nombre | Descripción |
+| --- | --- |
+| toString() |  |
+
+ **Result:**
+Cadena
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/viewport/_index.md
+++ b/spanish/nodejs-java/aspose.threed/viewport/_index.md
@@ -1,0 +1,185 @@
+---
+title: "Viewport"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/viewport/
+---
+## Viewport class
+
+Un com.aspose.threed.IRenderTarget contiene al menos una ventana de visualización para renderizar la escena.  @hideconstructor
+
+
+## Métodos
+
+### getFrustum{#getFrustum}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFrustum() | Obtiene o establece la cámara de este Viewport |
+
+ **Result:**
+
+
+
+---
+
+
+### setFrustum{#setFrustum}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFrustum(value) | Obtiene o establece la cámara de este Viewport |
+
+ **Result:**
+
+
+
+---
+
+
+### getEnabled{#getEnabled}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEnabled() | Habilita o deshabilita este viewport. |
+
+ **Result:**
+
+
+
+---
+
+
+### setEnabled{#setEnabled}
+
+| Nombre | Descripción |
+| --- | --- |
+| setEnabled(value) | Habilita o deshabilita este viewport. |
+
+ **Result:**
+
+
+
+---
+
+
+### getRenderTarget{#getRenderTarget}
+
+| Nombre | Descripción |
+| --- | --- |
+| getRenderTarget() | Obtiene el objetivo de renderizado que creó este viewport. |
+
+ **Result:**
+
+
+
+---
+
+
+### getArea{#getArea}
+
+| Nombre | Descripción |
+| --- | --- |
+| getArea() | Obtiene o establece el área del viewport en el objetivo de renderizado. |
+
+ **Result:**
+
+
+
+---
+
+
+### setArea{#setArea}
+
+| Nombre | Descripción |
+| --- | --- |
+| setArea(value) | Obtiene o establece el área del viewport en el objetivo de renderizado. |
+
+ **Result:**
+
+
+
+---
+
+
+### getZOrder{#getZOrder}
+
+| Nombre | Descripción |
+| --- | --- |
+| getZOrder() | Obtiene o establece el orden Z del viewport. |
+
+ **Result:**
+
+
+
+---
+
+
+### setZOrder{#setZOrder}
+
+| Nombre | Descripción |
+| --- | --- |
+| setZOrder(value) | Obtiene o establece el orden Z del viewport. |
+
+ **Result:**
+
+
+
+---
+
+
+### getBackgroundColor{#getBackgroundColor}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBackgroundColor() | Obtiene o establece el color de fondo del viewport. |
+
+ **Result:**
+
+
+
+---
+
+
+### setBackgroundColor{#setBackgroundColor}
+
+| Nombre | Descripción |
+| --- | --- |
+| setBackgroundColor(value) | Obtiene o establece el color de fondo del viewport. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDepthClear{#getDepthClear}
+
+| Nombre | Descripción |
+| --- | --- |
+| getDepthClear() | Obtiene o establece el valor de profundidad usado al limpiar el viewport con el bit del búfer de profundidad activado. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDepthClear{#setDepthClear}
+
+| Nombre | Descripción |
+| --- | --- |
+| setDepthClear(value) | Obtiene o establece el valor de profundidad usado al limpiar el viewport con el bit del búfer de profundidad activado. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/watermark/_index.md
+++ b/spanish/nodejs-java/aspose.threed/watermark/_index.md
@@ -1,0 +1,96 @@
+---
+title: "Watermark"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/watermark/
+---
+## Watermark class
+
+Utilidad para codificar/decodificar marca de agua ciega a/de una malla.  @hideconstructor
+
+
+## Métodos
+
+### encodeWatermark{#encodeWatermark}
+
+| Nombre | Descripción |
+| --- | --- |
+| encodeWatermark(input, text) | Codifica un texto en la marca de agua ciega de la malla. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| input | Malla | Malla para codificar una marca de agua ciega |
+| text | Cadena | Texto para codificar en la malla |
+
+ **Result:**
+Malla
+
+
+---
+
+
+### encodeWatermark{#encodeWatermark}
+
+| Nombre | Descripción |
+| --- | --- |
+| encodeWatermark(input, text, password) | Codifica un texto en la marca de agua ciega de la malla. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| input | Malla | Malla para codificar una marca de agua ciega |
+| text | Cadena | Texto para codificar en la malla |
+| password | Cadena | Contraseña para proteger la marca de agua, es opcional |
+
+ **Result:**
+Malla
+
+
+---
+
+
+### decodeWatermark{#decodeWatermark}
+
+| Nombre | Descripción |
+| --- | --- |
+| decodeWatermark(input) | Decodifica la marca de agua de una malla |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| input | Malla | La malla para extraer la marca de agua |
+
+ **Result:**
+Cadena
+
+
+---
+
+
+### decodeWatermark{#decodeWatermark}
+
+| Nombre | Descripción |
+| --- | --- |
+| decodeWatermark(input, password) | Decodifica la marca de agua de una malla |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| input | Malla | La malla para extraer la marca de agua |
+| password | Cadena | La contraseña para descifrar la marca de agua |
+
+ **Result:**
+Cadena
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/windowhandle/_index.md
+++ b/spanish/nodejs-java/aspose.threed/windowhandle/_index.md
@@ -1,0 +1,13 @@
+---
+title: "WindowHandle"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/windowhandle/
+---
+## WindowHandle class
+
+Manejador de ventana encapsulado para diferentes plataformas.  @hideconstructor
+
+

--- a/spanish/nodejs-java/aspose.threed/xloadoptions/_index.md
+++ b/spanish/nodejs-java/aspose.threed/xloadoptions/_index.md
@@ -1,0 +1,152 @@
+---
+title: "XLoadOptions"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/xloadoptions/
+---
+## XLoadOptions class
+
+Las opciones de carga para archivos DirectX X.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor(contentType) | Constructor de XLoadOptions |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| contentType | FileContentType | FileContentType |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlipCoordinateSystem{#getFlipCoordinateSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFlipCoordinateSystem() | Invierte el sistema de coordenadas, esto es true por defecto |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlipCoordinateSystem{#setFlipCoordinateSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFlipCoordinateSystem(value) | Invierte el sistema de coordenadas, esto es true por defecto |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileFormat() | Obtiene el formato de archivo especificado en la opción actual de Guardar/Cargar. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEncoding() | Obtiene o establece la codificación predeterminada para archivos basados en texto. El valor predeterminado es null, lo que significa que el importador/exportador decidirá qué codificación usar. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileSystem() | Permite al usuario manejar cómo gestionar las dependencias externas durante la carga/guardado. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFileSystem(value) | Permite al usuario manejar cómo gestionar las dependencias externas durante la carga/guardado. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| Nombre | Descripción |
+| --- | --- |
+| getLookupPaths() | Algunos archivos como OBJ dependen de archivos externos; las rutas de búsqueda permiten que Aspose.3D busque el archivo externo para cargarlo. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFileName() | El nombre de archivo de la escena de exportación/importación. Es opcional, pero útil al serializar recursos externos como el material de OBJ. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFileName(value) | El nombre de archivo de la escena de exportación/importación. Es opcional, pero útil al serializar recursos externos como el material de OBJ. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/ziparchivefilesystem/_index.md
+++ b/spanish/nodejs-java/aspose.threed/ziparchivefilesystem/_index.md
@@ -1,0 +1,75 @@
+---
+title: "ZipArchiveFileSystem"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/ziparchivefilesystem/
+---
+## ZipArchiveFileSystem class
+
+Sistema de archivos para proporcionar acceso de solo lectura al archivo zip especificado o al flujo zip.  El sistema de archivos se eliminará después de la operación de abrir/guardar.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor(fileName) | Construye un ZipArchiveFileSystem mediante un nombre de archivo. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| fileNam | Cadena | null |
+
+ **Result:**
+
+
+
+---
+
+
+### readFile{#readFile}
+
+| Nombre | Descripción |
+| --- | --- |
+| readFile(fileName, options) | Abrir archivo para lectura |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| fileNam | Cadena | null |
+| opción | IOConfig | null |
+
+ **Result:**
+Stream
+
+
+---
+
+
+### writeFile{#writeFile}
+
+| Nombre | Descripción |
+| --- | --- |
+| writeFile(fileName, options) | Abrir archivo para escritura, no implementado en esta clase. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| fileNam | Cadena | null |
+| opción | IOConfig | null |
+
+ **Result:**
+Stream
+
+
+---
+
+
+

--- a/spanish/nodejs-java/aspose.threed/zshape/_index.md
+++ b/spanish/nodejs-java/aspose.threed/zshape/_index.md
@@ -1,0 +1,437 @@
+---
+title: "ZShape"
+second_title: "Referencia de API de Aspose.3D para Node.js vía Java"
+description: 
+type: docs
+
+url: /es/nodejs-java/aspose.threed/zshape/
+---
+## ZShape class
+
+Perfil en forma de Z compatible con IFC definido por parámetros.
+
+
+## Métodos
+
+### constructor{#constructor}
+
+| Nombre | Descripción |
+| --- | --- |
+| constructor() | Constructor de ZShape |
+
+ **Result:**
+
+
+
+---
+
+
+### getDepth{#getDepth}
+
+| Nombre | Descripción |
+| --- | --- |
+| getDepth() | Obtiene o establece la longitud del web. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDepth{#setDepth}
+
+| Nombre | Descripción |
+| --- | --- |
+| setDepth(value) | Obtiene o establece la longitud del web. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlangeWidth{#getFlangeWidth}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFlangeWidth() | Obtiene o establece la longitud del flange. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlangeWidth{#setFlangeWidth}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFlangeWidth(value) | Obtiene o establece la longitud del flange. |
+
+ **Result:**
+
+
+
+---
+
+
+### getWebThickness{#getWebThickness}
+
+| Nombre | Descripción |
+| --- | --- |
+| getWebThickness() | Obtiene o establece el grosor de la pared. |
+
+ **Result:**
+
+
+
+---
+
+
+### setWebThickness{#setWebThickness}
+
+| Nombre | Descripción |
+| --- | --- |
+| setWebThickness(value) | Obtiene o establece el grosor de la pared. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlangeThickness{#getFlangeThickness}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFlangeThickness() | Obtiene o establece el grosor del flange. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlangeThickness{#setFlangeThickness}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFlangeThickness(value) | Obtiene o establece el grosor del flange. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFilletRadius{#getFilletRadius}
+
+| Nombre | Descripción |
+| --- | --- |
+| getFilletRadius() | Obtiene o establece el radio del filete entre el flange y el web. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFilletRadius{#setFilletRadius}
+
+| Nombre | Descripción |
+| --- | --- |
+| setFilletRadius(value) | Obtiene o establece el radio del filete entre el flange y el web. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEdgeRadius{#getEdgeRadius}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEdgeRadius() | Obtiene o establece el radio del borde del flange. |
+
+ **Result:**
+
+
+
+---
+
+
+### setEdgeRadius{#setEdgeRadius}
+
+| Nombre | Descripción |
+| --- | --- |
+| setEdgeRadius(value) | Obtiene o establece el radio del borde del flange. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNodes() | Obtiene todos los nodos padre; una entidad puede estar adjunta a varios nodos padre para la instanciación de geometría. Los nodos. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExcluded() | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Nombre | Descripción |
+| --- | --- |
+| setExcluded(value) | Obtiene o establece si excluir esta entidad durante la exportación. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| getParentNode() | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Nombre | Descripción |
+| --- | --- |
+| setParentNode(value) | Obtiene o establece el primer nodo padre; si se establece el primer nodo padre, esta entidad se separará de los demás nodos padres. El nodo padre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Nombre | Descripción |
+| --- | --- |
+| getScene() | Obtiene la escena a la que pertenece este objeto |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Nombre | Descripción |
+| --- | --- |
+| getName() | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Nombre | Descripción |
+| --- | --- |
+| setName(value) | Obtiene o establece el nombre. El nombre. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperties() | Obtiene la colección de todas las propiedades. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtent{#getExtent}
+
+| Nombre | Descripción |
+| --- | --- |
+| getExtent() | Obtiene la extensión en las dimensiones x e y. |
+
+ **Result:**
+Vector2
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Nombre | Descripción |
+| --- | --- |
+| getEntityRendererKey() | Obtiene la clave del renderizador de entidad registrado en el renderizador |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Nombre | Descripción |
+| --- | --- |
+| getBoundingBox() | Obtiene el cuadro delimitador de la entidad actual en su sistema de coordenadas de espacio de objeto. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Elimina una propiedad dinámica. |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Property | Qué propiedad eliminar |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| removeProperty(property) | Eliminar la propiedad especificada identificada por nombre |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propert | Cadena | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| getProperty(property) | Obtener el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| setProperty(property, value) | Establece el valor de la propiedad especificada |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| property | Cadena | Nombre de la propiedad |
+| valor | Objeto | El valor de la propiedad |
+
+ **Result:**
+Objeto
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Nombre | Descripción |
+| --- | --- |
+| findProperty(propertyName) | Busca la propiedad. Puede ser una propiedad dinámica (Creada por CreateDynamicProperty/SetProperty) o una propiedad nativa (Identificada por su nombre) |
+
+ **Parameters:**
+
+| Nombre | Tipo | Descripción |
+| --- | --- | --- |
+| propertyName | Cadena | Nombre de la propiedad. |
+
+ **Result:**
+Property
+
+
+---
+
+
+


### PR DESCRIPTION
Automated translation of the NODEJS-JAVA API Reference to **Spanish** (`es`) generated by RDA.

- Pages translated: 204/204
- Errors: 0
- Source: `english/nodejs-java`
- Output: `spanish/nodejs-java`

🤖 Generated by RDA