### PR TITLE
[auto] Translate NODEJS-JAVA API Reference to Swedish

### DIFF
--- a/swedish/nodejs-java/_index.md
+++ b/swedish/nodejs-java/_index.md
@@ -1,0 +1,13 @@
+---
+title: "Aspose.3D för Node.js via Java"
+type: docs
+weight: 11
+url: /sv/nodejs-java/
+description: "Aspose.3D för Node.js via Java API-referenser innehåller exempel, kodsnuttar och API-dokumentation. Den tillhandahåller paket, klasser, gränssnitt och andra API-detaljer."
+is_root: true
+---
+
+## Packages
+| Paket | Beskrivning |
+| --- | --- |
+| [aspose.threed](./aspose.threed) |  |

--- a/swedish/nodejs-java/aspose.threed/_index.md
+++ b/swedish/nodejs-java/aspose.threed/_index.md
@@ -1,0 +1,217 @@
+---
+title: "aspose.threed"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+keywords: "Aspose.3D for Node.js via Java, Aspose.3D, STL, OBJ, Aspose API Reference."
+type: docs
+weight: 10
+url: /sv/nodejs-java/aspose.threed/
+---
+
+
+## Klasser
+
+| Klass | Beskrivning |
+| --- | --- |
+| [A3DObject](../aspose.threed/a3dobject) | Bas-klassen för alla Aspose.ThreeD-objekt, alla underklasser kommer att stödja dynamiska egenskaper. |
+| [A3dwSaveOptions](../aspose.threed/a3dwsaveoptions) | Sparaalternativ för A3DW-format. |
+| [AmfSaveOptions](../aspose.threed/amfsaveoptions) | Sparaalternativ för AMF |
+| [AnimationChannel](../aspose.threed/animationchannel) | Ett kanal mappar egenskapens komponentfält till en uppsättning nyckelramsekvenser  @hideconstructor |
+| [AnimationClip](../aspose.threed/animationclip) | Animationsklippet är en samling animationer.  Scenen kan ha ett eller flera animationsklipp. |
+| [AnimationNode](../aspose.threed/animationnode) | Aspose.3D stödjer animationshierarki, varje animation kan bestå av flera animationer och animationens nyckelramdefinition.  AnimationNode definierar transformationen av ett egenskapsvärde över tid, till exempel kan en animationsnod användas för att kontrollera en nods transformation eller andra numeriska egenskaper hos ett A3DObject-objekt. |
+| [ArbitraryProfile](../aspose.threed/arbitraryprofile) | Denna klass låter dig konstruera en 2D-profil direkt från en godtycklig kurva. |
+| [AssetInfo](../aspose.threed/assetinfo) | Information om tillgången.  Tillgångsinformation kan bifogas till en scen.  En underordnad scen kan ha sin egen AssetInfo för att åsidosätta förälderns definition. |
+| [BindPoint](../aspose.threed/bindpoint) | En BindPoint skapas vanligtvis på ett objekts egenskap, vissa egenskapstyper innehåller flera komponentfält (som ett Vector3-fält),  BindPoint kommer att generera en kanal för varje komponentfält och ansluter fältet till en eller flera nyckelramsekvensinstans(er) via kanalerna. |
+| [Bone](../aspose.threed/bone) | Ett ben definierar delmängden av geometrins kontrollpunkt och definierar blandningsvikt för varje kontrollpunkt.  Bone-objektet kan inte användas direkt, en SkinDeformer-instans används för att deformera geometrin, och SkinDeformer levereras med en uppsättning ben, där varje ben är länkat till en nod.  OBS: En kontrollpunkt i en geometri kan vara bunden till mer än ett ben. |
+| [BonePose](../aspose.threed/bonepose) | BonePose innehåller transformationsmatrisen för en bennod |
+| [BoundingBox](../aspose.threed/boundingbox) | Den axeljusterade avgränsningsboxen |
+| [BoundingBox2D](../aspose.threed/boundingbox2d) | Den axeljusterade avgränsningsboxen för Vector2 |
+| [Box](../aspose.threed/box) | Box. |
+| [Camera](../aspose.threed/camera) | Kameran beskriver betraktarens ögonpunkt när denne tittar på scenen. |
+| [Circle](../aspose.threed/circle) | En cirkelkurva består av en uppsättning punkter på kanten av cirkelformen. |
+| [CircleShape](../aspose.threed/circleshape) | IFC-kompatibel cirkelprofil, som kan användas för att konstruera ett mesh genom LinearExtrusion |
+| [ColladaSaveOptions](../aspose.threed/colladasaveoptions) | Spara alternativ för collada |
+| [CompositeCurve](../aspose.threed/compositecurve) | En CompositeCurve består av flera kurvsegment. |
+| [CShape](../aspose.threed/cshape) | IFC-kompatibel C-form profil som definieras av parametrar.  Profilens mittposition är i mitten av omgivningsrutan. |
+| [Curve](../aspose.threed/curve) | Bas-klassen för alla kurvimplementationer.  @hideconstructor |
+| [CustomObject](../aspose.threed/customobject) | Metadata eller anpassade objekt som används i 3D-filer hanteras av denna klass.  Alla anpassade egenskaper sparas som dynamiska egenskaper. |
+| [Cylinder](../aspose.threed/cylinder) | Parametriserad cylinder.  Den kan också användas för att representera en kon när antingen radiusTop eller radiusBottom är noll. |
+| [Deformer](../aspose.threed/deformer) | Bas-klass för SkinDeformer och MorphTargetDeformer |
+| [DescriptorSetUpdater](../aspose.threed/descriptorsetupdater) | Denna klass möjliggör att uppdatera com.aspose.threed.IDescriptorSet i en kedjeoperation.  @hideconstructor |
+| [Discreet3dsLoadOptions](../aspose.threed/discreet3dsloadoptions) | Läsalternativ för 3DS-fil. |
+| [Discreet3dsSaveOptions](../aspose.threed/discreet3dssaveoptions) | Sparaalternativ för 3DS-fil. |
+| [Dish](../aspose.threed/dish) | Parametriserad skål. |
+| [DracoFormat](../aspose.threed/dracoformat) | Google Draco-format  @hideconstructor |
+| [DracoSaveOptions](../aspose.threed/dracosaveoptions) | Sparaalternativ för Google draco-filer |
+| [DriverException](../aspose.threed/driverexception) | Undantaget som kastas av interna renderingsdrivrutiner.  @hideconstructor |
+| [DummyFileSystem](../aspose.threed/dummyfilesystem) | Läs/skriv-operationer är dummy-operationer. |
+| [Ellipse](../aspose.threed/ellipse) | En ellips definierar en uppsättning punkter som bildar ellipsens form. |
+| [EllipseShape](../aspose.threed/ellipseshape) | IFC-kompatibel ellipsform som definieras av parametrar.  Profilens mittposition är i mitten av omgivningsrutan. |
+| [EndPoint](../aspose.threed/endpoint) | Slutpunkten för att trimma kurvan, kan vara ett parametervärde eller en kartesisk punkt. |
+| [Entity](../aspose.threed/entity) | Bas-klassen för alla enheter.  Entity representerar ett konkret objekt som är fäst under en nod som Light/Geometry. |
+| [EntityRenderer](../aspose.threed/entityrenderer) | Skapa en underklass för att implementera rendering för olika typer av enheter. |
+| [EntityRendererKey](../aspose.threed/entityrendererkey) | Nyckeln för registrerad enhetsrenderare |
+| [ExportException](../aspose.threed/exportexception) | Undantag när Aspose.3D misslyckades med att exportera scenen till fil |
+| [Extrapolation](../aspose.threed/extrapolation) | Extrapolering definierar hur man går tillväga när ett sampelvärde ligger utanför intervallet som definieras av de första och sista nyckelramarna.  @hideconstructor |
+| [FbxLoadOptions](../aspose.threed/fbxloadoptions) | Läsalternativ för Fbx-format. |
+| [FbxSaveOptions](../aspose.threed/fbxsaveoptions) | Sparaalternativ för Fbx-fil. |
+| [FileFormat](../aspose.threed/fileformat) | Filformatdefinition  @hideconstructor |
+| [FileFormatType](../aspose.threed/fileformattype) | Filformattyp  @hideconstructor |
+| [FileSystem](../aspose.threed/filesystem) | Filsysteminkapsling.  Aspose.3D kommer att använda detta för att läsa/skriva beroenden.  @hideconstructor |
+| [FMatrix4](../aspose.threed/fmatrix4) | 4x4-matris med alla komponenter i flyttalstyp |
+| [FontFile](../aspose.threed/fontfile) | Teckensnittfilen innehåller definitioner för glyfer, den används för att skapa textprofil.  @hideconstructor |
+| [Frustum](../aspose.threed/frustum) | Bas-klassen för Camera och Light  @hideconstructor |
+| [FVector2](../aspose.threed/fvector2) | En flyttalsvektor med två komponenter. |
+| [FVector3](../aspose.threed/fvector3) | En flyttalsvektor med tre komponenter. |
+| [FVector4](../aspose.threed/fvector4) | En flyttalsvektor med fyra komponenter. |
+| [Geometry](../aspose.threed/geometry) | Bas-klassen för alla renderbara geometriska objekt (som Mesh, NurbsSurface, Patch osv.).  Geometry-bas-klassen stödjer:  Hantering av kontrollpunkter, kontrollpunkter definierar den grundläggande 3D-rymdstrukturen för geometrin, olika geometrityper har olika sätt att definiera konkreta 3D-modeller. Definition av vertex-element, vertex-element tillför extra information som normaler/uv-koordinater/vertex-färger till geometrin, se VertexElement för mer detaljer. Objektdeformation, Deformer kan bindas för att animera geometrins form. |
+| [GlobalTransform](../aspose.threed/globaltransform) | Global transform är liknande Transform men är oföränderlig medan den representerar den slutgiltiga beräknade transformationen.  Högerhandskoordinatsystem används vid beräkning av global transform  @hideconstructor |
+| [GLSLSource](../aspose.threed/glslsource) | Källkoden för shaders i GLSL |
+| [GltfLoadOptions](../aspose.threed/gltfloadoptions) | Läsalternativ för glTF-format |
+| [GltfSaveOptions](../aspose.threed/gltfsaveoptions) | Sparaalternativ för glTF-format. |
+| [HollowCircleShape](../aspose.threed/hollowcircleshape) | IFC-kompatibel ihålig cirkelprofil. |
+| [HollowRectangleShape](../aspose.threed/hollowrectangleshape) | IFC-kompatibel ihålig rektangulär form med både inre/yttre avrundade hörn. |
+| [HShape](../aspose.threed/hshape) | HShape tillhandahåller de definierande parametrarna för en 'H'- eller 'I'-form. |
+| [Html5SaveOptions](../aspose.threed/html5saveoptions) | Sparaalternativ för HTML5 |
+| [ImageRenderOptions](../aspose.threed/imagerenderoptions) | Alternativ för Scene.render(com.aspose.threed.Camera, java.lang.String, com.aspose.threed.Vector2, java.lang.String, com.aspose.threed.ImageRenderOptions) och  Scene.render(com.aspose.threed.Camera, com.aspose.threed.TextureData, com.aspose.threed.ImageRenderOptions) |
+| [ImportException](../aspose.threed/importexception) | Undantag när Aspose.3D misslyckades med att öppna den angivna källan |
+| [InitializationException](../aspose.threed/initializationexception) | Undantag vid initiering av renderingspipeline |
+| [IOConfig](../aspose.threed/ioconfig) | IO-konfiguration för serialisering/deserialisering.  Användaren kan ange detaljerade konfigurationer som beroendeuppslagningsväg  Eller formatrelaterade konfigurationer här  @hideconstructor |
+| [IOUtils](../aspose.threed/ioutils) | Verktyg för att skriva matris/vektor till binär skrivare  @hideconstructor |
+| [KeyFrame](../aspose.threed/keyframe) | En nyckelram definieras huvudsakligen av en tid och ett värde, för vissa interpoleringstyper används även tangent/spänning/bias/kontinuitet vid beräkning av det slutliga samplade värdet.  Samplade värden i en tidpunkt utan nyckelram interpoleras av nyckelramar mellan föregående och nästa nyckelram.  Värden före/efter den första/sista nyckelramen beräknas av klassen Extrapolation. |
+| [KeyframeSequence](../aspose.threed/keyframesequence) | Sekvensen av nyckelramar beskriver transformationen av ett samplat värde över tid. |
+| [LambertMaterial](../aspose.threed/lambertmaterial) | Material för lambert-skuggningsmodell |
+| [License](../aspose.threed/license) | Tillhandahåller metoder för att licensiera komponenten. |
+| [Light](../aspose.threed/light) | Ljuset lyser upp scenen. Formeln för att beräkna den totala dämpningen av ljuset är:  A = ConstantAttenuation + (Dist  LinearAttenuation) + ((Dist^2)  QuadraticAttenuation) |
+| [Line](../aspose.threed/line) | En polylinje är en bana som definieras av en uppsättning punkter med Geometry.ControlPoints och som är sammankopplade med Segment, vilket betyder att den också kan vara en uppsättning sammankopplade linjesegment. Linjen är vanligtvis ett linjärt objekt, vilket innebär att den inte kan användas för att representera en kurva; för att representera en kurva används NurbsCurve. |
+| [LinearExtrusion](../aspose.threed/linearextrusion) | Linjär extrusion tar en 2D-form som indata och förlänger formen i den tredje dimensionen. |
+| [LoadOptions](../aspose.threed/loadoptions) | Bas-klassen för att konfigurera alternativ vid filinläsning för olika typer  @hideconstructor |
+| [LocalFileSystem](../aspose.threed/localfilesystem) | LocalFileSystem mappar läs-/skrivoperationer till den lokala katalogen. |
+| [LShape](../aspose.threed/lshape) | IFC-kompatibel L-formad profil som definieras av parametrar. |
+| [Material](../aspose.threed/material) | Material definierar de parametrar som behövs för geometrins visuella utseende. Aspose.3D tillhandahåller skuggningsmodeller för LambertMaterial, PhongMaterial och ShaderMaterial  @hideconstructor |
+| [MathUtils](../aspose.threed/mathutils) | En samling användbara matematiska verktyg.  @hideconstructor |
+| [Matrix4](../aspose.threed/matrix4) | 4x4-matrisimplementation. |
+| [MemoryFileSystem](../aspose.threed/memoryfilesystem) | MemoryFileSystem mappar läs-/skrivoperationer till minnet. |
+| [Mesh](../aspose.threed/mesh) | Ett nätverk består av många n-sidiga polygoner. |
+| [Metered](../aspose.threed/metered) | Tillhandahåller metoder för att ställa in mätad nyckel. |
+| [MirroredProfile](../aspose.threed/mirroredprofile) | IFC-kompatibel spegelprofil. Denna profil definierar en ny profil genom att spegla basprofilen kring y-axeln. |
+| [MorphTargetChannel](../aspose.threed/morphtargetchannel) | En MorphTargetChannel används av MorphTargetDeformer för att organisera målgeometrierna. Vissa filformat som FBX stödjer flera kanaler parallellt. Vikt är mellan 0 och 1.0, och standardvikt för målet är 0.0; |
+| [MorphTargetDeformer](../aspose.threed/morphtargetdeformer) | MorphTargetDeformer tillhandahåller per-vertex-animering. MorphTargetDeformer organiserar alla mål via MorphTargetChannel, varje kanal kan organisera flera mål. En vanlig användning av morph target-deformer är att applicera ansiktsuttryck på en karaktär. Mer detaljer finns på https://en.wikipedia.org/wiki/Morph_target_animation |
+| [Node](../aspose.threed/node) | Representerar ett element i scengrafen. En scengraf är ett träd av Node-objekt. Trädhanteringstjänsterna är självständiga i denna klass. Observera att Aspose.3D SDK inte testar giltigheten av den konstruerade scengrafen. Det är anroparens ansvar att säkerställa att den inte genererar cykliska grafer i en nodhierarki. Förutom trädhanteringen definierar denna klass alla egenskaper som krävs för att beskriva objektets position i scenen. Denna information inkluderar de grundläggande egenskaperna Translation, Rotation och Scaling samt mer avancerade alternativ för pivoter, begränsningar och IK-leden attribut såsom styvhet och dämpning. När den först skapas är Node-objektet "tomt" (dvs. det är ett objekt utan någon grafisk representation som endast innehåller positionsinformation). I detta tillstånd kan det användas för att representera föräldrar i nodträdet men inte mycket mer. Den normala användningen av denna typ av objekt är att lägga till dem en entitet som specialiserar noden (se "Entity"). Entiteten är ett eget objekt och är kopplad till Node. Detta innebär också att samma entitet kan delas mellan flera noder. Camera, Light, Mesh osv... är alla entiteter och de är alla härledda från basklassen Entity. |
+| [NurbsCurve](../aspose.threed/nurbscurve) | NURBS-kurva är en kurva som representeras av NURBS (Non-uniform rational basis spline). En NURBS-kurva definieras av dess ordning, en uppsättning viktade Geometry.ControlPoints och en KnotVectors. w-komponenten i kontrollpunkten används som kontrollpunktens vikt, oavsett om den är CurveDimension.TWO_DIMENSIONAL eller CurveDimension.THREE_DIMENSIONAL. |
+| [NurbsDirection](../aspose.threed/nurbsdirection) | En 3D NurbsSurface har två riktningar, NurbsSurface.U och NurbsSurface.V, där NurbsDirection definierar data för varje riktning. En riktning är i själva verket en NURBS-kurva, vilket betyder att den också definieras av dess ordning, en KnotVectors och en uppsättning viktade kontrollpunkter (definierade i NurbsSurface). |
+| [NurbsSurface](../aspose.threed/nurbssurface) | NurbsSurface är en yta som representeras av NURBS (Non-uniform rational basis spline). En NurbsSurface definieras av två NurbsDirectionU och V. w-komponenten i kontrollpunkten används som kontrollpunktens vikt, oavsett om riktningens typ är CurveDimension.TWO_DIMENSIONAL eller CurveDimension.THREE_DIMENSIONAL. |
+| [ObjLoadOptions](../aspose.threed/objloadoptions) | Läsalternativ för wavefront obj |
+| [ObjSaveOptions](../aspose.threed/objsaveoptions) | Sparaalternativ för wavefront obj-fil |
+| [ParameterizedProfile](../aspose.threed/parameterizedprofile) | Bas-klassen för alla parametriserade profiler.  @hideconstructor |
+| [ParseException](../aspose.threed/parseexception) | Undantag när Aspose.3D misslyckades med att tolka indata. |
+| [Patch](../aspose.threed/patch) | En Patch är en parametrisk modelleringsyta, liknande NurbsSurface, den definieras också av två PatchDirection, U och V. Men skillnaden mellan Patch och NurbsSurface är att PatchDirection-kurvan kan vara en av PatchDirectionType.BEZIER, PatchDirectionType.QUADRATIC_BEZIER, PatchDirectionType.BASIS_SPLINE, PatchDirectionType.CARDINAL_SPLINE och PatchDirectionType.LINEAR |
+| [PatchDirection](../aspose.threed/patchdirection) | Patchens U- och V-riktning. |
+| [PbrMaterial](../aspose.threed/pbrmaterial) | Material för fysiskt baserad rendering baserat på albedofärg/metallisk/roughness |
+| [PbrSpecularMaterial](../aspose.threed/pbrspecularmaterial) | Material för fysiskt baserad rendering baserat på diffus färg/specular/glossiness |
+| [PdfFormat](../aspose.threed/pdfformat) | Adobes Portable Document Format  @hideconstructor |
+| [PdfLoadOptions](../aspose.threed/pdfloadoptions) | Alternativ för PDF-inläsning |
+| [PdfSaveOptions](../aspose.threed/pdfsaveoptions) | Sparaalternativen vid PDF-export. |
+| [PhongMaterial](../aspose.threed/phongmaterial) | Material för blinn-phong skuggningsmodell. |
+| [PixelMapping](../aspose.threed/pixelmapping) | @hideconstructor |
+| [Plane](../aspose.threed/plane) | Parametriserat plan. |
+| [PlyFormat](../aspose.threed/plyformat) | PLY-formatet.  @hideconstructor |
+| [PlyLoadOptions](../aspose.threed/plyloadoptions) | Läsalternativ för PLY-filer |
+| [PlySaveOptions](../aspose.threed/plysaveoptions) | Sparaalternativ för att exportera scen som PLY-fil. |
+| [PointCloud](../aspose.threed/pointcloud) | Punktmolnet innehåller ingen topologiinformation utan endast kontrollpunkterna och vertex-elementen. |
+| [PolygonBuilder](../aspose.threed/polygonbuilder) | En hjälparklass för att bygga polygoner för Mesh |
+| [PolygonModifier](../aspose.threed/polygonmodifier) | Verktyg för att modifiera polygoner  @hideconstructor |
+| [Pose](../aspose.threed/pose) | Posen används för att lagra transformationsmatrisen när geometrin är skinad. Posen är en uppsättning BonePose, där varje BonePose sparar den konkreta transformationsinformationen för ben-noden. |
+| [PostProcessing](../aspose.threed/postprocessing) | Efterbehandlingseffekterna  @hideconstructor |
+| [Primitive](../aspose.threed/primitive) | Basklass för alla primitiv. |
+| [Profile](../aspose.threed/profile) | 2D-profil i xy-planet  @hideconstructor |
+| [Property](../aspose.threed/property) | Klass för att hålla användardefinierade egenskaper.  @hideconstructor |
+| [PropertyCollection](../aspose.threed/propertycollection) | Samlingen av egenskaper  @hideconstructor |
+| [PushConstant](../aspose.threed/pushconstant) | Ett verktyg för att tillhandahålla data till shader genom push constant. |
+| [Pyramid](../aspose.threed/pyramid) | Parametriserad pyramid. |
+| [Quaternion](../aspose.threed/quaternion) | Quaternion används vanligtvis för att utföra rotation i datorgrafik. |
+| [Rect](../aspose.threed/rect) | En klass för att representera rektangeln |
+| [RectangleShape](../aspose.threed/rectangleshape) | IFC-kompatibel rektangulär form med avrundade hörn. |
+| [RectangularTorus](../aspose.threed/rectangulartorus) | Parametriserad rektangulär torus. |
+| [RelativeRectangle](../aspose.threed/relativerectangle) | Relativ rektangel  Formeln mellan relativ komponent och absolut värde är:  Scale  (Reference Width) + offset  Så om vi vill att den ska representera ett absolut värde, lämna alla scale-fält noll, och använd offset-fält istället. |
+| [Renderer](../aspose.threed/renderer) | Kontexten om renderaren.  @hideconstructor |
+| [RendererVariableManager](../aspose.threed/renderervariablemanager) | Denna klass hanterar variabler som används vid rendering  @hideconstructor |
+| [RenderFactory](../aspose.threed/renderfactory) | RenderFactory skapar alla resurser som representeras i renderingspipeline.  @hideconstructor |
+| [RenderParameters](../aspose.threed/renderparameters) | Beskriv parametrarna för renderingsmålet |
+| [RenderResource](../aspose.threed/renderresource) | Den abstrakta klassen för alla renderingsresurser  Alla renderingsresurser kommer att tas bort när renderaren släpps.  Klasser som Mesh/Texture kommer att ha en motsvarande RenderResource  @hideconstructor |
+| [RenderState](../aspose.threed/renderstate) | Renderingsstatus för att bygga pipeline  Ändringarna som görs på renderingsstatusen kommer inte att påverka de skapade pipeline-instanserna. |
+| [RevolvedAreaSolid](../aspose.threed/revolvedareasolid) | Denna klass representerar en solid modell genom att rotera ett tvärsnitt som tillhandahålls av en profil kring en axel. |
+| [RvmFormat](../aspose.threed/rvmformat) | RVM-formatet  @hideconstructor |
+| [RvmLoadOptions](../aspose.threed/rvmloadoptions) | Läsalternativ för AVEVA Plant Design Management Systems RVM-fil. |
+| [RvmSaveOptions](../aspose.threed/rvmsaveoptions) | Sparaalternativ för Aveva PDMS RVM-fil. |
+| [SaveOptions](../aspose.threed/saveoptions) | Bas-klassen för att konfigurera alternativ vid filsparande för olika typer  @hideconstructor |
+| [Scene](../aspose.threed/scene) | En scen är ett top‑nivåobjekt som innehåller noder, geometrier, material, texturer, animationer, poser, under‑scener etc.  Scenen kan ha under‑scener, fungerar som stöd för flera dokument i filer som collada/blender/fbx.  Nodhierarkin kan nås via RootNodeLibrary som används för att hålla en referens till oanslutna objekt under serialisering (som metadata eller anpassade objekt) så att den kan användas som ett bibliotek. |
+| [SceneObject](../aspose.threed/sceneobject) | Rotklassen för objekt som kommer att lagras i en scen. |
+| [ShaderException](../aspose.threed/shaderexception) | Shaderrelaterade undantag |
+| [ShaderMaterial](../aspose.threed/shadermaterial) | Ett shader‑material tillåter att beskriva materialet med en extern renderingsmotor eller shader‑språk.  ShaderMaterial använder ShaderTechnique för att beskriva de konkreta renderingsdetaljerna,  och den mest lämpliga kommer att användas enligt den slutgiltiga renderingsplattformen.  Till exempel kan din ShaderMaterial‑instans ha två tekniker, en definierad av HLSL och en annan definierad av GLSL.  På icke‑Windows‑plattform bör GLSL användas istället för HLSL. |
+| [ShaderProgram](../aspose.threed/shaderprogram) | Shaderprogrammet  @hideconstructor |
+| [ShaderSet](../aspose.threed/shaderset) | Shaderprogram för varje typ av material |
+| [ShaderSource](../aspose.threed/shadersource) | Shaderns källkod  @hideconstructor |
+| [ShaderTechnique](../aspose.threed/shadertechnique) | En shader‑teknik representerar en konkret renderingsimplementation. |
+| [ShaderVariable](../aspose.threed/shadervariable) | Shader‑variabel |
+| [Shape](../aspose.threed/shape) | Formen beskriver deformationen på en uppsättning kontrollpunkter, vilket liknar cluster‑deformeraren i Maya.  Till exempel kan vi lägga till en form till en skapad geometri.  Och formen och geometrin har samma topologiska information men olika positioner för kontrollpunkterna.  Med varierande mängder av påverkan utför geometrin en deformationseffekt. |
+| [Skeleton](../aspose.threed/skeleton) | Skeleton används huvudsakligen av CAD‑program för att hjälpa designern att manipulera transformationen av skelettstrukturen, den är vanligtvis oanvändbar utanför CAD‑programmen. För att få skelettshierarkin att fungera som ett objekt i CAD‑programmet måste den översta Skeleton‑noden markeras som rot genom att sätta Type till SkeletonType.SKELETON, och alla barn sättas till SkeletonType.BONE |
+| [SkinDeformer](../aspose.threed/skindeformer) | En skin‑deformer innehåller flera ben för att arbeta, varje ben blandar en del av geometrin med kontrollpunktens vikter. |
+| [Sphere](../aspose.threed/sphere) | Parametriserad sfär. |
+| [SPIRVSource](../aspose.threed/spirvsource) | Den kompilerade shadern i SPIR‑V‑format. |
+| [StencilState](../aspose.threed/stencilstate) | Stencil‑tillstånd per yta.  @hideconstructor |
+| [StlLoadOptions](../aspose.threed/stlloadoptions) | Läsalternativ för STL |
+| [StlSaveOptions](../aspose.threed/stlsaveoptions) | Sparaalternativ för STL |
+| [SweptAreaSolid](../aspose.threed/sweptareasolid) | En SweptAreaSolid konstruerar en geometri genom att svepa en profil längs en direktrix. |
+| [Text](../aspose.threed/text) | Textprofil, denna profil beskriver konturer med hjälp av typsnitt och text. |
+| [Texture](../aspose.threed/texture) | Denna klass definierar texturen från en extern fil. |
+| [TextureBase](../aspose.threed/texturebase) | Basklass för alla konkreta texturer.  Texture definierar utseendet och känslan av en geometrisk yta. |
+| [TextureCodec](../aspose.threed/texturecodec) | Klass för att hantera kodare och avkodare för texturer. |
+| [TextureData](../aspose.threed/texturedata) | Denna klass innehåller rådata och formatdefinitionen för en textur. |
+| [TextureSlot](../aspose.threed/textureslot) | Texturplats i Material, kan enumereras genom materialinstansen.  @hideconstructor |
+| [Torus](../aspose.threed/torus) | Parametriserad torus. |
+| [Transform](../aspose.threed/transform) | En transform innehåller information som möjliggör åtkomst till objektets förflyttning/skala/rotation eller transformmatris med minimal kostnad. Detta används av lokal transform.  @hideconstructor |
+| [TransformBuilder](../aspose.threed/transformbuilder) | TransformBuilder används för att bygga en transformmatris genom en kedja av transformationer. |
+| [TransformedCurve](../aspose.threed/transformedcurve) | En TransformedCurve ger en kurva en placering genom att använda en transformationsmatris. Detta möjliggör att utföra en transformation inom en TrimmedCurve eller CompositeCurve. |
+| [TrapeziumShape](../aspose.threed/trapeziumshape) | IFC‑kompatibel trapetsform definierad av parametrar. |
+| [TrialException](../aspose.threed/trialexception) | Detta kastas i Scene.Open/Scene.Save när inga licenser har tillämpats. Du kan inaktivera detta undantag genom att sätta SuppressTrialException till true. |
+| [TriMesh](../aspose.threed/trimesh) | En TriMesh innehåller rådata som kan användas direkt av GPU. Denna klass är ett verktyg för att hjälpa till att konstruera ett mesh som endast innehåller per-vertex‑data. |
+| [TrimmedCurve](../aspose.threed/trimmedcurve) | En begränsad kurva som beskär den grundläggande kurvan i båda ändar. |
+| [TShape](../aspose.threed/tshape) | IFC‑kompatibel T‑form definierad av parametrar. |
+| [U3dLoadOptions](../aspose.threed/u3dloadoptions) | Läsalternativ för universal 3d |
+| [U3dSaveOptions](../aspose.threed/u3dsaveoptions) | Sparaalternativ för universal 3d |
+| [UsdSaveOptions](../aspose.threed/usdsaveoptions) | Spara alternativ för USD/USDZ-format. |
+| [UShape](../aspose.threed/ushape) | IFC-kompatibel U-form definierad av parametrar. |
+| [Vector2](../aspose.threed/vector2) | En vektor med två komponenter. |
+| [Vector3](../aspose.threed/vector3) | En vektor med tre komponenter. |
+| [Vector4](../aspose.threed/vector4) | En vektor med fyra komponenter. |
+| [Vertex](../aspose.threed/vertex) | Vertexreferens, används för att komma åt den råa vertexen i TriMesh.  @hideconstructor |
+| [VertexDeclaration](../aspose.threed/vertexdeclaration) | Deklarationen av en anpassad definierad vertexstruktur |
+| [VertexElement](../aspose.threed/vertexelement) | Basklass för vertexelement.  En vertexelementtyp identifieras av VertexElementType.  Ett VertexElement beskriver hur vertexelementet mappas till en geometrisk yta och hur mappningsinformationen är ordnad i minnet.  Ett VertexElement innehåller Normals, UVs eller annan typ av information.  @hideconstructor |
+| [VertexElementBinormal](../aspose.threed/vertexelementbinormal) | Definierar binormala vektorer för angivna komponenter. |
+| [VertexElementDoublesTemplate](../aspose.threed/vertexelementdoublestemplate) | En hjälparklass för att definiera konkreta VertexElement-implementationer.  @hideconstructor |
+| [VertexElementEdgeCrease](../aspose.threed/vertexelementedgecrease) | Definierar kantveck för angivna komponenter |
+| [VertexElementHole](../aspose.threed/vertexelementhole) | Definierar om angiven polygon är ett hål |
+| [VertexElementIntsTemplate](../aspose.threed/vertexelementintstemplate) | En hjälparklass för att definiera konkreta VertexElement-implementationer.  @hideconstructor |
+| [VertexElementMaterial](../aspose.threed/vertexelementmaterial) | Definierar materialindex för angivna komponenter.  En nod kan ha flera material, VertexElementMaterial används för att rendera olika delar av geometrin i olika material. |
+| [VertexElementNormal](../aspose.threed/vertexelementnormal) | Definierar normala vektorer för angivna komponenter. |
+| [VertexElementPolygonGroup](../aspose.threed/vertexelementpolygongroup) | Definierar polygongrupp för angivna komponenter för att gruppera relaterade polygoner tillsammans. |
+| [VertexElementSmoothingGroup](../aspose.threed/vertexelementsmoothinggroup) | En slätningsgrupp är en grupp av polygoner i ett polygonnät som ska framstå som en slät yta.  Viss tidig 3D-modelleringsprogramvara som 3D Studio Max för DOS använde slätningsgrupp för att undvika lagring av normala vektorer för varje mesh-vertex. |
+| [VertexElementSpecular](../aspose.threed/vertexelementspecular) | Definierar spekulär färg för angivna komponenter. |
+| [VertexElementTangent](../aspose.threed/vertexelementtangent) | Definierar tangentiala vektorer för angivna komponenter. |
+| [VertexElementUserData](../aspose.threed/vertexelementuserdata) | Definierar anpassad användardata för angivna komponenter.  Vanligtvis är det applikationsspecifik data för speciellt ändamål. |
+| [VertexElementUV](../aspose.threed/vertexelementuv) | Definierar UV-koordinaterna för angivna komponenter.  En geometri kan ha flera VertexElementUV-element, och var och en har olika TextureMappings. |
+| [VertexElementVector4](../aspose.threed/vertexelementvector4) | En hjälparklass för att definiera konkreta VertexElement-implementationer.  @hideconstructor |
+| [VertexElementVertexColor](../aspose.threed/vertexelementvertexcolor) | Definierar vertexfärgen för angivna komponenter |
+| [VertexElementVertexCrease](../aspose.threed/vertexelementvertexcrease) | Definierar vertexveck för angivna komponenter |
+| [VertexElementVisibility](../aspose.threed/vertexelementvisibility) | Definierar om angivna komponenter är synliga |
+| [VertexElementWeight](../aspose.threed/vertexelementweight) | Definierar blandningsvikt för angivna komponenter. |
+| [VertexField](../aspose.threed/vertexfield) | Vertexens fältminneslayoutbeskrivning.  @hideconstructor |
+| [Viewport](../aspose.threed/viewport) | En com.aspose.threed.IRenderTarget innehåller minst en viewport för att rendera scenen.  @hideconstructor |
+| [Watermark](../aspose.threed/watermark) | Verktyg för att koda/avkoda blind vattenstämpel till/från ett mesh.  @hideconstructor |
+| [WindowHandle](../aspose.threed/windowhandle) | Inkapslad fönsterhandtag för olika plattformar.  @hideconstructor |
+| [XLoadOptions](../aspose.threed/xloadoptions) | Laddningsalternativen för DirectX X-filer. |
+| [ZipArchiveFileSystem](../aspose.threed/ziparchivefilesystem) | Filsystem för att ge skrivskyddad åtkomst till angiven zip-fil eller zip-ström.  Filsystemet kommer att tas bort efter öppna/spara‑operationen. |
+| [ZShape](../aspose.threed/zshape) | IFC‑kompatibel Z‑formad profil definierad av parametrar. |
+| [CubeFace](../aspose.threed/cubeface) | Verktygsklass som innehåller konstanter.  Varje ansikte av kubkarts-texturen  @hideconstructor |
+| [IndexDataType](../aspose.threed/indexdatatype) | Verktygsklass som innehåller konstanter.  Datatypen för elementen i com.aspose.threed.IIndexBuffer  @hideconstructor |

--- a/swedish/nodejs-java/aspose.threed/a3dobject/_index.md
+++ b/swedish/nodejs-java/aspose.threed/a3dobject/_index.md
@@ -1,0 +1,183 @@
+---
+title: "A3DObject"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/a3dobject/
+---
+## A3DObject class
+
+Bas-klassen för alla Aspose.ThreeD-objekt, alla underklasser kommer att stödja dynamiska egenskaper.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor(name) | Initierar en ny instans av klassen A3DObject. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| name | Sträng | Namn |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload() | Initierar en ny instans av klassen A3DObject utan namn. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/a3dwsaveoptions/_index.md
+++ b/swedish/nodejs-java/aspose.threed/a3dwsaveoptions/_index.md
@@ -1,0 +1,198 @@
+---
+title: "A3dwSaveOptions"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/a3dwsaveoptions/
+---
+## A3dwSaveOptions class
+
+Sparaalternativ för A3DW-format.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Konstruktor för A3dwSaveOptions |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportMetaData{#getExportMetaData}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExportMetaData() | Exportera metadata associerad med Scene/Node till klienten. Standardvärdet är true |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportMetaData{#setExportMetaData}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExportMetaData(value) | Exportera metadata associerad med Scene/Node till klienten. Standardvärdet är true |
+
+ **Result:**
+
+
+
+---
+
+
+### getMetaDataPrefix{#getMetaDataPrefix}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getMetaDataPrefix() | Om den här egenskapen är icke-null, exporteras endast egenskaperna i Scene/Node som börjar med detta prefix, och prefixet kommer att tas bort. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMetaDataPrefix{#setMetaDataPrefix}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setMetaDataPrefix(value) | Om den här egenskapen är icke-null, exporteras endast egenskaperna i Scene/Node som börjar med detta prefix, och prefixet kommer att tas bort. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportTextures{#getExportTextures}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExportTextures() | Försök att kopiera texturer som används i scenen till utdatamappen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextures{#setExportTextures}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExportTextures(value) | Försök att kopiera texturer som används i scenen till utdatamappen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileFormat() | Hämtar filformatet som anges i aktuellt Spara/Ladda-alternativ. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEncoding() | Hämtar eller anger standardkodning för textbaserade filer. Standardvärdet är null, vilket betyder att importören/exportören bestämmer vilken kodning som ska användas. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileSystem() | Tillåter användaren att hantera hur externa beroenden ska hanteras under laddning/sparning. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFileSystem(value) | Tillåter användaren att hantera hur externa beroenden ska hanteras under laddning/sparning. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getLookupPaths() | Vissa filer, som OBJ, är beroende av externa filer; sökvägarna gör det möjligt för Aspose.3D att leta efter externa filer att ladda. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileName() | Filnamnet för den exporterade/importerade scenen. Detta är valfritt, men användbart när externa resurser som OBJ:s material serialiseras. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFileName(value) | Filnamnet för den exporterade/importerade scenen. Detta är valfritt, men användbart när externa resurser som OBJ:s material serialiseras. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/amfsaveoptions/_index.md
+++ b/swedish/nodejs-java/aspose.threed/amfsaveoptions/_index.md
@@ -1,0 +1,172 @@
+---
+title: "AmfSaveOptions"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/amfsaveoptions/
+---
+## AmfSaveOptions class
+
+Sparaalternativ för AMF
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Konstruktor för AmfSaveOptions |
+
+ **Result:**
+
+
+
+---
+
+
+### getEnableCompression{#getEnableCompression}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEnableCompression() | Om komprimering ska användas för att minska den slutliga filstorleken, standardvärdet är true |
+
+ **Result:**
+
+
+
+---
+
+
+### setEnableCompression{#setEnableCompression}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setEnableCompression(value) | Om komprimering ska användas för att minska den slutliga filstorleken, standardvärdet är true |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportTextures{#getExportTextures}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExportTextures() | Försök att kopiera texturer som används i scenen till utdatamappen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextures{#setExportTextures}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExportTextures(value) | Försök att kopiera texturer som används i scenen till utdatamappen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileFormat() | Hämtar filformatet som anges i aktuellt Spara/Ladda-alternativ. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEncoding() | Hämtar eller anger standardkodning för textbaserade filer. Standardvärdet är null, vilket betyder att importören/exportören bestämmer vilken kodning som ska användas. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileSystem() | Tillåter användaren att hantera hur externa beroenden ska hanteras under laddning/sparning. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFileSystem(value) | Tillåter användaren att hantera hur externa beroenden ska hanteras under laddning/sparning. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getLookupPaths() | Vissa filer, som OBJ, är beroende av externa filer; sökvägarna gör det möjligt för Aspose.3D att leta efter externa filer att ladda. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileName() | Filnamnet för den exporterade/importerade scenen. Detta är valfritt, men användbart när externa resurser som OBJ:s material serialiseras. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFileName(value) | Filnamnet för den exporterade/importerade scenen. Detta är valfritt, men användbart när externa resurser som OBJ:s material serialiseras. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/animationchannel/_index.md
+++ b/swedish/nodejs-java/aspose.threed/animationchannel/_index.md
@@ -1,0 +1,113 @@
+---
+title: "AnimationChannel"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/animationchannel/
+---
+## AnimationChannel class
+
+Ett kanal mappar egenskapens komponentfält till en uppsättning nyckelramsekvenser  @hideconstructor
+
+
+## Metoder
+
+### getComponentType{#getComponentType}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getComponentType() | Hämtar komponentfältets typ |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar kanalens namn |
+
+ **Result:**
+
+
+
+---
+
+
+### getDefaultValue{#getDefaultValue}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getDefaultValue() | Hämtar eller anger standardvärdet för kanalen. Om en kanal inte har några keyframe‑sekvenser anslutna, kommer standardvärdet att användas under animationens utvärdering. Ett verkligt scenario: Animationen animera bara en nods x‑koordinat, y‑ och z‑koordinaterna ändras inte, då kommer standardvärdet att användas under full översättningsutvärdering. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDefaultValue{#setDefaultValue}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setDefaultValue(value) | Hämtar eller anger standardvärdet för kanalen. Om en kanal inte har några keyframe‑sekvenser anslutna, kommer standardvärdet att användas under animationens utvärdering. Ett verkligt scenario: Animationen animera bara en nods x‑koordinat, y‑ och z‑koordinaterna ändras inte, då kommer standardvärdet att användas under full översättningsutvärdering. |
+
+ **Result:**
+
+
+
+---
+
+
+### getKeyframeSequences{#getKeyframeSequences}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getKeyframeSequences() | Hämtar alla keyframe‑sekvenser i denna kanal |
+
+ **Result:**
+
+
+
+---
+
+
+### addKeyframeSequence{#addKeyframeSequence}
+
+| Namn | Beskrivning |
+| --- | --- |
+| addKeyframeSequence(sequence) | Lägger till keyframe‑sekvens till denna kanal |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| sekvens | KeyframeSequence | Keyframe‑sekvensen att lägga till. |
+
+ **Result:**
+
+
+
+---
+
+
+### iterator{#iterator}
+
+| Namn | Beskrivning |
+| --- | --- |
+| iterator() | Reserverad för internt bruk. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/animationclip/_index.md
+++ b/swedish/nodejs-java/aspose.threed/animationclip/_index.md
@@ -1,0 +1,306 @@
+---
+title: "AnimationClip"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/animationclip/
+---
+## AnimationClip class
+
+Animationsklippet är en samling animationer.  Scenen kan ha ett eller flera animationsklipp.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Initierar en ny instans av klassen AnimationClip. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload(name) | Initierar en ny instans av klassen AnimationClip. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| name | Sträng | Namn |
+
+ **Result:**
+
+
+
+---
+
+
+### getAnimations{#getAnimations}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getAnimations() | Hämtar animationerna som finns i klippet. Lagerna. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDescription{#getDescription}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getDescription() | Hämtar eller anger beskrivningen av detta animationsklipp |
+
+ **Result:**
+
+
+
+---
+
+
+### setDescription{#setDescription}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setDescription(value) | Hämtar eller anger beskrivningen av detta animationsklipp |
+
+ **Result:**
+
+
+
+---
+
+
+### getStart{#getStart}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getStart() | Hämtar eller anger tiden i sekunder för början av klippet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setStart{#setStart}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setStart(value) | Hämtar eller anger tiden i sekunder för början av klippet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getStop{#getStop}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getStop() | Hämtar eller anger tiden i sekunder för slutet av klippet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setStop{#setStop}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setStop(value) | Hämtar eller anger tiden i sekunder för slutet av klippet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getScene() | Hämtar scenen som detta objekt tillhör |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### createAnimationNode{#createAnimationNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| createAnimationNode(nodeName) | En förkortad funktion för att skapa och registrera animationsnoden på det aktuella klippet. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| nodeName | Sträng | Nytt namn för animationsnoden |
+
+ **Result:**
+AnimationNode
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/animationnode/_index.md
+++ b/swedish/nodejs-java/aspose.threed/animationnode/_index.md
@@ -1,0 +1,312 @@
+---
+title: "AnimationNode"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/animationnode/
+---
+## AnimationNode class
+
+Aspose.3D stödjer animationshierarki, varje animation kan bestå av flera animationer och animationens nyckelramdefinition.  AnimationNode definierar transformationen av ett egenskapsvärde över tid, till exempel kan en animationsnod användas för att kontrollera en nods transformation eller andra numeriska egenskaper hos ett A3DObject-objekt.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor(name) | Initierar en ny instans av klassen AnimationNode. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| name | Sträng | Namn |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload() | Initierar en ny instans av klassen AnimationNode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getBindPoints{#getBindPoints}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBindPoints() | Hämtar de aktuella bindningspunkterna |
+
+ **Result:**
+
+
+
+---
+
+
+### getSubAnimations{#getSubAnimations}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getSubAnimations() | Hämtar delanimationsnoderna under aktuella animationer |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### findBindPoint{#findBindPoint}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findBindPoint(name) | Hittar bindningspunkten efter namn. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| name | Sträng | Namnet på bindningspunkten att hitta. |
+
+ **Result:**
+BindPoint
+
+
+---
+
+
+### getBindPoint{#getBindPoint}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBindPoint(target, propName, create) | Hämtar animationsbindningspunkten för given egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| mål | A3DObject | På vilket objekt bindningspunkten ska skapas. |
+| propName | Sträng | Egenskapens namn. |
+| skapa | boolean | Om inställt på |
+
+ **Result:**
+BindPoint
+
+
+---
+
+
+### getKeyframeSequence{#getKeyframeSequence}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getKeyframeSequence(target, propName, channelName, create) | Hämtar nyckelbildssekvensen för given egenskap och kanal. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| mål | A3DObject | På vilken instans nyckelbildssekvensen ska skapas. |
+| propName | Sträng | Egenskapens namn. |
+| channelName | Sträng | Kanalens namn. |
+| skapa | boolean | Om inställt på |
+
+ **Result:**
+KeyframeSequence
+
+
+---
+
+
+### getKeyframeSequence{#getKeyframeSequence}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getKeyframeSequence(target, propName, create) | Hämtar nyckelbildssekvensen för given egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| mål | A3DObject | På vilken instans nyckelbildssekvensen ska skapas. |
+| propName | Sträng | Egenskapens namn. |
+| skapa | boolean | Om inställt på |
+
+ **Result:**
+KeyframeSequence
+
+
+---
+
+
+### createBindPoint{#createBindPoint}
+
+| Namn | Beskrivning |
+| --- | --- |
+| createBindPoint(obj, propName) | Skapar en BindPoint baserat på egenskapens datatyp. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| obj | A3DObject | Objekt. |
+| propName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+BindPoint
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/arbitraryprofile/_index.md
+++ b/swedish/nodejs-java/aspose.threed/arbitraryprofile/_index.md
@@ -1,0 +1,313 @@
+---
+title: "ArbitraryProfile"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/arbitraryprofile/
+---
+## ArbitraryProfile class
+
+Denna klass låter dig konstruera en 2D-profil direkt från en godtycklig kurva.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Konstruktor för ArbitraryProfile |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload(curve) | Konstruktor för ArbitraryProfile med en initial kurva. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| curv | Kurva | null |
+
+ **Result:**
+
+
+
+---
+
+
+### getCurve{#getCurve}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getCurve() | Kurvan som används för att konstruera profilen |
+
+ **Result:**
+
+
+
+---
+
+
+### setCurve{#setCurve}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setCurve(value) | Kurvan som används för att konstruera profilen |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNodes() | Hämtar alla föräldranoder, en entitet kan fästas vid flera föräldranoder för geometri‑instansering. Noderna. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExcluded() | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExcluded(value) | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNode() | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setParentNode(value) | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getScene() | Hämtar scenen som detta objekt tillhör |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEntityRendererKey() | Hämtar nyckeln för enhetens renderare som är registrerad i renderaren |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBoundingBox() | Hämtar den omgivande lådan för den aktuella enheten i dess objektrums koordinatsystem. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/assetinfo/_index.md
+++ b/swedish/nodejs-java/aspose.threed/assetinfo/_index.md
@@ -1,0 +1,586 @@
+---
+title: "AssetInfo"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/assetinfo/
+---
+## AssetInfo class
+
+Information om tillgången.  Tillgångsinformation kan bifogas till en scen.  En underordnad scen kan ha sin egen AssetInfo för att åsidosätta förälderns definition.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Initierar en ny instans av klassen AssetInfo. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload(name) | Initierar en ny instans av klassen AssetInfo. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| name | Sträng | Namn |
+
+ **Result:**
+
+
+
+---
+
+
+### getCreationTime{#getCreationTime}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getCreationTime() | Hämtar eller anger skapandetiden för denna tillgång |
+
+ **Result:**
+
+
+
+---
+
+
+### getModificationTime{#getModificationTime}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getModificationTime() | Hämtar eller anger ändringstiden för denna tillgång |
+
+ **Result:**
+
+
+
+---
+
+
+### getAmbient{#getAmbient}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getAmbient() | Hämtar eller anger standardambientfärgen för denna tillgång |
+
+ **Result:**
+
+
+
+---
+
+
+### getUrl{#getUrl}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getUrl() | Hämtar eller anger URL:en för denna tillgång. |
+
+ **Result:**
+
+
+
+---
+
+
+### setUrl{#setUrl}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setUrl(value) | Hämtar eller anger URL:en för denna tillgång. |
+
+ **Result:**
+
+
+
+---
+
+
+### getApplicationVendor{#getApplicationVendor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getApplicationVendor() | Hämtar eller anger namnet på applikationsleverantören |
+
+ **Result:**
+
+
+
+---
+
+
+### setApplicationVendor{#setApplicationVendor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setApplicationVendor(value) | Hämtar eller anger namnet på applikationsleverantören |
+
+ **Result:**
+
+
+
+---
+
+
+### getCopyright{#getCopyright}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getCopyright() | Hämtar eller anger dokumentets upphovsrätt |
+
+ **Result:**
+
+
+
+---
+
+
+### setCopyright{#setCopyright}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setCopyright(value) | Hämtar eller anger dokumentets upphovsrätt |
+
+ **Result:**
+
+
+
+---
+
+
+### getApplicationName{#getApplicationName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getApplicationName() | Hämtar eller anger applikationen som skapade denna tillgång |
+
+ **Result:**
+
+
+
+---
+
+
+### setApplicationName{#setApplicationName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setApplicationName(value) | Hämtar eller anger applikationen som skapade denna tillgång |
+
+ **Result:**
+
+
+
+---
+
+
+### getApplicationVersion{#getApplicationVersion}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getApplicationVersion() | Hämtar eller anger versionen av applikationen som skapade denna tillgång. |
+
+ **Result:**
+
+
+
+---
+
+
+### setApplicationVersion{#setApplicationVersion}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setApplicationVersion(value) | Hämtar eller anger versionen av applikationen som skapade denna tillgång. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTitle{#getTitle}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getTitle() | Hämtar eller anger titeln för detta objekt |
+
+ **Result:**
+
+
+
+---
+
+
+### setTitle{#setTitle}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setTitle(value) | Hämtar eller anger titeln för detta objekt |
+
+ **Result:**
+
+
+
+---
+
+
+### getSubject{#getSubject}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getSubject() | Hämtar eller anger ämnet för detta objekt |
+
+ **Result:**
+
+
+
+---
+
+
+### setSubject{#setSubject}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setSubject(value) | Hämtar eller anger ämnet för detta objekt |
+
+ **Result:**
+
+
+
+---
+
+
+### getAuthor{#getAuthor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getAuthor() | Hämtar eller anger författaren för detta objekt |
+
+ **Result:**
+
+
+
+---
+
+
+### setAuthor{#setAuthor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setAuthor(value) | Hämtar eller anger författaren för detta objekt |
+
+ **Result:**
+
+
+
+---
+
+
+### getKeywords{#getKeywords}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getKeywords() | Hämtar eller anger nyckelorden för detta objekt |
+
+ **Result:**
+
+
+
+---
+
+
+### setKeywords{#setKeywords}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setKeywords(value) | Hämtar eller anger nyckelorden för detta objekt |
+
+ **Result:**
+
+
+
+---
+
+
+### getRevision{#getRevision}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getRevision() | Hämtar eller anger revisionsnumret för detta objekt, vanligtvis använt i versionskontrollsystem. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRevision{#setRevision}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setRevision(value) | Hämtar eller anger revisionsnumret för detta objekt, vanligtvis använt i versionskontrollsystem. |
+
+ **Result:**
+
+
+
+---
+
+
+### getComment{#getComment}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getComment() | Hämtar eller anger kommentaren för detta objekt. |
+
+ **Result:**
+
+
+
+---
+
+
+### setComment{#setComment}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setComment(value) | Hämtar eller anger kommentaren för detta objekt. |
+
+ **Result:**
+
+
+
+---
+
+
+### getUnitName{#getUnitName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getUnitName() | Hämtar eller anger längdenheten som används i detta objekt. t.ex. cm/m/km/tum/fot |
+
+ **Result:**
+
+
+
+---
+
+
+### setUnitName{#setUnitName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setUnitName(value) | Hämtar eller anger längdenheten som används i detta objekt. t.ex. cm/m/km/tum/fot |
+
+ **Result:**
+
+
+
+---
+
+
+### getUnitScaleFactor{#getUnitScaleFactor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getUnitScaleFactor() | Hämtar eller anger skalningsfaktorn till verklig meter. Detta ignoreras vid serialisering om enhetsnamnet är null. |
+
+ **Result:**
+
+
+
+---
+
+
+### setUnitScaleFactor{#setUnitScaleFactor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setUnitScaleFactor(value) | Hämtar eller anger skalningsfaktorn till verklig meter. Detta ignoreras vid serialisering om enhetsnamnet är null. |
+
+ **Result:**
+
+
+
+---
+
+
+### getCoordinatedSystem{#getCoordinatedSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getCoordinatedSystem() | Hämtar eller anger koordinatsystemet som används i detta objekt. |
+
+ **Result:**
+
+
+
+---
+
+
+### getUpVector{#getUpVector}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getUpVector() | Hämtar eller anger uppvektorn som används i detta objekt. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/bindpoint/_index.md
+++ b/swedish/nodejs-java/aspose.threed/bindpoint/_index.md
@@ -1,0 +1,386 @@
+---
+title: "BindPoint"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/bindpoint/
+---
+## BindPoint class
+
+En BindPoint skapas vanligtvis på ett objekts egenskap, vissa egenskapstyper innehåller flera komponentfält (som ett Vector3-fält),  BindPoint kommer att generera en kanal för varje komponentfält och ansluter fältet till en eller flera nyckelramsekvensinstans(er) via kanalerna.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor(scene, prop) | Initierar en ny instans av klassen BindPoint. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| scen | Scene | Scenen som innehåller animationen. |
+| prop | Property | Egenskap. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty() | Hämtar egenskapen som är associerad med CurveMapping |
+
+ **Result:**
+
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(value) | Hämtar egenskapen som är associerad med CurveMapping |
+
+ **Result:**
+
+
+
+---
+
+
+### getChannelsCount{#getChannelsCount}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getChannelsCount() | Hämtar det totala antalet egenskapskanaler som definierats i denna animation CurveMapping. |
+
+ **Result:**
+Nummer
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+Nummer
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+Nummer
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+Nummer
+
+
+---
+
+
+### get{#get}
+
+| Namn | Beskrivning |
+| --- | --- |
+| get(channelName) |  |
+
+ **Result:**
+Nummer
+
+
+---
+
+
+### getKeyframeSequence{#getKeyframeSequence}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getKeyframeSequence(channelName) | Hämtar den första nyckelramsekvensen i angiven kanal |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| channelName | Sträng | Kanalnamnet att hitta |
+
+ **Result:**
+KeyframeSequence
+
+
+---
+
+
+### getKeyframeSequences{#getKeyframeSequences}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getKeyframeSequences(channelName) | Hämtar alla nyckelramsekvenser i angiven kanal |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| channelName | Sträng | Kanalnamnet att hitta |
+
+ **Result:**
+0, Culture=neutral, PublicKeyToken=f071c641d0b4582b]]
+
+
+---
+
+
+### createKeyframeSequence{#createKeyframeSequence}
+
+| Namn | Beskrivning |
+| --- | --- |
+| createKeyframeSequence(name) | Skapar en ny kurva och ansluter den till den första kanalen i kurvavbildningen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| name | Sträng | Det nya sekvensens namn. |
+
+ **Result:**
+KeyframeSequence
+
+
+---
+
+
+### bindKeyframeSequence{#bindKeyframeSequence}
+
+| Namn | Beskrivning |
+| --- | --- |
+| bindKeyframeSequence(channelName, sequence) | Koppla nyckelramsekvensen till den angivna kanalen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| channelName | Sträng | Vilken kanal nyckelramsekvensen kommer att bindas till |
+| sekvens | KeyframeSequence | Nyckelramsekvensen att binda |
+
+ **Result:**
+KeyframeSequence
+
+
+---
+
+
+### getChannel{#getChannel}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getChannel(channelName) | Hämtar kanal med angivet namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| channelName | Sträng | Kanalnamnet att hitta |
+
+ **Result:**
+AnimationChannel
+
+
+---
+
+
+### addChannel{#addChannel}
+
+| Namn | Beskrivning |
+| --- | --- |
+| addChannel(name, value) | Lägger till den angivna kanalegenskapen. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| name | Sträng | Namn. |
+| värde | Objekt | Värde. |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### addChannel{#addChannel}
+
+| Namn | Beskrivning |
+| --- | --- |
+| addChannel(name, type, value) | Lägger till den angivna kanalegenskapen. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| name | Sträng | Namn. |
+| typ | Klass | Typ. |
+| värde | Objekt | Värde. |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### resetChannels{#resetChannels}
+
+| Namn | Beskrivning |
+| --- | --- |
+| resetChannels() | Tömmer egenskapskanalerna i denna animationskurvavbildning. |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### toString{#toString}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toString() | Formaterar objekt till sträng. |
+
+ **Result:**
+Sträng
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/bone/_index.md
+++ b/swedish/nodejs-java/aspose.threed/bone/_index.md
@@ -1,0 +1,339 @@
+---
+title: "Bone"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/bone/
+---
+## Bone class
+
+Ett ben definierar delmängden av geometrins kontrollpunkt och definierar blandningsvikt för varje kontrollpunkt.  Bone-objektet kan inte användas direkt, en SkinDeformer-instans används för att deformera geometrin, och SkinDeformer levereras med en uppsättning ben, där varje ben är länkat till en nod.  OBS: En kontrollpunkt i en geometri kan vara bunden till mer än ett ben.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor(name) | Initierar en ny instans av Bone-klassen. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| name | Sträng | Namn. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload() | Initierar en ny instans av Bone-klassen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getWeightCount{#getWeightCount}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getWeightCount() | Hämtar antalet vikter, detta utökas automatiskt av setWeight(int, double) |
+
+ **Result:**
+
+
+
+---
+
+
+### getTransform{#getTransform}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getTransform() | Hämtar eller anger transformmatrisen för noden som innehåller benet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTransform{#setTransform}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setTransform(value) | Hämtar eller anger transformmatrisen för noden som innehåller benet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getBoneTransform{#getBoneTransform}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBoneTransform() | Hämtar eller anger transformmatrisen för benet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setBoneTransform{#setBoneTransform}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setBoneTransform(value) | Hämtar eller anger transformmatrisen för benet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getNode{#getNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getNode() | Hämtar eller anger noden. Bone‑noden är benet som huden är fäst vid, SkinDeformer kommer att använda bone‑noden för att påverka förskjutningen av kontrollpunkterna. Bone‑noden har vanligtvis ett Skeleton kopplat, men det är inte obligatoriskt. Ett kopplat Skeleton används vanligtvis av DCC‑programvara för att visa skelettet för användaren. |
+
+ **Result:**
+
+
+
+---
+
+
+### setNode{#setNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setNode(value) | Hämtar eller anger noden. Bone‑noden är benet som huden är fäst vid, SkinDeformer kommer att använda bone‑noden för att påverka förskjutningen av kontrollpunkterna. Bone‑noden har vanligtvis ett Skeleton kopplat, men det är inte obligatoriskt. Ett kopplat Skeleton används vanligtvis av DCC‑programvara för att visa skelettet för användaren. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### get{#get}
+
+| Namn | Beskrivning |
+| --- | --- |
+| get(index) |  |
+
+ **Result:**
+
+
+
+---
+
+
+### set{#set}
+
+| Namn | Beskrivning |
+| --- | --- |
+| set(index, value) |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getWeight{#getWeight}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getWeight(index) | Hämtar vikten för kontrollpunkten som anges av indexet |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| index | Nummer | Kontrollpunktens index |
+
+ **Result:**
+Nummer
+
+
+---
+
+
+### setWeight{#setWeight}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setWeight(index, weight) | Anger vikten för kontrollpunkten som anges av indexet |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| index | Nummer | Kontrollpunktens index |
+| vikt | Nummer | Ny vikt |
+
+ **Result:**
+Nummer
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/bonepose/_index.md
+++ b/swedish/nodejs-java/aspose.threed/bonepose/_index.md
@@ -1,0 +1,107 @@
+---
+title: "BonePose"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/bonepose/
+---
+## BonePose class
+
+BonePose innehåller transformationsmatrisen för en bennod
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getNode{#getNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getNode() | Hämtar eller sätter scen‑noden, pekar på en skinnad skelettnod |
+
+ **Result:**
+
+
+
+---
+
+
+### setNode{#setNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setNode(value) | Hämtar eller sätter scen‑noden, pekar på en skinnad skelettnod |
+
+ **Result:**
+
+
+
+---
+
+
+### getMatrix{#getMatrix}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getMatrix() | Hämtar eller sätter transformmatrisen för noden i aktuell pose. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMatrix{#setMatrix}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setMatrix(value) | Hämtar eller sätter transformmatrisen för noden i aktuell pose. |
+
+ **Result:**
+
+
+
+---
+
+
+### isLocal{#isLocal}
+
+| Namn | Beskrivning |
+| --- | --- |
+| isLocal() | Hämtar eller anger om matrisen är definierad i lokala koordinater. true om detta objekt är i lokalt utrymme; annars betyder false globalt utrymme. |
+
+ **Result:**
+
+
+
+---
+
+
+### setLocal{#setLocal}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setLocal(value) | Hämtar eller anger om matrisen är definierad i lokala koordinater. true om detta objekt är i lokalt utrymme; annars betyder false globalt utrymme. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/boundingbox/_index.md
+++ b/swedish/nodejs-java/aspose.threed/boundingbox/_index.md
@@ -1,0 +1,198 @@
+---
+title: "BoundingBox"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/boundingbox/
+---
+## BoundingBox class
+
+Den axeljusterade avgränsningsboxen
+
+
+## Egenskaper
+
+| Namn | Beskrivning |
+| --- | --- |
+| NULL | Den nulla avgränsningsboxen |
+| INFINITE | Den oändliga avgränsningsboxen |
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload(minimum, maximum) | Initierar en ändlig avgränsningsbox med angivet minsta och största hörn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| minimum | Vector3 | Det minsta hörnet |
+| maximum | Vector3 | Det största hörnet |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload2(minX, minY, minZ, maxX, maxY, maxZ) | Initierar en ändlig avgränsningsbox med angivet minsta och största hörn |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtent{#getExtent}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExtent() | Hämtar omfattningen av avgränsningsboxen. Värdet på egenskapen är heltalskonstanten BoundingBoxExtent. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMinimum{#getMinimum}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getMinimum() | Det minsta hörnet av avgränsningsboxen |
+
+ **Result:**
+
+
+
+---
+
+
+### getMaximum{#getMaximum}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getMaximum() | Det största hörnet av avgränsningsboxen |
+
+ **Result:**
+
+
+
+---
+
+
+### getSize{#getSize}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getSize() | Storleken på begränsningsboxen |
+
+ **Result:**
+
+
+
+---
+
+
+### getCenter{#getCenter}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getCenter() | Centrum av begränsningsboxen. |
+
+ **Result:**
+
+
+
+---
+
+
+### fromGeometry{#fromGeometry}
+
+| Namn | Beskrivning |
+| --- | --- |
+| fromGeometry(geometry) | Skapa en begränsningsbox från given geometri |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| geometr | Geometry | null |
+
+ **Result:**
+BoundingBox
+
+
+---
+
+
+### toString{#toString}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toString() | Hämtar strängrepresentationen av den omgivande lådan. |
+
+ **Result:**
+Sträng
+
+
+---
+
+
+### hashCode{#hashCode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| hashCode() | Returnerar hash-koden för detta objekt |
+
+ **Result:**
+Nummer
+
+
+---
+
+
+### equals{#equals}
+
+| Namn | Beskrivning |
+| --- | --- |
+| equals(obj) | Bestämmer om två objekt är lika |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| ob | Objekt | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/boundingbox2d/_index.md
+++ b/swedish/nodejs-java/aspose.threed/boundingbox2d/_index.md
@@ -1,0 +1,146 @@
+---
+title: "BoundingBox2D"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/boundingbox2d/
+---
+## BoundingBox2D class
+
+Den axeljusterade avgränsningsboxen för Vector2
+
+
+## Egenskaper
+
+| Namn | Beskrivning |
+| --- | --- |
+| NULL | Den nulla avgränsningsboxen |
+| INFINITE | Den oändliga avgränsningsboxen |
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload(minimum, maximum) | Initierar en ändlig avgränsningsbox med angivet minsta och största hörn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| minimum | Vector2 | Det minsta hörnet |
+| maximum | Vector2 | Det största hörnet |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtent{#getExtent}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExtent() | Hämtar omfattningen av avgränsningsboxen. Värdet på egenskapen är heltalskonstanten BoundingBoxExtent. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMinimum{#getMinimum}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getMinimum() | Det minsta hörnet av avgränsningsboxen |
+
+ **Result:**
+
+
+
+---
+
+
+### getMaximum{#getMaximum}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getMaximum() | Det största hörnet av avgränsningsboxen |
+
+ **Result:**
+
+
+
+---
+
+
+### merge{#merge}
+
+| Namn | Beskrivning |
+| --- | --- |
+| merge(pt) | Sammanfogar den nya boxen med den aktuella avgränsningsboxen. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| p | Vector2 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### merge{#merge}
+
+| Namn | Beskrivning |
+| --- | --- |
+| merge(bb) | Sammanfogar den nya boxen med den aktuella avgränsningsboxen. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| b | BoundingBox2D | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toString() | Hämtar strängrepresentationen av den omgivande lådan. |
+
+ **Result:**
+Sträng
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/box/_index.md
+++ b/swedish/nodejs-java/aspose.threed/box/_index.md
@@ -1,0 +1,535 @@
+---
+title: "Box"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/box/
+---
+## Box class
+
+Box.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Initierar en ny instans av klassen Box. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload(length, width, height) | Initierar en ny instans av klassen Box. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| length | Nummer | Längd på lådan inriktad längs z‑axeln. |
+| bredd | Nummer | Bredd på lådan inriktad längs x‑axeln. |
+| height | Nummer | Höjd på lådan inriktad längs y‑axeln. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload2(name, length, width, height, lengthSegments, widthSegments, heightSegments) | Initierar en ny instans av klassen Box. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| name | Sträng | Namn på lådan. |
+| length | Nummer | Längd på lådan inriktad längs z‑axeln. |
+| bredd | Nummer | Bredd på lådan inriktad längs x‑axeln. |
+| height | Nummer | Höjd på lådan inriktad längs y‑axeln. |
+| lengthSegments | Nummer | Längdsegment. |
+| widthSegments | Nummer | Breddsegment. |
+| heightSegments | Nummer | Höjsegment. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLengthSegments{#getLengthSegments}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getLengthSegments() | Hämtar eller anger längdsegmenten. |
+
+ **Result:**
+
+
+
+---
+
+
+### setLengthSegments{#setLengthSegments}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setLengthSegments(value) | Hämtar eller anger längdsegmenten. |
+
+ **Result:**
+
+
+
+---
+
+
+### getWidthSegments{#getWidthSegments}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getWidthSegments() | Hämtar eller anger breddsegmenten |
+
+ **Result:**
+
+
+
+---
+
+
+### setWidthSegments{#setWidthSegments}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setWidthSegments(value) | Hämtar eller anger breddsegmenten |
+
+ **Result:**
+
+
+
+---
+
+
+### getHeightSegments{#getHeightSegments}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getHeightSegments() | hämtar eller anger höjdsegmenten. |
+
+ **Result:**
+
+
+
+---
+
+
+### setHeightSegments{#setHeightSegments}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setHeightSegments(value) | hämtar eller anger höjdsegmenten. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLength{#getLength}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getLength() | Hämtar eller anger längden på lådan inriktad längs z‑axeln. Längden inriktad längs z‑axeln. |
+
+ **Result:**
+
+
+
+---
+
+
+### setLength{#setLength}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setLength(value) | Hämtar eller anger längden på lådan inriktad längs z‑axeln. Längden inriktad längs z‑axeln. |
+
+ **Result:**
+
+
+
+---
+
+
+### getWidth{#getWidth}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getWidth() | Hämtar eller anger bredden på lådan som är justerad i x-axeln. Bredden som är justerad i x-axeln. |
+
+ **Result:**
+
+
+
+---
+
+
+### setWidth{#setWidth}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setWidth(value) | Hämtar eller anger bredden på lådan som är justerad i x-axeln. Bredden som är justerad i x-axeln. |
+
+ **Result:**
+
+
+
+---
+
+
+### getHeight{#getHeight}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getHeight() | Hämtar eller anger höjden på lådan som är justerad i y-axeln. Höjden som är justerad i y-axeln. |
+
+ **Result:**
+
+
+
+---
+
+
+### setHeight{#setHeight}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setHeight(value) | Hämtar eller anger höjden på lådan som är justerad i y-axeln. Höjden som är justerad i y-axeln. |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastShadows{#getCastShadows}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getCastShadows() | Hämtar eller anger om denna geometri kan kasta skugga |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastShadows{#setCastShadows}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setCastShadows(value) | Hämtar eller anger om denna geometri kan kasta skugga |
+
+ **Result:**
+
+
+
+---
+
+
+### getReceiveShadows{#getReceiveShadows}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getReceiveShadows() | Hämtar eller anger om denna geometri kan ta emot skugga. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReceiveShadows{#setReceiveShadows}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setReceiveShadows(value) | Hämtar eller anger om denna geometri kan ta emot skugga. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNodes() | Hämtar alla föräldranoder, en entitet kan fästas vid flera föräldranoder för geometri‑instansering. Noderna. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExcluded() | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExcluded(value) | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNode() | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setParentNode(value) | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getScene() | Hämtar scenen som detta objekt tillhör |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### toMesh{#toMesh}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toMesh() | Konvertera aktuellt objekt till mesh |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBoundingBox() | Hämtar den omgivande lådan för den aktuella enheten i dess objektrums koordinatsystem. |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEntityRendererKey() | Hämtar nyckeln för enhetens renderare som är registrerad i renderaren |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/camera/_index.md
+++ b/swedish/nodejs-java/aspose.threed/camera/_index.md
@@ -1,0 +1,813 @@
+---
+title: "Kamera"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/camera/
+---
+## Camera class
+
+Kameran beskriver betraktarens ögonpunkt när denne tittar på scenen.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Initierar en ny instans av klassen Camera. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload(projectionType) | Initierar en ny instans av klassen Camera. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| projectionType | ProjectionType | ProjectionType |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload2(name) | Initierar en ny instans av klassen Camera. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| name | Sträng | Namn. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload3{#constructor_overload3}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload3(name, projectionType) | Initierar en ny instans av klassen Camera. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| name | Sträng | Namn. |
+| projectionType | ProjectionType | ProjectionType |
+
+ **Result:**
+
+
+
+---
+
+
+### getApertureMode{#getApertureMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getApertureMode() | Hämtar eller anger kamerans bländarläge. Värdet på egenskapen är heltalskonstanten ApertureMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setApertureMode{#setApertureMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setApertureMode(value) | Hämtar eller anger kamerans bländarläge. Värdet på egenskapen är heltalskonstanten ApertureMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFieldOfView{#getFieldOfView}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFieldOfView() | Hämtar eller anger kamerans synfält i grader, den här egenskapen används endast när ApertureMode är ApertureMode.HORIZONTAL eller ApertureMode.VERTICAL |
+
+ **Result:**
+
+
+
+---
+
+
+### setFieldOfView{#setFieldOfView}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFieldOfView(value) | Hämtar eller anger kamerans synfält i grader, den här egenskapen används endast när ApertureMode är ApertureMode.HORIZONTAL eller ApertureMode.VERTICAL |
+
+ **Result:**
+
+
+
+---
+
+
+### getFieldOfViewX{#getFieldOfViewX}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFieldOfViewX() | Hämtar eller anger kamerans horisontella synfält i grader, den här egenskapen används endast när ApertureMode är ApertureMode.HORIZ_AND_VERT |
+
+ **Result:**
+
+
+
+---
+
+
+### setFieldOfViewX{#setFieldOfViewX}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFieldOfViewX(value) | Hämtar eller anger kamerans horisontella synfält i grader, den här egenskapen används endast när ApertureMode är ApertureMode.HORIZ_AND_VERT |
+
+ **Result:**
+
+
+
+---
+
+
+### getFieldOfViewY{#getFieldOfViewY}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFieldOfViewY() | Hämtar eller anger kamerans vertikala synfält i grader, den här egenskapen används endast när ApertureMode är ApertureMode.HORIZ_AND_VERT |
+
+ **Result:**
+
+
+
+---
+
+
+### setFieldOfViewY{#setFieldOfViewY}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFieldOfViewY(value) | Hämtar eller anger kamerans vertikala synfält i grader, den här egenskapen används endast när ApertureMode är ApertureMode.HORIZ_AND_VERT |
+
+ **Result:**
+
+
+
+---
+
+
+### getWidth{#getWidth}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getWidth() | Hämtar eller anger vyplanens bredd i tum |
+
+ **Result:**
+
+
+
+---
+
+
+### setWidth{#setWidth}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setWidth(value) | Hämtar eller anger vyplanens bredd i tum |
+
+ **Result:**
+
+
+
+---
+
+
+### getHeight{#getHeight}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getHeight() | Hämtar eller anger vyplanens höjd i tum |
+
+ **Result:**
+
+
+
+---
+
+
+### setHeight{#setHeight}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setHeight(value) | Hämtar eller anger vyplanens höjd i tum |
+
+ **Result:**
+
+
+
+---
+
+
+### getAspectRatio{#getAspectRatio}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getAspectRatio() | Hämtar eller anger vyplanens bildförhållande. |
+
+ **Result:**
+
+
+
+---
+
+
+### setAspectRatio{#setAspectRatio}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setAspectRatio(value) | Hämtar eller anger vyplanens bildförhållande. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMagnification{#getMagnification}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getMagnification() | Hämtar eller anger förstoring som används i en ortografisk kamera. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMagnification{#setMagnification}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setMagnification(value) | Hämtar eller anger förstoring som används i en ortografisk kamera. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProjectionType{#getProjectionType}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProjectionType() | Hämtar eller anger kamerans projektionstyp. Som standard används perspektivprojektion. Värdet på egenskapen är heltalskonstanten ProjectionType. |
+
+ **Result:**
+
+
+
+---
+
+
+### setProjectionType{#setProjectionType}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProjectionType(value) | Hämtar eller anger kamerans projektionstyp. Som standard används perspektivprojektion. Värdet på egenskapen är heltalskonstanten ProjectionType. |
+
+ **Result:**
+
+
+
+---
+
+
+### getRotationMode{#getRotationMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getRotationMode() | Hämtar eller anger frustumens orienteringsläge. Denna egenskap fungerar endast när Target är null. Om värdet är RotationMode.FIXED_TARGET beräknas riktningen alltid av egenskapen LookAt. Annars beräknas LookAt alltid av Direction. Värdet för egenskapen är heltalskonstanten RotationMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRotationMode{#setRotationMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setRotationMode(value) | Hämtar eller anger frustumens orienteringsläge. Denna egenskap fungerar endast när Target är null. Om värdet är RotationMode.FIXED_TARGET beräknas riktningen alltid av egenskapen LookAt. Annars beräknas LookAt alltid av Direction. Värdet för egenskapen är heltalskonstanten RotationMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getNearPlane{#getNearPlane}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getNearPlane() | Hämtar eller anger frustumens närplanavstånd. |
+
+ **Result:**
+
+
+
+---
+
+
+### setNearPlane{#setNearPlane}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setNearPlane(value) | Hämtar eller anger frustumens närplanavstånd. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFarPlane{#getFarPlane}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFarPlane() | Hämtar eller anger frustumets avstånd till den fjärrplanen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFarPlane{#setFarPlane}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFarPlane(value) | Hämtar eller anger frustumets avstånd till den fjärrplanen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAspect{#getAspect}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getAspect() | Hämtar eller anger bildförhållandet för frustumen |
+
+ **Result:**
+
+
+
+---
+
+
+### setAspect{#setAspect}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setAspect(value) | Hämtar eller anger bildförhållandet för frustumen |
+
+ **Result:**
+
+
+
+---
+
+
+### getOrthoHeight{#getOrthoHeight}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getOrthoHeight() | Hämtar eller anger höjden när frustumen är i ortografisk projektion. |
+
+ **Result:**
+
+
+
+---
+
+
+### setOrthoHeight{#setOrthoHeight}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setOrthoHeight(value) | Hämtar eller anger höjden när frustumen är i ortografisk projektion. |
+
+ **Result:**
+
+
+
+---
+
+
+### getUp{#getUp}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getUp() | Hämtar eller anger kamerans uppåtriktning |
+
+ **Result:**
+
+
+
+---
+
+
+### setUp{#setUp}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setUp(value) | Hämtar eller anger kamerans uppåtriktning |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookAt{#getLookAt}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getLookAt() | Hämtar eller anger den intressanta positionen som kameran tittar på. |
+
+ **Result:**
+
+
+
+---
+
+
+### setLookAt{#setLookAt}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setLookAt(value) | Hämtar eller anger den intressanta positionen som kameran tittar på. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDirection{#getDirection}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getDirection() | Hämtar eller anger den riktning som kameran tittar mot. Ändringar av denna egenskap påverkar också LookAt och Target. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDirection{#setDirection}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setDirection(value) | Hämtar eller anger den riktning som kameran tittar mot. Ändringar av denna egenskap påverkar också LookAt och Target. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTarget{#getTarget}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getTarget() | Hämtar eller anger målet som kameran tittar på. Om användaren stöder denna egenskap bör den vara före LookAt-egenskapen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTarget{#setTarget}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setTarget(value) | Hämtar eller anger målet som kameran tittar på. Om användaren stöder denna egenskap bör den vara före LookAt-egenskapen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNodes() | Hämtar alla föräldranoder, en entitet kan fästas vid flera föräldranoder för geometri‑instansering. Noderna. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExcluded() | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExcluded(value) | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNode() | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setParentNode(value) | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getScene() | Hämtar scenen som detta objekt tillhör |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### moveForward{#moveForward}
+
+| Namn | Beskrivning |
+| --- | --- |
+| moveForward(distance) | Flytta kameran framåt i dess riktning eller mot målet. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| distance | Nummer | Hur långt ska den flyttas framåt |
+
+ **Result:**
+
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBoundingBox() | Hämtar den omgivande lådan för den aktuella enheten i dess objektrums koordinatsystem. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEntityRendererKey() | Hämtar nyckeln för enhetens renderare som är registrerad i renderaren |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/circle/_index.md
+++ b/swedish/nodejs-java/aspose.threed/circle/_index.md
@@ -1,0 +1,339 @@
+---
+title: "Circle"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/circle/
+---
+## Circle class
+
+En cirkelkurva består av en uppsättning punkter på kanten av cirkelformen.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Konstruktor för Circle |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload(radius) | Konstruktor för Circle |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| radius | Nummer | Radien på cirkelkurvan. |
+
+ **Result:**
+
+
+
+---
+
+
+### getRadius{#getRadius}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getRadius() | Radien på cirkelkurvan, standardvärdet är 10 |
+
+ **Result:**
+
+
+
+---
+
+
+### setRadius{#setRadius}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setRadius(value) | Radien på cirkelkurvan, standardvärdet är 10 |
+
+ **Result:**
+
+
+
+---
+
+
+### getColor{#getColor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getColor() | Hämtar eller anger färgen på linjen, standardvärdet är vit(1, 1, 1) |
+
+ **Result:**
+
+
+
+---
+
+
+### setColor{#setColor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setColor(value) | Hämtar eller anger färgen på linjen, standardvärdet är vit(1, 1, 1) |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNodes() | Hämtar alla föräldranoder, en entitet kan fästas vid flera föräldranoder för geometri‑instansering. Noderna. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExcluded() | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExcluded(value) | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNode() | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setParentNode(value) | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getScene() | Hämtar scenen som detta objekt tillhör |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEntityRendererKey() | Hämtar nyckeln för enhetens renderare som är registrerad i renderaren |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBoundingBox() | Hämtar den omgivande lådan för den aktuella enheten i dess objektrums koordinatsystem. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/circleshape/_index.md
+++ b/swedish/nodejs-java/aspose.threed/circleshape/_index.md
@@ -1,0 +1,326 @@
+---
+title: "CircleShape"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/circleshape/
+---
+## CircleShape class
+
+IFC-kompatibel cirkelprofil, som kan användas för att konstruera ett mesh genom LinearExtrusion
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Skapa en CircleShape-profil med standardradie(5). |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload(radius) | Skapa en CircleShape-profil med angiven radie. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| radie | Nummer | null |
+
+ **Result:**
+
+
+
+---
+
+
+### getRadius{#getRadius}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getRadius() | Hämtar eller anger radien på cirkeln. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRadius{#setRadius}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setRadius(value) | Hämtar eller anger radien på cirkeln. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNodes() | Hämtar alla föräldranoder, en entitet kan fästas vid flera föräldranoder för geometri‑instansering. Noderna. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExcluded() | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExcluded(value) | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNode() | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setParentNode(value) | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getScene() | Hämtar scenen som detta objekt tillhör |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtent{#getExtent}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExtent() | Hämtar omfattningen i x- och y-dimension. |
+
+ **Result:**
+Vector2
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEntityRendererKey() | Hämtar nyckeln för enhetens renderare som är registrerad i renderaren |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBoundingBox() | Hämtar den omgivande lådan för den aktuella enheten i dess objektrums koordinatsystem. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/colladasaveoptions/_index.md
+++ b/swedish/nodejs-java/aspose.threed/colladasaveoptions/_index.md
@@ -1,0 +1,198 @@
+---
+title: "ColladaSaveOptions"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/colladasaveoptions/
+---
+## ColladaSaveOptions class
+
+Spara alternativ för collada
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Konstruktor för ColladaSaveOptions |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndented{#getIndented}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getIndented() | Hämtar eller anger om det exporterade XML-dokumentet är indenterat. |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndented{#setIndented}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setIndented(value) | Hämtar eller anger om det exporterade XML-dokumentet är indenterat. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTransformStyle{#getTransformStyle}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getTransformStyle() | Hämtar eller anger stilen för nodtransformation. Värdet på egenskapen är heltalskonstanten ColladaTransformStyle. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTransformStyle{#setTransformStyle}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setTransformStyle(value) | Hämtar eller anger stilen för nodtransformation. Värdet på egenskapen är heltalskonstanten ColladaTransformStyle. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportTextures{#getExportTextures}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExportTextures() | Försök att kopiera texturer som används i scenen till utdatamappen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextures{#setExportTextures}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExportTextures(value) | Försök att kopiera texturer som används i scenen till utdatamappen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileFormat() | Hämtar filformatet som anges i aktuellt Spara/Ladda-alternativ. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEncoding() | Hämtar eller anger standardkodning för textbaserade filer. Standardvärdet är null, vilket betyder att importören/exportören bestämmer vilken kodning som ska användas. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileSystem() | Tillåter användaren att hantera hur externa beroenden ska hanteras under laddning/sparning. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFileSystem(value) | Tillåter användaren att hantera hur externa beroenden ska hanteras under laddning/sparning. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getLookupPaths() | Vissa filer, som OBJ, är beroende av externa filer; sökvägarna gör det möjligt för Aspose.3D att leta efter externa filer att ladda. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileName() | Filnamnet för den exporterade/importerade scenen. Detta är valfritt, men användbart när externa resurser som OBJ:s material serialiseras. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFileName(value) | Filnamnet för den exporterade/importerade scenen. Detta är valfritt, men användbart när externa resurser som OBJ:s material serialiseras. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/compositecurve/_index.md
+++ b/swedish/nodejs-java/aspose.threed/compositecurve/_index.md
@@ -1,0 +1,327 @@
+---
+title: "CompositeCurve"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/compositecurve/
+---
+## CompositeCurve class
+
+En CompositeCurve består av flera kurvsegment.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Konstruktor för CompositeCurve |
+
+ **Result:**
+
+
+
+---
+
+
+### getSegments{#getSegments}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getSegments() | Kurvans segment. |
+
+ **Result:**
+
+
+
+---
+
+
+### getColor{#getColor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getColor() | Hämtar eller anger färgen på linjen, standardvärdet är vit(1, 1, 1) |
+
+ **Result:**
+
+
+
+---
+
+
+### setColor{#setColor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setColor(value) | Hämtar eller anger färgen på linjen, standardvärdet är vit(1, 1, 1) |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNodes() | Hämtar alla föräldranoder, en entitet kan fästas vid flera föräldranoder för geometri‑instansering. Noderna. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExcluded() | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExcluded(value) | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNode() | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setParentNode(value) | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getScene() | Hämtar scenen som detta objekt tillhör |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### addSegment{#addSegment}
+
+| Namn | Beskrivning |
+| --- | --- |
+| addSegment(curve, sameDirection) | Den |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| curv | Kurva | null |
+| sameDirectio | boolean | null |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEntityRendererKey() | Hämtar nyckeln för enhetens renderare som är registrerad i renderaren |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBoundingBox() | Hämtar den omgivande lådan för den aktuella enheten i dess objektrums koordinatsystem. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/cshape/_index.md
+++ b/swedish/nodejs-java/aspose.threed/cshape/_index.md
@@ -1,0 +1,411 @@
+---
+title: "CShape"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/cshape/
+---
+## CShape class
+
+IFC-kompatibel C-form profil som definieras av parametrar.  Profilens mittposition är i mitten av omgivningsrutan.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Konstruktor för CShape |
+
+ **Result:**
+
+
+
+---
+
+
+### getDepth{#getDepth}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getDepth() | Hämtar eller sätter djupet på profilen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDepth{#setDepth}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setDepth(value) | Hämtar eller sätter djupet på profilen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getWidth{#getWidth}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getWidth() | Hämtar eller sätter bredden på profilen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setWidth{#setWidth}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setWidth(value) | Hämtar eller sätter bredden på profilen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getGirth{#getGirth}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getGirth() | Hämtar eller sätter längden på omkretsen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setGirth{#setGirth}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setGirth(value) | Hämtar eller sätter längden på omkretsen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getWallThickness{#getWallThickness}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getWallThickness() | Hämtar eller sätter tjockleken på väggen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setWallThickness{#setWallThickness}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setWallThickness(value) | Hämtar eller sätter tjockleken på väggen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getInternalFilletRadius{#getInternalFilletRadius}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getInternalFilletRadius() | Hämtar eller sätter den interna avrundningsradien. |
+
+ **Result:**
+
+
+
+---
+
+
+### setInternalFilletRadius{#setInternalFilletRadius}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setInternalFilletRadius(value) | Hämtar eller sätter den interna avrundningsradien. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNodes() | Hämtar alla föräldranoder, en entitet kan fästas vid flera föräldranoder för geometri‑instansering. Noderna. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExcluded() | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExcluded(value) | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNode() | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setParentNode(value) | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getScene() | Hämtar scenen som detta objekt tillhör |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtent{#getExtent}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExtent() | Hämtar omfattningen i x- och y-dimension. |
+
+ **Result:**
+Vector2
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEntityRendererKey() | Hämtar nyckeln för enhetens renderare som är registrerad i renderaren |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBoundingBox() | Hämtar den omgivande lådan för den aktuella enheten i dess objektrums koordinatsystem. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/cubeface/_index.md
+++ b/swedish/nodejs-java/aspose.threed/cubeface/_index.md
@@ -1,0 +1,13 @@
+---
+title: "CubeFace"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/cubeface/
+---
+## CubeFace class
+
+Verktygsklass som innehåller konstanter.  Varje ansikte av kubkarts-texturen  @hideconstructor
+
+

--- a/swedish/nodejs-java/aspose.threed/curve/_index.md
+++ b/swedish/nodejs-java/aspose.threed/curve/_index.md
@@ -1,0 +1,281 @@
+---
+title: "Kurva"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/curve/
+---
+## Curve class
+
+Bas-klassen för alla kurvimplementationer.  @hideconstructor
+
+
+## Metoder
+
+### getColor{#getColor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getColor() | Hämtar eller anger färgen på linjen, standardvärdet är vit(1, 1, 1) |
+
+ **Result:**
+
+
+
+---
+
+
+### setColor{#setColor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setColor(value) | Hämtar eller anger färgen på linjen, standardvärdet är vit(1, 1, 1) |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNodes() | Hämtar alla föräldranoder, en entitet kan fästas vid flera föräldranoder för geometri‑instansering. Noderna. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExcluded() | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExcluded(value) | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNode() | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setParentNode(value) | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getScene() | Hämtar scenen som detta objekt tillhör |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEntityRendererKey() | Hämtar nyckeln för enhetens renderare som är registrerad i renderaren |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBoundingBox() | Hämtar den omgivande lådan för den aktuella enheten i dess objektrums koordinatsystem. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/customobject/_index.md
+++ b/swedish/nodejs-java/aspose.threed/customobject/_index.md
@@ -1,0 +1,183 @@
+---
+title: "CustomObject"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/customobject/
+---
+## CustomObject class
+
+Metadata eller anpassade objekt som används i 3D-filer hanteras av denna klass.  Alla anpassade egenskaper sparas som dynamiska egenskaper.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Initierar en ny instans av klassen CustomObject. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload(name) | Initierar en ny instans av klassen CustomObject. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| name | Sträng | Namn |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/cylinder/_index.md
+++ b/swedish/nodejs-java/aspose.threed/cylinder/_index.md
@@ -1,0 +1,763 @@
+---
+title: "Cylinder"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/cylinder/
+---
+## Cylinder class
+
+Parametriserad cylinder.  Den kan också användas för att representera en kon när antingen radiusTop eller radiusBottom är noll.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Initierar en ny instans av klassen Cylinder. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload(radius, height) | Initierar en ny instans av klassen Cylinder. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| radius | Nummer | Radie för den övre och nedre kapseln. |
+| height | Nummer | Höjd. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload2(radiusTop, radiusBottom, height) | Initierar en ny instans av klassen Cylinder. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| radiusTop | Nummer | Övre radie. |
+| radiusBottom | Nummer | Nedre radie. |
+| height | Nummer | Höjd. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload3{#constructor_overload3}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload3(radiusTop, radiusBottom, height, radialSegments, heightSegments, openEnded) | Initierar en ny instans av klassen Cylinder. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| radiusTop | Nummer | Radie för cylinderns övre kapsel. |
+| radiusBottom | Nummer | Radie för cylinderns nedre kapsel. |
+| height | Nummer | Cylinderns höjd. |
+| radialSegments | Nummer | Radiala segment av både övre och nedre cirklar.. |
+| heightSegments | Nummer | Höjsegment. |
+| openEnded | boolean | Om inställt på |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload4{#constructor_overload4}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload4(name, radiusTop, radiusBottom, height, radialSegments, heightSegments, openEnded, thetaStart, thetaLength) | Initierar en ny instans av klassen Cylinder. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| name | Sträng | Namnet på detta objekt |
+| radiusTop | Nummer | Radie för cylinderns övre kapsel. |
+| radiusBottom | Nummer | Radie för cylinderns nedre kapsel. |
+| height | Nummer | Cylinderns höjd. |
+| radialSegments | Nummer | Radiala segment av både övre och nedre cirklar.. |
+| heightSegments | Nummer | Höjsegment. |
+| openEnded | boolean | Om inställt på |
+| thetaStart | Nummer | Theta start. |
+| thetaLength | Nummer | Theta längd. |
+
+ **Result:**
+
+
+
+---
+
+
+### getOffsetBottom{#getOffsetBottom}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getOffsetBottom() | Hämtar eller anger vertexens transformationsförskjutning för den nedre sidan. |
+
+ **Result:**
+
+
+
+---
+
+
+### setOffsetBottom{#setOffsetBottom}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setOffsetBottom(value) | Hämtar eller anger vertexens transformationsförskjutning för den nedre sidan. |
+
+ **Result:**
+
+
+
+---
+
+
+### getOffsetTop{#getOffsetTop}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getOffsetTop() | Hämtar eller anger vertexens transformationsförskjutning för den övre sidan. |
+
+ **Result:**
+
+
+
+---
+
+
+### setOffsetTop{#setOffsetTop}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setOffsetTop(value) | Hämtar eller anger vertexens transformationsförskjutning för den övre sidan. |
+
+ **Result:**
+
+
+
+---
+
+
+### getGenerateFanCylinder{#getGenerateFanCylinder}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getGenerateFanCylinder() | Hämtar eller anger om en fläktstilad cylinder ska genereras när ThetaLength är mindre än 2π, annars kommer modellen inte att kapas. |
+
+ **Result:**
+
+
+
+---
+
+
+### setGenerateFanCylinder{#setGenerateFanCylinder}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setGenerateFanCylinder(value) | Hämtar eller anger om en fläktstilad cylinder ska genereras när ThetaLength är mindre än 2π, annars kommer modellen inte att kapas. |
+
+ **Result:**
+
+
+
+---
+
+
+### getShearBottom{#getShearBottom}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getShearBottom() | Hämtar eller anger skjuvtransformen för den nedre sidan, vektorn lagrar (x-axel, z-axel) skjuvvärdet som mäts i radian, standardvärdet är (0, 0). |
+
+ **Result:**
+
+
+
+---
+
+
+### setShearBottom{#setShearBottom}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setShearBottom(value) | Hämtar eller anger skjuvtransformen för den nedre sidan, vektorn lagrar (x-axel, z-axel) skjuvvärdet som mäts i radian, standardvärdet är (0, 0). |
+
+ **Result:**
+
+
+
+---
+
+
+### getShearTop{#getShearTop}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getShearTop() | Hämtar eller anger skjuvtransformen för den övre sidan, vektorn lagrar (x-axel, z-axel) skjuvvärdet som mäts i radian, standardvärdet är (0, 0). |
+
+ **Result:**
+
+
+
+---
+
+
+### setShearTop{#setShearTop}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setShearTop(value) | Hämtar eller anger skjuvtransformen för den övre sidan, vektorn lagrar (x-axel, z-axel) skjuvvärdet som mäts i radian, standardvärdet är (0, 0). |
+
+ **Result:**
+
+
+
+---
+
+
+### getRadiusTop{#getRadiusTop}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getRadiusTop() | Hämtar eller anger radien för cylinderns övre lock. Radien för det övre locket. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRadiusTop{#setRadiusTop}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setRadiusTop(value) | Hämtar eller anger radien för cylinderns övre lock. Radien för det övre locket. |
+
+ **Result:**
+
+
+
+---
+
+
+### getRadiusBottom{#getRadiusBottom}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getRadiusBottom() | Hämtar eller anger radien för cylinderns nedre lock. Radien för det nedre locket. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRadiusBottom{#setRadiusBottom}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setRadiusBottom(value) | Hämtar eller anger radien för cylinderns nedre lock. Radien för det nedre locket. |
+
+ **Result:**
+
+
+
+---
+
+
+### getHeight{#getHeight}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getHeight() | Hämtar eller anger höjden på cylindern. Höjden. |
+
+ **Result:**
+
+
+
+---
+
+
+### setHeight{#setHeight}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setHeight(value) | Hämtar eller anger höjden på cylindern. Höjden. |
+
+ **Result:**
+
+
+
+---
+
+
+### getRadialSegments{#getRadialSegments}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getRadialSegments() | Hämtar eller anger de radiella segmenten. De radiella segmenten. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRadialSegments{#setRadialSegments}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setRadialSegments(value) | Hämtar eller anger de radiella segmenten. De radiella segmenten. |
+
+ **Result:**
+
+
+
+---
+
+
+### getHeightSegments{#getHeightSegments}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getHeightSegments() | Hämtar eller anger höjsegmenten. Höjsegmenten. |
+
+ **Result:**
+
+
+
+---
+
+
+### setHeightSegments{#setHeightSegments}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setHeightSegments(value) | Hämtar eller anger höjsegmenten. Höjsegmenten. |
+
+ **Result:**
+
+
+
+---
+
+
+### getOpenEnded{#getOpenEnded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getOpenEnded() | Hämtar eller anger ett värde som indikerar om denna cylinder är öppen. Standardvärdet är falskt. Sant om öppen; annars finns topp-/bottenlock. |
+
+ **Result:**
+
+
+
+---
+
+
+### setOpenEnded{#setOpenEnded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setOpenEnded(value) | Hämtar eller anger ett värde som indikerar om denna cylinder är öppen. Standardvärdet är falskt. Sant om öppen; annars finns topp-/bottenlock. |
+
+ **Result:**
+
+
+
+---
+
+
+### getThetaStart{#getThetaStart}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getThetaStart() | Hämtar eller anger theta-starten. Standardvärdet är 0. Theta-starten. |
+
+ **Result:**
+
+
+
+---
+
+
+### setThetaStart{#setThetaStart}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setThetaStart(value) | Hämtar eller anger theta-starten. Standardvärdet är 0. Theta-starten. |
+
+ **Result:**
+
+
+
+---
+
+
+### getThetaLength{#getThetaLength}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getThetaLength() | Hämtar eller anger theta-längden. Standardvärdet är 2π. Theta-längden. |
+
+ **Result:**
+
+
+
+---
+
+
+### setThetaLength{#setThetaLength}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setThetaLength(value) | Hämtar eller anger theta-längden. Standardvärdet är 2π. Theta-längden. |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastShadows{#getCastShadows}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getCastShadows() | Hämtar eller anger om denna geometri kan kasta skugga |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastShadows{#setCastShadows}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setCastShadows(value) | Hämtar eller anger om denna geometri kan kasta skugga |
+
+ **Result:**
+
+
+
+---
+
+
+### getReceiveShadows{#getReceiveShadows}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getReceiveShadows() | Hämtar eller anger om denna geometri kan ta emot skugga. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReceiveShadows{#setReceiveShadows}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setReceiveShadows(value) | Hämtar eller anger om denna geometri kan ta emot skugga. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNodes() | Hämtar alla föräldranoder, en entitet kan fästas vid flera föräldranoder för geometri‑instansering. Noderna. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExcluded() | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExcluded(value) | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNode() | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setParentNode(value) | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getScene() | Hämtar scenen som detta objekt tillhör |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### toMesh{#toMesh}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toMesh() | Konvertera aktuellt objekt till mesh |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBoundingBox() | Hämtar den omgivande lådan för den aktuella enheten i dess objektrums koordinatsystem. |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEntityRendererKey() | Hämtar nyckeln för enhetens renderare som är registrerad i renderaren |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/deformer/_index.md
+++ b/swedish/nodejs-java/aspose.threed/deformer/_index.md
@@ -1,0 +1,183 @@
+---
+title: "Deformer"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/deformer/
+---
+## Deformer class
+
+Bas-klass för SkinDeformer och MorphTargetDeformer
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor(name) | Initierar en ny instans av klassen Deformer. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| name | Sträng | Namn. |
+
+ **Result:**
+
+
+
+---
+
+
+### getOwner{#getOwner}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getOwner() | Hämtar geometrin som äger denna deformerare |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/descriptorsetupdater/_index.md
+++ b/swedish/nodejs-java/aspose.threed/descriptorsetupdater/_index.md
@@ -1,0 +1,137 @@
+---
+title: "DescriptorSetUpdater"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/descriptorsetupdater/
+---
+## DescriptorSetUpdater class
+
+Denna klass möjliggör att uppdatera com.aspose.threed.IDescriptorSet i en kedjeoperation.  @hideconstructor
+
+
+## Metoder
+
+### bind{#bind}
+
+| Namn | Beskrivning |
+| --- | --- |
+| bind(buffer, offset, size) | Bind bufferten till aktuellt descriptor set |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| buffer | IBuffer | Vilken buffer som ska bindas |
+| offset | Nummer | Offset för bufferten som ska bindas |
+| storlek | Nummer | Storlek för bufferten som ska bindas |
+
+ **Result:**
+DescriptorSetUpdater
+
+
+---
+
+
+### bind{#bind}
+
+| Namn | Beskrivning |
+| --- | --- |
+| bind(buffer) | Bind hela bufferten till aktuellt descriptor |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| buffert | IBuffer | null |
+
+ **Result:**
+DescriptorSetUpdater
+
+
+---
+
+
+### bind{#bind}
+
+| Namn | Beskrivning |
+| --- | --- |
+| bind(binding, buffer) | Koppla bufferten till aktuella descriptor set på angiven bindningsplats. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| bindning | Nummer | Bindningsplats |
+| buffer | IBuffer | Hela bufferten som ska bindas |
+
+ **Result:**
+DescriptorSetUpdater
+
+
+---
+
+
+### bind{#bind}
+
+| Namn | Beskrivning |
+| --- | --- |
+| bind(binding, buffer, offset, size) | Koppla bufferten till aktuella descriptor set på angiven bindningsplats. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| bindning | Nummer | Bindningsplats |
+| buffer | IBuffer | Bufferten som ska bindas |
+| offset | Nummer | Offset för bufferten som ska bindas |
+| storlek | Nummer | Storlek för bufferten som ska bindas |
+
+ **Result:**
+DescriptorSetUpdater
+
+
+---
+
+
+### bind{#bind}
+
+| Namn | Beskrivning |
+| --- | --- |
+| bind(texture) | Koppla texturenheten till aktuella descriptor set |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| texture | ITextureUnit | Texturenheten som ska bindas |
+
+ **Result:**
+DescriptorSetUpdater
+
+
+---
+
+
+### bind{#bind}
+
+| Namn | Beskrivning |
+| --- | --- |
+| bind(binding, texture) | Koppla texturenheten till aktuella descriptor set |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| bindning | Nummer | Bindningsplatsen |
+| texture | ITextureUnit | Texturenheten som ska bindas |
+
+ **Result:**
+DescriptorSetUpdater
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/discreet3dsloadoptions/_index.md
+++ b/swedish/nodejs-java/aspose.threed/discreet3dsloadoptions/_index.md
@@ -1,0 +1,198 @@
+---
+title: "Discreet3dsLoadOptions"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/discreet3dsloadoptions/
+---
+## Discreet3dsLoadOptions class
+
+Läsalternativ för 3DS-fil.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Konstruktor för Discreet3dsLoadOptions |
+
+ **Result:**
+
+
+
+---
+
+
+### getGammaCorrectedColor{#getGammaCorrectedColor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getGammaCorrectedColor() | En 3ds-fil kan innehålla originalfärg och gamma‑korrigerad färg för samma attribut. Att sätta detta till true kommer att använda den gamma‑korrigerade färgen om möjligt, annars kommer Aspose.3D att försöka använda originalfärgen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setGammaCorrectedColor{#setGammaCorrectedColor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setGammaCorrectedColor(value) | En 3ds-fil kan innehålla originalfärg och gamma‑korrigerad färg för samma attribut. Att sätta detta till true kommer att använda den gamma‑korrigerade färgen om möjligt, annars kommer Aspose.3D att försöka använda originalfärgen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlipCoordinateSystem{#getFlipCoordinateSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFlipCoordinateSystem() | Hämtar eller anger vändning av koordinatsystemet för kontrollpunkter/normaler under import/export. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlipCoordinateSystem{#setFlipCoordinateSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFlipCoordinateSystem(value) | Hämtar eller anger vändning av koordinatsystemet för kontrollpunkter/normaler under import/export. |
+
+ **Result:**
+
+
+
+---
+
+
+### getApplyAnimationTransform{#getApplyAnimationTransform}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getApplyAnimationTransform() | Hämtar eller anger huruvida transformationen som definierats i den första bildrutan av animationsspåret ska användas. |
+
+ **Result:**
+
+
+
+---
+
+
+### setApplyAnimationTransform{#setApplyAnimationTransform}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setApplyAnimationTransform(value) | Hämtar eller anger huruvida transformationen som definierats i den första bildrutan av animationsspåret ska användas. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileFormat() | Hämtar filformatet som anges i aktuellt Spara/Ladda-alternativ. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEncoding() | Hämtar eller anger standardkodning för textbaserade filer. Standardvärdet är null, vilket betyder att importören/exportören bestämmer vilken kodning som ska användas. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileSystem() | Tillåter användaren att hantera hur externa beroenden ska hanteras under laddning/sparning. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFileSystem(value) | Tillåter användaren att hantera hur externa beroenden ska hanteras under laddning/sparning. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getLookupPaths() | Vissa filer, som OBJ, är beroende av externa filer; sökvägarna gör det möjligt för Aspose.3D att leta efter externa filer att ladda. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileName() | Filnamnet för den exporterade/importerade scenen. Detta är valfritt, men användbart när externa resurser som OBJ:s material serialiseras. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFileName(value) | Filnamnet för den exporterade/importerade scenen. Detta är valfritt, men användbart när externa resurser som OBJ:s material serialiseras. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/discreet3dssaveoptions/_index.md
+++ b/swedish/nodejs-java/aspose.threed/discreet3dssaveoptions/_index.md
@@ -1,0 +1,380 @@
+---
+title: "Discreet3dsSaveOptions"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/discreet3dssaveoptions/
+---
+## Discreet3dsSaveOptions class
+
+Sparaalternativ för 3DS-fil.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Konstruktor för Discreet3dsSaveOptions |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportLight{#getExportLight}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExportLight() | Hämtar eller anger om alla ljus i scenen ska exporteras. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportLight{#setExportLight}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExportLight(value) | Hämtar eller anger om alla ljus i scenen ska exporteras. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportCamera{#getExportCamera}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExportCamera() | Hämtar eller anger om alla kameror i scenen ska exporteras. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportCamera{#setExportCamera}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExportCamera(value) | Hämtar eller anger om alla kameror i scenen ska exporteras. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDuplicatedNameSeparator{#getDuplicatedNameSeparator}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getDuplicatedNameSeparator() | Separatorn mellan objektets namn och den duplicerade räknaren, standardvärdet är "_". När scenen innehåller objekt som använder samma namn kommer Aspose.3D 3DS-exportören att generera ett annat namn för objektet. Till exempel finns det två noder med namnet "Box", den första noden får namnet "Box" och den andra noden får ett nytt namn "Box_2" med standardkonfigurationen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDuplicatedNameSeparator{#setDuplicatedNameSeparator}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setDuplicatedNameSeparator(value) | Separatorn mellan objektets namn och den duplicerade räknaren, standardvärdet är "_". När scenen innehåller objekt som använder samma namn kommer Aspose.3D 3DS-exportören att generera ett annat namn för objektet. Till exempel finns det två noder med namnet "Box", den första noden får namnet "Box" och den andra noden får ett nytt namn "Box_2" med standardkonfigurationen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDuplicatedNameCounterBase{#getDuplicatedNameCounterBase}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getDuplicatedNameCounterBase() | Räknaren som används för att generera nya namn för duplicerade namn, standardvärdet är 2. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDuplicatedNameCounterBase{#setDuplicatedNameCounterBase}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setDuplicatedNameCounterBase(value) | Räknaren som används för att generera nya namn för duplicerade namn, standardvärdet är 2. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDuplicatedNameCounterFormat{#getDuplicatedNameCounterFormat}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getDuplicatedNameCounterFormat() | Formatet för den duplicerade räknaren, standardvärdet är en tom sträng. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDuplicatedNameCounterFormat{#setDuplicatedNameCounterFormat}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setDuplicatedNameCounterFormat(value) | Formatet för den duplicerade räknaren, standardvärdet är en tom sträng. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMasterScale{#getMasterScale}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getMasterScale() | Hämtar eller anger huvudskalan som används vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMasterScale{#setMasterScale}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setMasterScale(value) | Hämtar eller anger huvudskalan som används vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### getGammaCorrectedColor{#getGammaCorrectedColor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getGammaCorrectedColor() | En 3ds-fil kan innehålla originalfärg och gamma‑korrigerad färg för samma attribut. Att sätta detta till true kommer att använda den gamma‑korrigerade färgen om möjligt, annars kommer Aspose.3D att försöka använda originalfärgen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setGammaCorrectedColor{#setGammaCorrectedColor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setGammaCorrectedColor(value) | En 3ds-fil kan innehålla originalfärg och gamma‑korrigerad färg för samma attribut. Att sätta detta till true kommer att använda den gamma‑korrigerade färgen om möjligt, annars kommer Aspose.3D att försöka använda originalfärgen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlipCoordinateSystem{#getFlipCoordinateSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFlipCoordinateSystem() | Hämtar eller anger vändning av koordinatsystemet för kontrollpunkter/normaler under import/export. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlipCoordinateSystem{#setFlipCoordinateSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFlipCoordinateSystem(value) | Hämtar eller anger vändning av koordinatsystemet för kontrollpunkter/normaler under import/export. |
+
+ **Result:**
+
+
+
+---
+
+
+### getHighPreciseColor{#getHighPreciseColor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getHighPreciseColor() | Om detta är true kommer den genererade 3ds-filen att använda högprecis färg, vilket betyder att varje kanal för röd/grön/blå är i 32‑bit flyttal. Annars kommer den genererade filen att använda 24‑bit färg, varje kanal använder 8‑bit byte. Standardvärdet är false, eftersom inte alla program stödjer högprecis färg. |
+
+ **Result:**
+
+
+
+---
+
+
+### setHighPreciseColor{#setHighPreciseColor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setHighPreciseColor(value) | Om detta är true kommer den genererade 3ds-filen att använda högprecis färg, vilket betyder att varje kanal för röd/grön/blå är i 32‑bit flyttal. Annars kommer den genererade filen att använda 24‑bit färg, varje kanal använder 8‑bit byte. Standardvärdet är false, eftersom inte alla program stödjer högprecis färg. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportTextures{#getExportTextures}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExportTextures() | Försök att kopiera texturer som används i scenen till utdatamappen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextures{#setExportTextures}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExportTextures(value) | Försök att kopiera texturer som används i scenen till utdatamappen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileFormat() | Hämtar filformatet som anges i aktuellt Spara/Ladda-alternativ. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEncoding() | Hämtar eller anger standardkodning för textbaserade filer. Standardvärdet är null, vilket betyder att importören/exportören bestämmer vilken kodning som ska användas. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileSystem() | Tillåter användaren att hantera hur externa beroenden ska hanteras under laddning/sparning. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFileSystem(value) | Tillåter användaren att hantera hur externa beroenden ska hanteras under laddning/sparning. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getLookupPaths() | Vissa filer, som OBJ, är beroende av externa filer; sökvägarna gör det möjligt för Aspose.3D att leta efter externa filer att ladda. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileName() | Filnamnet för den exporterade/importerade scenen. Detta är valfritt, men användbart när externa resurser som OBJ:s material serialiseras. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFileName(value) | Filnamnet för den exporterade/importerade scenen. Detta är valfritt, men användbart när externa resurser som OBJ:s material serialiseras. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/dish/_index.md
+++ b/swedish/nodejs-java/aspose.threed/dish/_index.md
@@ -1,0 +1,480 @@
+---
+title: "Dish"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/dish/
+---
+## Dish class
+
+Parametriserad skål.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Skapa en ny dish-instans med standardradie(10) och standardhöjd(5) |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload(radius, height) | Skapa en ny dish-instans med angiven radie och höjd |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| radius | Nummer | Radien på dish |
+| height | Nummer | Höjden på dish |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload2(name, radius, height, widthSegments, heightSegments) | Skapa en ny dish-instans med angiven radie och höjd |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| name | Sträng | Namnet på dish |
+| radius | Nummer | Radien på dish |
+| height | Nummer | Höjden på dish |
+| widthSegments | Nummer | Breddsegmentet för dish |
+| heightSegments | Nummer | Höjdsegmentet för skålen |
+
+ **Result:**
+
+
+
+---
+
+
+### getHeight{#getHeight}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getHeight() | Höjd på skålen |
+
+ **Result:**
+
+
+
+---
+
+
+### setHeight{#setHeight}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setHeight(value) | Höjd på skålen |
+
+ **Result:**
+
+
+
+---
+
+
+### getRadius{#getRadius}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getRadius() | Radie på skålen |
+
+ **Result:**
+
+
+
+---
+
+
+### setRadius{#setRadius}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setRadius(value) | Radie på skålen |
+
+ **Result:**
+
+
+
+---
+
+
+### getWidthSegments{#getWidthSegments}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getWidthSegments() | Hämtar eller anger breddsegmenten |
+
+ **Result:**
+
+
+
+---
+
+
+### setWidthSegments{#setWidthSegments}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setWidthSegments(value) | Hämtar eller anger breddsegmenten |
+
+ **Result:**
+
+
+
+---
+
+
+### getHeightSegments{#getHeightSegments}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getHeightSegments() | Hämtar eller anger höjdsegmenten |
+
+ **Result:**
+
+
+
+---
+
+
+### setHeightSegments{#setHeightSegments}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setHeightSegments(value) | Hämtar eller anger höjdsegmenten |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastShadows{#getCastShadows}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getCastShadows() | Hämtar eller anger om denna geometri kan kasta skugga |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastShadows{#setCastShadows}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setCastShadows(value) | Hämtar eller anger om denna geometri kan kasta skugga |
+
+ **Result:**
+
+
+
+---
+
+
+### getReceiveShadows{#getReceiveShadows}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getReceiveShadows() | Hämtar eller anger om denna geometri kan ta emot skugga. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReceiveShadows{#setReceiveShadows}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setReceiveShadows(value) | Hämtar eller anger om denna geometri kan ta emot skugga. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNodes() | Hämtar alla föräldranoder, en entitet kan fästas vid flera föräldranoder för geometri‑instansering. Noderna. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExcluded() | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExcluded(value) | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNode() | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setParentNode(value) | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getScene() | Hämtar scenen som detta objekt tillhör |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### toMesh{#toMesh}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toMesh() | Konvertera aktuellt objekt till mesh |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBoundingBox() | Hämtar den omgivande lådan för den aktuella enheten i dess objektrums koordinatsystem. |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEntityRendererKey() | Hämtar nyckeln för enhetens renderare som är registrerad i renderaren |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/dracoformat/_index.md
+++ b/swedish/nodejs-java/aspose.threed/dracoformat/_index.md
@@ -1,0 +1,199 @@
+---
+title: "DracoFormat"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/dracoformat/
+---
+## DracoFormat class
+
+Google Draco-format  @hideconstructor
+
+
+## Metoder
+
+### getVersion{#getVersion}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getVersion() | Hämtar filformatversion |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtension{#getExtension}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExtension() | Hämtar filändelsens namn för den här typen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtensions{#getExtensions}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExtensions() | Hämtar filändelserna för den här typen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getContentType{#getContentType}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getContentType() | Hämtar filformatets innehållstyp. Värdet på egenskapen är heltalskonstanten FileContentType. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormatType{#getFileFormatType}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileFormatType() | Hämtar filformattyp |
+
+ **Result:**
+
+
+
+---
+
+
+### decode{#decode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| decode(fileName) | Dekoda punktmolnet eller meshen från angivet filnamn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| fileName | Sträng | Filnamnet innehåller drc-filen |
+
+ **Result:**
+Geometry
+
+
+---
+
+
+### decode{#decode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| decode(data) | Dekoda punktmolnet eller meshen från minnesdata |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| data | byte[] | De råa drc-byterna |
+
+ **Result:**
+Geometry
+
+
+---
+
+
+### encode{#encode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| encode(entity, fileName, options) | Koda enheten till angiven fil |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| entitet | Entitet | Entiteten som ska kodas |
+| fileName | Sträng | Filnamnet som ska skrivas |
+| alternativ | DracoSaveOptions | Extra alternativ för kodning av punktmolnet |
+
+ **Result:**
+Geometry
+
+
+---
+
+
+### encode{#encode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| encode(entity, options) | Koda enheten till Draco rådata |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| entitet | Entitet | Entiteten som ska kodas |
+| alternativ | DracoSaveOptions | Extra alternativ för kodning av punktmolnet |
+
+ **Result:**
+byte[]
+
+
+---
+
+
+### createLoadOptions{#createLoadOptions}
+
+| Namn | Beskrivning |
+| --- | --- |
+| createLoadOptions() | Skapa standardalternativ för inläsning för detta filformat. |
+
+ **Result:**
+LoadOptions
+
+
+---
+
+
+### createSaveOptions{#createSaveOptions}
+
+| Namn | Beskrivning |
+| --- | --- |
+| createSaveOptions() | Skapa standardalternativ för sparning för detta filformat. |
+
+ **Result:**
+SaveOptions
+
+
+---
+
+
+### toString{#toString}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toString() | Formaterar till sträng |
+
+ **Result:**
+Sträng
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/dracosaveoptions/_index.md
+++ b/swedish/nodejs-java/aspose.threed/dracosaveoptions/_index.md
@@ -1,0 +1,328 @@
+---
+title: "DracoSaveOptions"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/dracosaveoptions/
+---
+## DracoSaveOptions class
+
+Sparaalternativ för Google draco-filer
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Skapa en standardkonfiguration för att spara draco-filer. |
+
+ **Result:**
+
+
+
+---
+
+
+### getPositionBits{#getPositionBits}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getPositionBits() | Kvantiseringsbitar för position, standardvärdet är 14 |
+
+ **Result:**
+
+
+
+---
+
+
+### setPositionBits{#setPositionBits}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setPositionBits(value) | Kvantiseringsbitar för position, standardvärdet är 14 |
+
+ **Result:**
+
+
+
+---
+
+
+### getTextureCoordinateBits{#getTextureCoordinateBits}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getTextureCoordinateBits() | Kvantiseringsbitar för texturkoordinat, standardvärdet är 12 |
+
+ **Result:**
+
+
+
+---
+
+
+### setTextureCoordinateBits{#setTextureCoordinateBits}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setTextureCoordinateBits(value) | Kvantiseringsbitar för texturkoordinat, standardvärdet är 12 |
+
+ **Result:**
+
+
+
+---
+
+
+### getColorBits{#getColorBits}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getColorBits() | Kvantiseringsbitar för vertexfärg, standardvärdet är 10 |
+
+ **Result:**
+
+
+
+---
+
+
+### setColorBits{#setColorBits}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setColorBits(value) | Kvantiseringsbitar för vertexfärg, standardvärdet är 10 |
+
+ **Result:**
+
+
+
+---
+
+
+### getNormalBits{#getNormalBits}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getNormalBits() | Kvantiseringsbitar för normalvektorer, standardvärdet är 10 |
+
+ **Result:**
+
+
+
+---
+
+
+### setNormalBits{#setNormalBits}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setNormalBits(value) | Kvantiseringsbitar för normalvektorer, standardvärdet är 10 |
+
+ **Result:**
+
+
+
+---
+
+
+### getCompressionLevel{#getCompressionLevel}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getCompressionLevel() | Komprimeringsnivå, standardvärdet är DracoCompressionLevel.STANDARDVärdet på egenskapen är ett heltalskonstant för DracoCompressionLevel. |
+
+ **Result:**
+
+
+
+---
+
+
+### setCompressionLevel{#setCompressionLevel}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setCompressionLevel(value) | Komprimeringsnivå, standardvärdet är DracoCompressionLevel.STANDARDVärdet på egenskapen är ett heltalskonstant för DracoCompressionLevel. |
+
+ **Result:**
+
+
+
+---
+
+
+### getApplyUnitScale{#getApplyUnitScale}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getApplyUnitScale() | Tillämpa AssetInfo.UnitScaleFactor på meshen. Standardvärdet är falskt. |
+
+ **Result:**
+
+
+
+---
+
+
+### setApplyUnitScale{#setApplyUnitScale}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setApplyUnitScale(value) | Tillämpa AssetInfo.UnitScaleFactor på meshen. Standardvärdet är falskt. |
+
+ **Result:**
+
+
+
+---
+
+
+### getPointCloud{#getPointCloud}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getPointCloud() | Exportera scenen som punktmoln, standardvärdet är falskt. |
+
+ **Result:**
+
+
+
+---
+
+
+### setPointCloud{#setPointCloud}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setPointCloud(value) | Exportera scenen som punktmoln, standardvärdet är falskt. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportTextures{#getExportTextures}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExportTextures() | Försök att kopiera texturer som används i scenen till utdatamappen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextures{#setExportTextures}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExportTextures(value) | Försök att kopiera texturer som används i scenen till utdatamappen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileFormat() | Hämtar filformatet som anges i aktuellt Spara/Ladda-alternativ. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEncoding() | Hämtar eller anger standardkodning för textbaserade filer. Standardvärdet är null, vilket betyder att importören/exportören bestämmer vilken kodning som ska användas. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileSystem() | Tillåter användaren att hantera hur externa beroenden ska hanteras under laddning/sparning. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFileSystem(value) | Tillåter användaren att hantera hur externa beroenden ska hanteras under laddning/sparning. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getLookupPaths() | Vissa filer, som OBJ, är beroende av externa filer; sökvägarna gör det möjligt för Aspose.3D att leta efter externa filer att ladda. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileName() | Filnamnet för den exporterade/importerade scenen. Detta är valfritt, men användbart när externa resurser som OBJ:s material serialiseras. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFileName(value) | Filnamnet för den exporterade/importerade scenen. Detta är valfritt, men användbart när externa resurser som OBJ:s material serialiseras. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/driverexception/_index.md
+++ b/swedish/nodejs-java/aspose.threed/driverexception/_index.md
@@ -1,0 +1,29 @@
+---
+title: "DriverException"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/driverexception/
+---
+## DriverException class
+
+Undantaget som kastas av interna renderingsdrivrutiner.  @hideconstructor
+
+
+## Metoder
+
+### getErrorCode{#getErrorCode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getErrorCode() | Hämtar den inhemska felkoden. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/dummyfilesystem/_index.md
+++ b/swedish/nodejs-java/aspose.threed/dummyfilesystem/_index.md
@@ -1,0 +1,69 @@
+---
+title: "DummyFileSystem"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/dummyfilesystem/
+---
+## DummyFileSystem class
+
+Läs/skriv-operationer är dummy-operationer.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### readFile{#readFile}
+
+| Namn | Beskrivning |
+| --- | --- |
+| readFile(fileName, options) | Skapa en ström för att läsa beroenden. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| fileNam | Sträng | null |
+| alternativ | IOConfig | null |
+
+ **Result:**
+Stream
+
+
+---
+
+
+### writeFile{#writeFile}
+
+| Namn | Beskrivning |
+| --- | --- |
+| writeFile(fileName, options) | Skapa en ström för att skriva beroenden. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| fileNam | Sträng | null |
+| alternativ | IOConfig | null |
+
+ **Result:**
+Stream
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/ellipse/_index.md
+++ b/swedish/nodejs-java/aspose.threed/ellipse/_index.md
@@ -1,0 +1,359 @@
+---
+title: "Ellips"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/ellipse/
+---
+## Ellipse class
+
+En ellips definierar en uppsättning punkter som bildar ellipsens form.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Konstruktor för Ellips |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload(semiAxis1, semiAxis2) | Konstruktor för Ellips |
+
+ **Result:**
+
+
+
+---
+
+
+### getSemiAxis1{#getSemiAxis1}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getSemiAxis1() | Radie på X-axeln |
+
+ **Result:**
+
+
+
+---
+
+
+### setSemiAxis1{#setSemiAxis1}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setSemiAxis1(value) | Radie på X-axeln |
+
+ **Result:**
+
+
+
+---
+
+
+### getSemiAxis2{#getSemiAxis2}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getSemiAxis2() | Radie på Y-axeln |
+
+ **Result:**
+
+
+
+---
+
+
+### setSemiAxis2{#setSemiAxis2}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setSemiAxis2(value) | Radie på Y-axeln |
+
+ **Result:**
+
+
+
+---
+
+
+### getColor{#getColor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getColor() | Hämtar eller anger färgen på linjen, standardvärdet är vit(1, 1, 1) |
+
+ **Result:**
+
+
+
+---
+
+
+### setColor{#setColor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setColor(value) | Hämtar eller anger färgen på linjen, standardvärdet är vit(1, 1, 1) |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNodes() | Hämtar alla föräldranoder, en entitet kan fästas vid flera föräldranoder för geometri‑instansering. Noderna. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExcluded() | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExcluded(value) | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNode() | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setParentNode(value) | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getScene() | Hämtar scenen som detta objekt tillhör |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEntityRendererKey() | Hämtar nyckeln för enhetens renderare som är registrerad i renderaren |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBoundingBox() | Hämtar den omgivande lådan för den aktuella enheten i dess objektrums koordinatsystem. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/ellipseshape/_index.md
+++ b/swedish/nodejs-java/aspose.threed/ellipseshape/_index.md
@@ -1,0 +1,333 @@
+---
+title: "EllipseShape"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/ellipseshape/
+---
+## EllipseShape class
+
+IFC-kompatibel ellipsform som definieras av parametrar.  Profilens mittposition är i mitten av omgivningsrutan.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getSemiAxis1{#getSemiAxis1}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getSemiAxis1() | Hämtar eller anger den första radien av ellipsen som mäts i x-axelns riktning. |
+
+ **Result:**
+
+
+
+---
+
+
+### setSemiAxis1{#setSemiAxis1}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setSemiAxis1(value) | Hämtar eller anger den första radien av ellipsen som mäts i x-axelns riktning. |
+
+ **Result:**
+
+
+
+---
+
+
+### getSemiAxis2{#getSemiAxis2}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getSemiAxis2() | Hämtar eller anger den andra radien av ellipsen som mäts i y‑axelns riktning. |
+
+ **Result:**
+
+
+
+---
+
+
+### setSemiAxis2{#setSemiAxis2}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setSemiAxis2(value) | Hämtar eller anger den andra radien av ellipsen som mäts i y‑axelns riktning. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNodes() | Hämtar alla föräldranoder, en entitet kan fästas vid flera föräldranoder för geometri‑instansering. Noderna. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExcluded() | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExcluded(value) | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNode() | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setParentNode(value) | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getScene() | Hämtar scenen som detta objekt tillhör |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtent{#getExtent}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExtent() | Hämtar omfattningen i x- och y-dimension. |
+
+ **Result:**
+Vector2
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEntityRendererKey() | Hämtar nyckeln för enhetens renderare som är registrerad i renderaren |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBoundingBox() | Hämtar den omgivande lådan för den aktuella enheten i dess objektrums koordinatsystem. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/endpoint/_index.md
+++ b/swedish/nodejs-java/aspose.threed/endpoint/_index.md
@@ -1,0 +1,157 @@
+---
+title: "EndPoint"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/endpoint/
+---
+## EndPoint class
+
+Slutpunkten för att trimma kurvan, kan vara ett parametervärde eller en kartesisk punkt.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload(point) | Skapa ett EndPoint från en kartesisk punkt. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| poin | Vector3 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload2(v) | Skapa ett EndPoint från en reell parameter. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+|  | Nummer | null |
+
+ **Result:**
+
+
+
+---
+
+
+### isCartesianPoint{#isCartesianPoint}
+
+| Namn | Beskrivning |
+| --- | --- |
+| isCartesianPoint() | Är slutpunkten en kartesisk punkt? |
+
+ **Result:**
+
+
+
+---
+
+
+### getAsPoint{#getAsPoint}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getAsPoint() | Hämtar slutpunkten som en kartesisk punkt, eller kastar ett undantag. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAsValue{#getAsValue}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getAsValue() | Hämtar slutpunkten som en reell parameter, eller kastar ett undantag. |
+
+ **Result:**
+
+
+
+---
+
+
+### fromDegree{#fromDegree}
+
+| Namn | Beskrivning |
+| --- | --- |
+| fromDegree(degree) | Skapa en slutpunkt mätt i grader. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| grad | Nummer | null |
+
+ **Result:**
+EndPoint
+
+
+---
+
+
+### fromRadian{#fromRadian}
+
+| Namn | Beskrivning |
+| --- | --- |
+| fromRadian(degree) | Skapa en slutpunkt mätt i radian. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| grad | Nummer | null |
+
+ **Result:**
+EndPoint
+
+
+---
+
+
+### toString{#toString}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toString() | Returnerar en strängrepresentation av den aktuella slutpunkten. |
+
+ **Result:**
+Sträng
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/entity/_index.md
+++ b/swedish/nodejs-java/aspose.threed/entity/_index.md
@@ -1,0 +1,274 @@
+---
+title: "Entitet"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/entity/
+---
+## Entity class
+
+Bas-klassen för alla enheter.  Entity representerar ett konkret objekt som är fäst under en nod som Light/Geometry.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor(name) | Initierar en ny instans av Entity-klassen. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| name | Sträng | Namn. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNodes() | Hämtar alla föräldranoder, en entitet kan fästas vid flera föräldranoder för geometri‑instansering. Noderna. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExcluded() | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExcluded(value) | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNode() | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setParentNode(value) | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getScene() | Hämtar scenen som detta objekt tillhör |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBoundingBox() | Hämtar den omgivande lådan för den aktuella enheten i dess objektrums koordinatsystem. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEntityRendererKey() | Hämtar nyckeln för enhetens renderare som är registrerad i renderaren |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/entityrenderer/_index.md
+++ b/swedish/nodejs-java/aspose.threed/entityrenderer/_index.md
@@ -1,0 +1,185 @@
+---
+title: "EntityRenderer"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/entityrenderer/
+---
+## EntityRenderer class
+
+Skapa en underklass för att implementera rendering för olika typer av enheter.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor(key, features) | Konstruktor för EntityRenderer |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| key | Sträng | Nyckeln för entity renderer |
+| features | byte | EntityRendererFeatures |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload(key) | Konstruktor för EntityRenderer |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| key | Sträng | Nyckeln för entity renderer |
+
+ **Result:**
+
+
+
+---
+
+
+### initialize{#initialize}
+
+| Namn | Beskrivning |
+| --- | --- |
+| initialize(renderer) | Initiera entity renderer |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| rendere | Renderare | null |
+
+ **Result:**
+
+
+
+---
+
+
+### resetSceneCache{#resetSceneCache}
+
+| Namn | Beskrivning |
+| --- | --- |
+| resetSceneCache() | Scenen har ändrats eller tagits bort, så resurser på scen‑nivå måste avyttras här |
+
+ **Result:**
+
+
+
+---
+
+
+### frameBegin{#frameBegin}
+
+| Namn | Beskrivning |
+| --- | --- |
+| frameBegin(renderer, renderQueue) | Starta rendering av en ram |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| renderare | Renderare | Aktuell renderare |
+| renderQueue | IRenderQueue | Renderingskö |
+
+ **Result:**
+
+
+
+---
+
+
+### frameEnd{#frameEnd}
+
+| Namn | Beskrivning |
+| --- | --- |
+| frameEnd(renderer, renderQueue) | Avslutar rendering av en ram |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| renderare | Renderare | Aktuell renderare |
+| renderQueue | IRenderQueue | Renderingskö |
+
+ **Result:**
+
+
+
+---
+
+
+### prepareRenderQueue{#prepareRenderQueue}
+
+| Namn | Beskrivning |
+| --- | --- |
+| prepareRenderQueue(renderer, queue, node, entity) | Förbered renderingskommandon för angivet nod-/entitetspar. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| renderare | Renderare | Den aktuella renderarinstansen |
+| kö | IRenderQueue | Renderingskön som används för att hantera renderingsuppgifter |
+| nod | Nod | Aktuell nod |
+| entitet | Entitet | Entiteten som behöver renderas |
+
+ **Result:**
+
+
+
+---
+
+
+### renderEntity{#renderEntity}
+
+| Namn | Beskrivning |
+| --- | --- |
+| renderEntity(renderer, commandList, node, renderableResource, subEntity) | Varje renderingsuppgift som läggs till i com.aspose.threed.IRenderQueue kommer att ha ett motsvarande RenderEntity‑anrop för att utföra det konkreta renderingsarbetet. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| renderare | Renderare | Renderaren |
+| commandList | ICommandList | commandList som används för att spela in renderingskommandon |
+| nod | Nod | Samma nod som skickas till PrepareRenderQueue för den enhet som ska renderas |
+| renderableResource | Objekt | Det anpassade objektet som skickas till IRenderQueue under PrepareRenderQueue |
+| subEntity | Nummer | Index för delentiteten som skickas till IRenderQueue |
+
+ **Result:**
+
+
+
+---
+
+
+### dispose{#dispose}
+
+| Namn | Beskrivning |
+| --- | --- |
+| dispose() | Entitetsrenderaren håller på att avyttras, släpp delade resurser. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/entityrendererkey/_index.md
+++ b/swedish/nodejs-java/aspose.threed/entityrendererkey/_index.md
@@ -1,0 +1,48 @@
+---
+title: "EntityRendererKey"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/entityrendererkey/
+---
+## EntityRendererKey class
+
+Nyckeln för registrerad enhetsrenderare
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor(name) | Konstruktor för EntityRendererKey |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| nam | Sträng | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toString() |  |
+
+ **Result:**
+Sträng
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/exportexception/_index.md
+++ b/swedish/nodejs-java/aspose.threed/exportexception/_index.md
@@ -1,0 +1,35 @@
+---
+title: "ExportException"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/exportexception/
+---
+## ExportException class
+
+Undantag när Aspose.3D misslyckades med att exportera scenen till fil
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor(msg) | Initierar en ny instans |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| msg | Sträng | Felmeddelande |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/extrapolation/_index.md
+++ b/swedish/nodejs-java/aspose.threed/extrapolation/_index.md
@@ -1,0 +1,68 @@
+---
+title: "Extrapolation"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/extrapolation/
+---
+## Extrapolation class
+
+Extrapolering definierar hur man går tillväga när ett sampelvärde ligger utanför intervallet som definieras av de första och sista nyckelramarna.  @hideconstructor
+
+
+## Metoder
+
+### getType{#getType}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getType() | Hämtar och anger samplingsmönstret för extrapolation. Värdet på egenskapen är ett heltalskonstant av typen ExtrapolationType. Typen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setType{#setType}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setType(value) | Hämtar och anger samplingsmönstret för extrapolation. Värdet på egenskapen är ett heltalskonstant av typen ExtrapolationType. Typen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getRepeatCount{#getRepeatCount}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getRepeatCount() | Hämtar och anger antalet upprepningar av extrapolationsmönstret. Antalet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRepeatCount{#setRepeatCount}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setRepeatCount(value) | Hämtar och anger antalet upprepningar av extrapolationsmönstret. Antalet. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/fbxloadoptions/_index.md
+++ b/swedish/nodejs-java/aspose.threed/fbxloadoptions/_index.md
@@ -1,0 +1,165 @@
+---
+title: "FbxLoadOptions"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/fbxloadoptions/
+---
+## FbxLoadOptions class
+
+Läsalternativ för Fbx-format.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| konstruktor(format) | Konstruktor för FbxLoadOptions |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| form | Filformat | null |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload() | Konstruktor för FbxLoadOptions |
+
+ **Result:**
+
+
+
+---
+
+
+### getKeepBuiltinGlobalSettings{#getKeepBuiltinGlobalSettings}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getKeepBuiltinGlobalSettings() | Hämtar eller anger huruvida de inbyggda egenskaperna i GlobalSettings som har en inbyggd egenskapsersättning i AssetInfo ska behållas. Sätt detta till true om du vill ha alla egenskaper i GlobalSettings. Standardvärdet är false |
+
+ **Result:**
+
+
+
+---
+
+
+### setKeepBuiltinGlobalSettings{#setKeepBuiltinGlobalSettings}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setKeepBuiltinGlobalSettings(value) | Hämtar eller anger huruvida de inbyggda egenskaperna i GlobalSettings som har en inbyggd egenskapsersättning i AssetInfo ska behållas. Sätt detta till true om du vill ha alla egenskaper i GlobalSettings. Standardvärdet är false |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileFormat() | Hämtar filformatet som anges i aktuellt Spara/Ladda-alternativ. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEncoding() | Hämtar eller anger standardkodning för textbaserade filer. Standardvärdet är null, vilket betyder att importören/exportören bestämmer vilken kodning som ska användas. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileSystem() | Tillåter användaren att hantera hur externa beroenden ska hanteras under laddning/sparning. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFileSystem(value) | Tillåter användaren att hantera hur externa beroenden ska hanteras under laddning/sparning. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getLookupPaths() | Vissa filer, som OBJ, är beroende av externa filer; sökvägarna gör det möjligt för Aspose.3D att leta efter externa filer att ladda. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileName() | Filnamnet för den exporterade/importerade scenen. Detta är valfritt, men användbart när externa resurser som OBJ:s material serialiseras. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFileName(value) | Filnamnet för den exporterade/importerade scenen. Detta är valfritt, men användbart när externa resurser som OBJ:s material serialiseras. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/fbxsaveoptions/_index.md
+++ b/swedish/nodejs-java/aspose.threed/fbxsaveoptions/_index.md
@@ -1,0 +1,340 @@
+---
+title: "FbxSaveOptions"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/fbxsaveoptions/
+---
+## FbxSaveOptions class
+
+Sparaalternativ för Fbx-fil.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| konstruktor(format) | Initierar en FbxSaveOptions |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| form | Filformat | null |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload(contentType) | Initiera en FbxSaveOptions med den senaste stödda versionen. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| contentType | FileContentType | FileContentType |
+
+ **Result:**
+
+
+
+---
+
+
+### getReusePrimitiveMesh{#getReusePrimitiveMesh}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getReusePrimitiveMesh() | Återanvänd nätet för primitivorna med samma parametrar, detta kommer avsevärt minska storleken på FBX-utdata när scenen är konstruerad av en stor mängd primitiva former (t.ex. importerade från CAD-filer). Standardvärdet är falskt. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReusePrimitiveMesh{#setReusePrimitiveMesh}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setReusePrimitiveMesh(value) | Återanvänd nätet för primitivorna med samma parametrar, detta kommer avsevärt minska storleken på FBX-utdata när scenen är konstruerad av en stor mängd primitiva former (t.ex. importerade från CAD-filer). Standardvärdet är falskt. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEnableCompression{#getEnableCompression}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEnableCompression() | Komprimering av stora binära data i FBX-filen (t.ex. animationsdata, kontrollpunkter, vertex-elementdata, index), standardvärdet är sant. |
+
+ **Result:**
+
+
+
+---
+
+
+### setEnableCompression{#setEnableCompression}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setEnableCompression(value) | Komprimering av stora binära data i FBX-filen (t.ex. animationsdata, kontrollpunkter, vertex-elementdata, index), standardvärdet är sant. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFoldRepeatedCurveData{#getFoldRepeatedCurveData}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFoldRepeatedCurveData() | Hämtar eller anger om upprepad kurvdata ska återanvändas genom att öka den sista datans referensräkning, true om upprepad kurvdata ska fällas; annars false. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportLegacyMaterialProperties{#getExportLegacyMaterialProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExportLegacyMaterialProperties() | Hämtar eller anger om äldre materialegenskaper ska exporteras, används för bakåtkompatibilitet. Detta alternativ är aktiverat som standard. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportLegacyMaterialProperties{#setExportLegacyMaterialProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExportLegacyMaterialProperties(value) | Hämtar eller anger om äldre materialegenskaper ska exporteras, används för bakåtkompatibilitet. Detta alternativ är aktiverat som standard. |
+
+ **Result:**
+
+
+
+---
+
+
+### getVideoForTexture{#getVideoForTexture}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getVideoForTexture() | Hämtar eller anger om en Video-instans ska genereras för Textur vid export som FBX. |
+
+ **Result:**
+
+
+
+---
+
+
+### setVideoForTexture{#setVideoForTexture}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setVideoForTexture(value) | Hämtar eller anger om en Video-instans ska genereras för Textur vid export som FBX. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEmbedTextures{#getEmbedTextures}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEmbedTextures() | Hämtar eller anger om texturen ska bäddas in i den slutliga utdatafilen. FBX Exporter kommer att försöka hitta texturens rådata från filsystemet och bädda in filen i den slutliga FBX-filen. Standardvärdet är falskt. |
+
+ **Result:**
+
+
+
+---
+
+
+### setEmbedTextures{#setEmbedTextures}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setEmbedTextures(value) | Hämtar eller anger om texturen ska bäddas in i den slutliga utdatafilen. FBX Exporter kommer att försöka hitta texturens rådata från filsystemet och bädda in filen i den slutliga FBX-filen. Standardvärdet är falskt. |
+
+ **Result:**
+
+
+
+---
+
+
+### getGenerateVertexElementMaterial{#getGenerateVertexElementMaterial}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getGenerateVertexElementMaterial() | Hämtar eller anger om ett VertexElementMaterial alltid ska genereras för geometrier om den bifogade noden innehåller material. Detta är avstängt som standard. |
+
+ **Result:**
+
+
+
+---
+
+
+### setGenerateVertexElementMaterial{#setGenerateVertexElementMaterial}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setGenerateVertexElementMaterial(value) | Hämtar eller anger om ett VertexElementMaterial alltid ska genereras för geometrier om den bifogade noden innehåller material. Detta är avstängt som standard. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportTextures{#getExportTextures}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExportTextures() | Försök att kopiera texturer som används i scenen till utdatamappen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextures{#setExportTextures}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExportTextures(value) | Försök att kopiera texturer som används i scenen till utdatamappen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileFormat() | Hämtar filformatet som anges i aktuellt Spara/Ladda-alternativ. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEncoding() | Hämtar eller anger standardkodning för textbaserade filer. Standardvärdet är null, vilket betyder att importören/exportören bestämmer vilken kodning som ska användas. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileSystem() | Tillåter användaren att hantera hur externa beroenden ska hanteras under laddning/sparning. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFileSystem(value) | Tillåter användaren att hantera hur externa beroenden ska hanteras under laddning/sparning. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getLookupPaths() | Vissa filer, som OBJ, är beroende av externa filer; sökvägarna gör det möjligt för Aspose.3D att leta efter externa filer att ladda. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileName() | Filnamnet för den exporterade/importerade scenen. Detta är valfritt, men användbart när externa resurser som OBJ:s material serialiseras. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFileName(value) | Filnamnet för den exporterade/importerade scenen. Detta är valfritt, men användbart när externa resurser som OBJ:s material serialiseras. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/fileformat/_index.md
+++ b/swedish/nodejs-java/aspose.threed/fileformat/_index.md
@@ -1,0 +1,187 @@
+---
+title: "Filformat"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/fileformat/
+---
+## FileFormat class
+
+Filformatdefinition  @hideconstructor
+
+
+## Egenskaper
+
+| Namn | Beskrivning |
+| --- | --- |
+| MAYA_BINARY | Autodesk Maya i binärt format |
+| STL_BINARY | Binärt STL-filformat |
+| STLASCII | ASCII STL-filformat |
+| COLLADA | Collada-filformat |
+| GLTF | Khronos Groups glTF |
+| GLTF_BINARY | Khronos Groups glTF i binärt format |
+| PDF | Adobes Portable Document Format |
+| DXF | AutoCAD DXF |
+| PLY | Polygonfilformat eller Stanford Triangle Format |
+| X_BINARY | DirectX X-fil i binärt format |
+| X_TEXT | DirectX X-fil i binärt format |
+| DRACO | Google Draco Mesh |
+| RVM_TEXT | AVEVA Plant Design Management System-modell i textformat |
+| RVM_BINARY | AVEVA Plant Design Management System-modell i binärformat |
+| ASE | 3D Studio Max:s ASCII Scene Exporter-format. |
+| IFC | ISO 16739-1 Industry Foundation Classes-datamodell. |
+| AMF | Additiv tillverkningsfilformat |
+| VRML | Det virtuella verklighetsmodellspråket |
+| ZIP | Zip-arkiv som innehåller andra 3d-filformat. |
+| USD | Universell scenbeskrivning |
+| USDZ | Komprimerad universell scenbeskrivning |
+| XYZ | Xyz-punktmolnsfil |
+| PCD | PCL Point Cloud Data-fil i ASCII-läge |
+| PCD_BINARY | PCL Point Cloud Data-fil i binärt läge |
+
+## Metoder
+
+### getVersion{#getVersion}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getVersion() | Hämtar filformatversion |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtension{#getExtension}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExtension() | Hämtar filändelsens namn för den här typen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtensions{#getExtensions}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExtensions() | Hämtar filändelserna för den här typen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getContentType{#getContentType}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getContentType() | Hämtar filformatets innehållstyp. Värdet på egenskapen är heltalskonstanten FileContentType. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormatType{#getFileFormatType}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileFormatType() | Hämtar filformattyp |
+
+ **Result:**
+
+
+
+---
+
+
+### getFormatByExtension{#getFormatByExtension}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFormatByExtension(extensionName) | Hämtar det föredragna filformatet från filändelsen. Filändelsen bör börja med en punkt ('.'). |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| extensionNam | Sträng | null |
+
+ **Result:**
+Filformat
+
+
+---
+
+
+### detect{#detect}
+
+| Namn | Beskrivning |
+| --- | --- |
+| detect(fileName) | Detektera filformatet från filnamnet, filen måste vara läsbar så att Aspose.3D kan identifiera filformatet via filhuvudet. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| fileNam | Sträng | null |
+
+ **Result:**
+Filformat
+
+
+---
+
+
+### createLoadOptions{#createLoadOptions}
+
+| Namn | Beskrivning |
+| --- | --- |
+| createLoadOptions() | Skapa standardalternativ för inläsning för detta filformat. |
+
+ **Result:**
+LoadOptions
+
+
+---
+
+
+### createSaveOptions{#createSaveOptions}
+
+| Namn | Beskrivning |
+| --- | --- |
+| createSaveOptions() | Skapa standardalternativ för sparning för detta filformat. |
+
+ **Result:**
+SaveOptions
+
+
+---
+
+
+### toString{#toString}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toString() | Formaterar till sträng |
+
+ **Result:**
+Sträng
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/fileformattype/_index.md
+++ b/swedish/nodejs-java/aspose.threed/fileformattype/_index.md
@@ -1,0 +1,66 @@
+---
+title: "FileFormatType"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/fileformattype/
+---
+## FileFormatType class
+
+Filformattyp  @hideconstructor
+
+
+## Egenskaper
+
+| Namn | Beskrivning |
+| --- | --- |
+| MAYA | Autodesk Maya-formattyp |
+| FBX | FBX-filformattyp |
+| STL | STL-filformattyp |
+| COLLADA | Khronos Groups Collada-filformat. |
+| PDF | Portabelt dokumentformat |
+| GLTF | Khronos Groups glTF |
+| DXF | AutoCAD DXF |
+| PLY | Polygonfilformat eller Stanford Triangle Format |
+| X | DirectX:s X-fil |
+| DRACO | Google Draco Mesh |
+| RVM | AVEGA Plant Design Management System-modell. |
+| ASE | 3D Studio Max:s ASCII Scene Exporter-format. |
+| ZIP | Zip-arkiv som innehåller andra 3d-filformat. |
+| USD | Universell scenbeskrivning |
+| PCD | Punktmolnsdata som används av Point Cloud Library |
+| XYZ | Xyz-punktmolnsfil |
+| IFC | ISO 16739-1 Industry Foundation Classes-datamodell. |
+| AMF | Additiv tillverkningsfilformat |
+| VRML | Det virtuella verklighetsmodellspråket |
+
+## Metoder
+
+### getExtension{#getExtension}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExtension() | Filformatets filändelse, som börjar med . |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toString() | Hämta namnet på denna filformatstyp |
+
+ **Result:**
+Sträng
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/filesystem/_index.md
+++ b/swedish/nodejs-java/aspose.threed/filesystem/_index.md
@@ -1,0 +1,56 @@
+---
+title: "Filsystem"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/filesystem/
+---
+## FileSystem class
+
+Filsysteminkapsling.  Aspose.3D kommer att använda detta för att läsa/skriva beroenden.  @hideconstructor
+
+
+## Metoder
+
+### readFile{#readFile}
+
+| Namn | Beskrivning |
+| --- | --- |
+| readFile(fileName, options) | Skapa en ström för att läsa beroenden. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| fileNam | Sträng | null |
+| alternativ | IOConfig | null |
+
+ **Result:**
+Stream
+
+
+---
+
+
+### writeFile{#writeFile}
+
+| Namn | Beskrivning |
+| --- | --- |
+| writeFile(fileName, options) | Skapa en ström för att skriva beroenden. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| fileNam | Sträng | null |
+| alternativ | IOConfig | null |
+
+ **Result:**
+Stream
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/fmatrix4/_index.md
+++ b/swedish/nodejs-java/aspose.threed/fmatrix4/_index.md
@@ -1,0 +1,190 @@
+---
+title: "FMatrix4"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/fmatrix4/
+---
+## FMatrix4 class
+
+4x4-matris med alla komponenter i flyttalstyp
+
+
+## Egenskaper
+
+| Namn | Beskrivning |
+| --- | --- |
+| m00 | m00‑värdet. |
+| m01 | m01‑värdet. |
+| m02 | m02‑värdet. |
+| m03 | m03‑värdet. |
+| m10 | m10‑värdet. |
+| m11 | m11‑värdet. |
+| m12 | Den m12. |
+| m13 | Den m13. |
+| m20 | Den m20. |
+| m21 | Den m21. |
+| m22 | Den m22. |
+| m23 | Den m23. |
+| m30 | Den m30. |
+| m31 | Den m31. |
+| m32 | Den m32. |
+| m33 | Den m33. |
+| IDENTITY | Identitetsmatrisen |
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload(m00, m01, m02, m03, m10, m11, m12, m13, m20, m21, m22, m23, m30, m31, m32, m33) | Initiera instansen av FMatrix4 |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| m0 | Nummer | null |
+| m0 | Nummer | null |
+| m0 | Nummer | null |
+| m0 | Nummer | null |
+| m1 | Nummer | null |
+| m1 | Nummer | null |
+| m1 | Nummer | null |
+| m1 | Nummer | null |
+| m2 | Nummer | null |
+| m2 | Nummer | null |
+| m2 | Nummer | null |
+| m2 | Nummer | null |
+| m3 | Nummer | null |
+| m3 | Nummer | null |
+| m3 | Nummer | null |
+| m3 | Nummer | null |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload2(mat) | Initiera instansen av FMatrix4 från en Matrix4-instans. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| ma | Matrix4 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload3{#constructor_overload3}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload3(r0, r1, r2, r3) | Skapar en matris från 4 rader. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| r0 | FVector4 | R0. |
+| r1 | FVector4 | R1. |
+| r2 | FVector4 | R2. |
+| r3 | FVector4 | R3. |
+
+ **Result:**
+
+
+
+---
+
+
+### concatenate{#concatenate}
+
+| Namn | Beskrivning |
+| --- | --- |
+| concatenate(m2) | Konkatenar de två matriserna |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| m2 | FMatrix4 | M2. |
+
+ **Result:**
+FMatrix4
+
+
+---
+
+
+### concatenate{#concatenate}
+
+| Namn | Beskrivning |
+| --- | --- |
+| concatenate(m2) | Konkatenar de två matriserna |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| m2 | Matrix4 | M2. |
+
+ **Result:**
+FMatrix4
+
+
+---
+
+
+### transpose{#transpose}
+
+| Namn | Beskrivning |
+| --- | --- |
+| transpose() | Transponerar den här instansen. |
+
+ **Result:**
+FMatrix4
+
+
+---
+
+
+### inverse{#inverse}
+
+| Namn | Beskrivning |
+| --- | --- |
+| inverse() | Beräkna den inversa matrisen för den aktuella instansen. |
+
+ **Result:**
+FMatrix4
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/fontfile/_index.md
+++ b/swedish/nodejs-java/aspose.threed/fontfile/_index.md
@@ -1,0 +1,189 @@
+---
+title: "FontFile"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/fontfile/
+---
+## FontFile class
+
+Teckensnittfilen innehåller definitioner för glyfer, den används för att skapa textprofil.  @hideconstructor
+
+
+## Metoder
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### fromFile{#fromFile}
+
+| Namn | Beskrivning |
+| --- | --- |
+| fromFile(fileName) | Läs in FontFile från filnamn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| fileName | Sträng | Sökväg till teckensnittsfilen |
+
+ **Result:**
+FontFile
+
+
+---
+
+
+### parse{#parse}
+
+| Namn | Beskrivning |
+| --- | --- |
+| parse(bytes) | Analysera FontFile från bytes |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| bytes | byte[] | Råinnehåll för OTF-teckensnittfil |
+
+ **Result:**
+FontFile
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/frustum/_index.md
+++ b/swedish/nodejs-java/aspose.threed/frustum/_index.md
@@ -1,0 +1,489 @@
+---
+title: "Frustum"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/frustum/
+---
+## Frustum class
+
+Bas-klassen för Camera och Light  @hideconstructor
+
+
+## Metoder
+
+### getRotationMode{#getRotationMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getRotationMode() | Hämtar eller anger frustumens orienteringsläge. Denna egenskap fungerar endast när Target är null. Om värdet är RotationMode.FIXED_TARGET beräknas riktningen alltid av egenskapen LookAt. Annars beräknas LookAt alltid av Direction. Värdet för egenskapen är heltalskonstanten RotationMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRotationMode{#setRotationMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setRotationMode(value) | Hämtar eller anger frustumens orienteringsläge. Denna egenskap fungerar endast när Target är null. Om värdet är RotationMode.FIXED_TARGET beräknas riktningen alltid av egenskapen LookAt. Annars beräknas LookAt alltid av Direction. Värdet för egenskapen är heltalskonstanten RotationMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getNearPlane{#getNearPlane}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getNearPlane() | Hämtar eller anger frustumens närplanavstånd. |
+
+ **Result:**
+
+
+
+---
+
+
+### setNearPlane{#setNearPlane}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setNearPlane(value) | Hämtar eller anger frustumens närplanavstånd. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFarPlane{#getFarPlane}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFarPlane() | Hämtar eller anger frustumets avstånd till den fjärrplanen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFarPlane{#setFarPlane}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFarPlane(value) | Hämtar eller anger frustumets avstånd till den fjärrplanen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAspect{#getAspect}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getAspect() | Hämtar eller anger bildförhållandet för frustumen |
+
+ **Result:**
+
+
+
+---
+
+
+### setAspect{#setAspect}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setAspect(value) | Hämtar eller anger bildförhållandet för frustumen |
+
+ **Result:**
+
+
+
+---
+
+
+### getOrthoHeight{#getOrthoHeight}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getOrthoHeight() | Hämtar eller anger höjden när frustumen är i ortografisk projektion. |
+
+ **Result:**
+
+
+
+---
+
+
+### setOrthoHeight{#setOrthoHeight}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setOrthoHeight(value) | Hämtar eller anger höjden när frustumen är i ortografisk projektion. |
+
+ **Result:**
+
+
+
+---
+
+
+### getUp{#getUp}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getUp() | Hämtar eller anger kamerans uppåtriktning |
+
+ **Result:**
+
+
+
+---
+
+
+### setUp{#setUp}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setUp(value) | Hämtar eller anger kamerans uppåtriktning |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookAt{#getLookAt}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getLookAt() | Hämtar eller anger den intressanta positionen som kameran tittar på. |
+
+ **Result:**
+
+
+
+---
+
+
+### setLookAt{#setLookAt}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setLookAt(value) | Hämtar eller anger den intressanta positionen som kameran tittar på. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDirection{#getDirection}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getDirection() | Hämtar eller anger den riktning som kameran tittar mot. Ändringar av denna egenskap påverkar också LookAt och Target. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDirection{#setDirection}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setDirection(value) | Hämtar eller anger den riktning som kameran tittar mot. Ändringar av denna egenskap påverkar också LookAt och Target. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTarget{#getTarget}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getTarget() | Hämtar eller anger målet som kameran tittar på. Om användaren stöder denna egenskap bör den vara före LookAt-egenskapen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTarget{#setTarget}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setTarget(value) | Hämtar eller anger målet som kameran tittar på. Om användaren stöder denna egenskap bör den vara före LookAt-egenskapen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNodes() | Hämtar alla föräldranoder, en entitet kan fästas vid flera föräldranoder för geometri‑instansering. Noderna. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExcluded() | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExcluded(value) | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNode() | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setParentNode(value) | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getScene() | Hämtar scenen som detta objekt tillhör |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBoundingBox() | Hämtar den omgivande lådan för den aktuella enheten i dess objektrums koordinatsystem. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEntityRendererKey() | Hämtar nyckeln för enhetens renderare som är registrerad i renderaren |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/fvector2/_index.md
+++ b/swedish/nodejs-java/aspose.threed/fvector2/_index.md
@@ -1,0 +1,126 @@
+---
+title: "FVector2"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/fvector2/
+---
+## FVector2 class
+
+En flyttalsvektor med två komponenter.
+
+
+## Egenskaper
+
+| Namn | Beskrivning |
+| --- | --- |
+| x | x-komponenten. |
+| y | y-komponenten. |
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload(x, y) | Initierar en ny instans av FVector2. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload2(vec) | Initierar en ny instans av FVector2. |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toString() |  |
+
+ **Result:**
+Sträng
+
+
+---
+
+
+### equals{#equals}
+
+| Namn | Beskrivning |
+| --- | --- |
+| equals(rhs) | Kontrollera om två vektorer är lika |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| rh | FVector2 | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### equals{#equals}
+
+| Namn | Beskrivning |
+| --- | --- |
+| equals(obj) | Kontrollera om två vektorer är lika |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| ob | Objekt | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### hashCode{#hashCode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| hashCode() | Hämtar hashkoden för den här instansen |
+
+ **Result:**
+Nummer
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/fvector3/_index.md
+++ b/swedish/nodejs-java/aspose.threed/fvector3/_index.md
@@ -1,0 +1,123 @@
+---
+title: "FVector3"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/fvector3/
+---
+## FVector3 class
+
+En flyttalsvektor med tre komponenter.
+
+
+## Egenskaper
+
+| Namn | Beskrivning |
+| --- | --- |
+| x | x-komponenten. |
+| y | y-komponenten. |
+| z | y-komponenten. |
+| ZERO | Zero-vektorn. |
+| UNIT_SCALE | En enhetsskalevektor med alla komponenter lika med 1 |
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload(x, y, z) | Initierar en ny instans av FVector3. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload2(vec) | Initierar en ny instans av FVector3. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload3{#constructor_overload3}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload3(vec) | Initierar en ny instans av FVector4. |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toString() |  |
+
+ **Result:**
+Sträng
+
+
+---
+
+
+### normalize{#normalize}
+
+| Namn | Beskrivning |
+| --- | --- |
+| normalize() | Normaliserar detta objekt. |
+
+ **Result:**
+FVector3
+
+
+---
+
+
+### cross{#cross}
+
+| Namn | Beskrivning |
+| --- | --- |
+| cross(rhs) | Korsprodukt av två vektorer |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| rhs | FVector3 | Värde för högra sidan. |
+
+ **Result:**
+FVector3
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/fvector4/_index.md
+++ b/swedish/nodejs-java/aspose.threed/fvector4/_index.md
@@ -1,0 +1,116 @@
+---
+title: "FVector4"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/fvector4/
+---
+## FVector4 class
+
+En flyttalsvektor med fyra komponenter.
+
+
+## Egenskaper
+
+| Namn | Beskrivning |
+| --- | --- |
+| x | x-komponenten. |
+| y | y-komponenten. |
+| z | z-komponenten. |
+| w | w-komponenten. |
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload(x, y, z, w) | Initierar en ny instans av FVector4. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload2(x, y, z) | Initierar en ny instans av FVector4. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload3{#constructor_overload3}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload3(vec) | Initierar en ny instans av FVector4. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload4{#constructor_overload4}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload4(vec) | Initierar en ny instans av FVector4. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload5{#constructor_overload5}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload5(vec, w) | Initierar en ny instans av FVector4. |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toString() |  |
+
+ **Result:**
+Sträng
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/geometry/_index.md
+++ b/swedish/nodejs-java/aspose.threed/geometry/_index.md
@@ -1,0 +1,528 @@
+---
+title: "Geometry"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/geometry/
+---
+## Geometry class
+
+Bas-klassen för alla renderbara geometriska objekt (som Mesh, NurbsSurface, Patch osv.).  Geometry-bas-klassen stödjer:  Hantering av kontrollpunkter, kontrollpunkter definierar den grundläggande 3D-rymdstrukturen för geometrin, olika geometrityper har olika sätt att definiera konkreta 3D-modeller. Definition av vertex-element, vertex-element tillför extra information som normaler/uv-koordinater/vertex-färger till geometrin, se VertexElement för mer detaljer. Objektdeformation, Deformer kan bindas för att animera geometrins form.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor(name) | Initierar en ny instans av klassen Geometry. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| name | Sträng | Namn |
+
+ **Result:**
+
+
+
+---
+
+
+### getVisible{#getVisible}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getVisible() | Hämtar eller anger om geometrin är synlig |
+
+ **Result:**
+
+
+
+---
+
+
+### setVisible{#setVisible}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setVisible(value) | Hämtar eller anger om geometrin är synlig |
+
+ **Result:**
+
+
+
+---
+
+
+### getDeformers{#getDeformers}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getDeformers() | Hämtar alla deformers som är associerade med denna geometri. Deformers. |
+
+ **Result:**
+
+
+
+---
+
+
+### getControlPoints{#getControlPoints}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getControlPoints() | Hämtar alla kontrollpunkter |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastShadows{#getCastShadows}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getCastShadows() | Hämtar eller anger om denna geometri kan kasta skugga |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastShadows{#setCastShadows}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setCastShadows(value) | Hämtar eller anger om denna geometri kan kasta skugga |
+
+ **Result:**
+
+
+
+---
+
+
+### getReceiveShadows{#getReceiveShadows}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getReceiveShadows() | Hämtar eller anger om denna geometri kan ta emot skugga. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReceiveShadows{#setReceiveShadows}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setReceiveShadows(value) | Hämtar eller anger om denna geometri kan ta emot skugga. |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElements{#getVertexElements}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getVertexElements() | Hämtar alla vertex elements |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNodes() | Hämtar alla föräldranoder, en entitet kan fästas vid flera föräldranoder för geometri‑instansering. Noderna. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExcluded() | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExcluded(value) | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNode() | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setParentNode(value) | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getScene() | Hämtar scenen som detta objekt tillhör |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### getElement{#getElement}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getElement(type) | Hämtar ett vertex element med angiven typ |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| typ | VertexElementType | VertexElementType |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### getVertexElementOfUV{#getVertexElementOfUV}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getVertexElementOfUV(textureMapping) | Hämtar en VertexElementUV-instans med given texture mapping-typ |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| textureMapping | TextureMapping | TextureMapping |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### createElement{#createElement}
+
+| Namn | Beskrivning |
+| --- | --- |
+| createElement(type) | Skapar ett vertex element med angiven typ och lägger till det i geometrin. Om typen är VertexElementType.UV, skapas ett VertexElementUV med texture mapping-typ till TextureMapping.DIFFUSE. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| typ | VertexElementType | VertexElementType |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### addElement{#addElement}
+
+| Namn | Beskrivning |
+| --- | --- |
+| addElement(element) | Lägger till ett befintligt vertex element i den aktuella geometrin |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| element | VertexElement | Vertex elementet att lägga till |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### createElement{#createElement}
+
+| Namn | Beskrivning |
+| --- | --- |
+| createElement(type, mappingMode, referenceMode) | Skapar ett vertex element med angiven typ och lägger till det i geometrin. Om typen är VertexElementType.UV, skapas ett VertexElementUV med texture mapping-typ till TextureMapping.DIFFUSE. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| typ | VertexElementType | VertexElementType |
+| mappingMode | MappingMode | MappingMode |
+| referenceMode | ReferenceMode | ReferenceMode |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### createElementUV{#createElementUV}
+
+| Namn | Beskrivning |
+| --- | --- |
+| createElementUV(uvMapping) | Skapar ett VertexElementUV med given texturkartläggningstyp. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| uvMapping | TextureMapping | TextureMapping |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### createElementUV{#createElementUV}
+
+| Namn | Beskrivning |
+| --- | --- |
+| createElementUV(uvMapping, mappingMode, referenceMode) | Skapar ett VertexElementUV med given texturkartläggningstyp. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| uvMapping | TextureMapping | TextureMapping |
+| mappingMode | MappingMode | MappingMode |
+| referenceMode | ReferenceMode | ReferenceMode |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBoundingBox() | Hämtar den omgivande lådan för den aktuella enheten i dess objektrums koordinatsystem. |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEntityRendererKey() | Hämtar nyckeln för enhetens renderare som är registrerad i renderaren |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/globaltransform/_index.md
+++ b/swedish/nodejs-java/aspose.threed/globaltransform/_index.md
@@ -1,0 +1,81 @@
+---
+title: "GlobalTransform"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/globaltransform/
+---
+## GlobalTransform class
+
+Global transform är liknande Transform men är oföränderlig medan den representerar den slutgiltiga beräknade transformationen.  Högerhandskoordinatsystem används vid beräkning av global transform  @hideconstructor
+
+
+## Metoder
+
+### getTranslation{#getTranslation}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getTranslation() | Hämtar förflyttningen |
+
+ **Result:**
+
+
+
+---
+
+
+### getScale{#getScale}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getScale() | Hämtar skalan |
+
+ **Result:**
+
+
+
+---
+
+
+### getEulerAngles{#getEulerAngles}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEulerAngles() | Hämtar rotationen representerad i Eulervinklar, mätt i grader |
+
+ **Result:**
+
+
+
+---
+
+
+### getRotation{#getRotation}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getRotation() | Hämtar rotationen som representeras i en kvaternion. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTransformMatrix{#getTransformMatrix}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getTransformMatrix() | Hämtar transformationsmatrisen. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/glslsource/_index.md
+++ b/swedish/nodejs-java/aspose.threed/glslsource/_index.md
@@ -1,0 +1,153 @@
+---
+title: "GLSLSource"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/glslsource/
+---
+## GLSLSource class
+
+Källkoden för shaders i GLSL
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getComputeShader{#getComputeShader}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getComputeShader() | Hämtar eller anger källkoden för compute-shadern. |
+
+ **Result:**
+
+
+
+---
+
+
+### setComputeShader{#setComputeShader}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setComputeShader(value) | Hämtar eller anger källkoden för compute-shadern. |
+
+ **Result:**
+
+
+
+---
+
+
+### getGeometryShader{#getGeometryShader}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getGeometryShader() | Hämtar eller anger källkoden för geometry-shadern. |
+
+ **Result:**
+
+
+
+---
+
+
+### setGeometryShader{#setGeometryShader}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setGeometryShader(value) | Hämtar eller anger källkoden för geometry-shadern. |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexShader{#getVertexShader}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getVertexShader() | Hämtar eller anger källkoden för vertex-shadern |
+
+ **Result:**
+
+
+
+---
+
+
+### setVertexShader{#setVertexShader}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setVertexShader(value) | Hämtar eller anger källkoden för vertex-shadern |
+
+ **Result:**
+
+
+
+---
+
+
+### getFragmentShader{#getFragmentShader}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFragmentShader() | Hämtar eller anger källkoden för fragmentshadern. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFragmentShader{#setFragmentShader}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFragmentShader(value) | Hämtar eller anger källkoden för fragmentshadern. |
+
+ **Result:**
+
+
+
+---
+
+
+### defineInclude{#defineInclude}
+
+| Namn | Beskrivning |
+| --- | --- |
+| defineInclude(fileName, content) | Definiera virtuell fil för #include i GLSL-källkod |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| fileName | Sträng | Filnamn för den virtuella filen |
+| innehåll | Sträng | null |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/gltfloadoptions/_index.md
+++ b/swedish/nodejs-java/aspose.threed/gltfloadoptions/_index.md
@@ -1,0 +1,146 @@
+---
+title: "GltfLoadOptions"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/gltfloadoptions/
+---
+## GltfLoadOptions class
+
+Läsalternativ för glTF-format
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Konstruktor för GltfLoadOptions |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlipTexCoordV{#getFlipTexCoordV}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFlipTexCoordV() | Vänd v(t)-koordinaten i meshens texturkoordinat, standardvärdet är true. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlipTexCoordV{#setFlipTexCoordV}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFlipTexCoordV(value) | Vänd v(t)-koordinaten i meshens texturkoordinat, standardvärdet är true. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileFormat() | Hämtar filformatet som anges i aktuellt Spara/Ladda-alternativ. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEncoding() | Hämtar eller anger standardkodning för textbaserade filer. Standardvärdet är null, vilket betyder att importören/exportören bestämmer vilken kodning som ska användas. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileSystem() | Tillåter användaren att hantera hur externa beroenden ska hanteras under laddning/sparning. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFileSystem(value) | Tillåter användaren att hantera hur externa beroenden ska hanteras under laddning/sparning. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getLookupPaths() | Vissa filer, som OBJ, är beroende av externa filer; sökvägarna gör det möjligt för Aspose.3D att leta efter externa filer att ladda. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileName() | Filnamnet för den exporterade/importerade scenen. Detta är valfritt, men användbart när externa resurser som OBJ:s material serialiseras. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFileName(value) | Filnamnet för den exporterade/importerade scenen. Detta är valfritt, men användbart när externa resurser som OBJ:s material serialiseras. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/gltfsaveoptions/_index.md
+++ b/swedish/nodejs-java/aspose.threed/gltfsaveoptions/_index.md
@@ -1,0 +1,470 @@
+---
+title: "GltfSaveOptions"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/gltfsaveoptions/
+---
+## GltfSaveOptions class
+
+Sparaalternativ för glTF-format.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor(contentType) | Konstruktor för GltfSaveOptions |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| contentType | FileContentType | FileContentType |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload(format) | Konstruktor för GltfSaveOptions |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| form | Filformat | null |
+
+ **Result:**
+
+
+
+---
+
+
+### getPrettyPrint{#getPrettyPrint}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getPrettyPrint() | JSON-innehållet i GLTF-filen är indenterat för mänsklig läsning, standardvärdet är false |
+
+ **Result:**
+
+
+
+---
+
+
+### setPrettyPrint{#setPrettyPrint}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setPrettyPrint(value) | JSON-innehållet i GLTF-filen är indenterat för mänsklig läsning, standardvärdet är false |
+
+ **Result:**
+
+
+
+---
+
+
+### getFallbackNormal{#getFallbackNormal}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFallbackNormal() | När GLTF2-exportören upptäcker en ogiltig normal, kommer detta att användas istället för dess ursprungliga värde för att kringgå valideringen. Standardvärdet är (0, 1, 0) |
+
+ **Result:**
+
+
+
+---
+
+
+### getEmbedAssets{#getEmbedAssets}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEmbedAssets() | Bädda in alla externa resurser som base64 i en enda fil i ASCII-läge, standardvärdet är false. |
+
+ **Result:**
+
+
+
+---
+
+
+### setEmbedAssets{#setEmbedAssets}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setEmbedAssets(value) | Bädda in alla externa resurser som base64 i en enda fil i ASCII-läge, standardvärdet är false. |
+
+ **Result:**
+
+
+
+---
+
+
+### getImageFormat{#getImageFormat}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getImageFormat() | Standard glTF stöder endast PNG/JPG som sitt texturformat, detta alternativ kommer att vägleda hur Aspose.3D konverterar de icke‑standardiserade bilderna till ett stödformat under exporten. Standardvärdet är GltfEmbeddedImageFormat.PNG Värdet på egenskapen är GltfEmbeddedImageFormat heltalskonstant. |
+
+ **Result:**
+
+
+
+---
+
+
+### setImageFormat{#setImageFormat}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setImageFormat(value) | Standard glTF stöder endast PNG/JPG som sitt texturformat, detta alternativ kommer att vägleda hur Aspose.3D konverterar de icke‑standardiserade bilderna till ett stödformat under exporten. Standardvärdet är GltfEmbeddedImageFormat.PNG Värdet på egenskapen är GltfEmbeddedImageFormat heltalskonstant. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMaterialConverter{#getMaterialConverter}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getMaterialConverter() | Anpassad konverterare för att konvertera geometriens material till PBR‑material. Om detta är odefinierat kommer glTF 2.0‑exportören automatiskt att konvertera standardmaterialet till PBR‑material. Standardvärdet är null. Denna egenskap används vid export av en scen till en glTF 2.0‑fil. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMaterialConverter{#setMaterialConverter}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setMaterialConverter(value) | Anpassad konverterare för att konvertera geometriens material till PBR‑material. Om detta är odefinierat kommer glTF 2.0‑exportören automatiskt att konvertera standardmaterialet till PBR‑material. Standardvärdet är null. Denna egenskap används vid export av en scen till en glTF 2.0‑fil. |
+
+ **Result:**
+
+
+
+---
+
+
+### getUseCommonMaterials{#getUseCommonMaterials}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getUseCommonMaterials() | Serialisera material med KHR‑gemensamma material‑tillägg, standardvärdet är false. Att sätta detta till false kommer att få Aspose.3D att exportera en uppsättning vertex/fragment‑shader om #Error Cref: P:Aspose.ThreeD.Formats.GltfSaveOptions.ExportShaders |
+
+ **Result:**
+
+
+
+---
+
+
+### setUseCommonMaterials{#setUseCommonMaterials}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setUseCommonMaterials(value) | Serialisera material med KHR‑gemensamma material‑tillägg, standardvärdet är false. Att sätta detta till false kommer att få Aspose.3D att exportera en uppsättning vertex/fragment‑shader om #Error Cref: P:Aspose.ThreeD.Formats.GltfSaveOptions.ExportShaders |
+
+ **Result:**
+
+
+
+---
+
+
+### getExternalDracoEncoder{#getExternalDracoEncoder}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExternalDracoEncoder() | Använd extern draco‑kodare för att påskynda draco‑komprimeringshastigheten. Aspose.3D kommer att skapa en ny underprocess för att koda meshen till draco‑formatet, använd den på egen risk. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExternalDracoEncoder{#setExternalDracoEncoder}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExternalDracoEncoder(value) | Använd extern draco‑kodare för att påskynda draco‑komprimeringshastigheten. Aspose.3D kommer att skapa en ny underprocess för att koda meshen till draco‑formatet, använd den på egen risk. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlipTexCoordV{#getFlipTexCoordV}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFlipTexCoordV() | Vänd texturkoordinatens v(t)-komponent, standardvärdet är true. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlipTexCoordV{#setFlipTexCoordV}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFlipTexCoordV(value) | Vänd texturkoordinatens v(t)-komponent, standardvärdet är true. |
+
+ **Result:**
+
+
+
+---
+
+
+### getBufferFile{#getBufferFile}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBufferFile() | Filnamnet på den externa bufferfilen som används för att lagra binär data. Om denna fil inte specificeras kommer Aspose.3D att generera ett namn åt dig. Detta ignoreras när glTF exporteras i binärt läge. |
+
+ **Result:**
+
+
+
+---
+
+
+### setBufferFile{#setBufferFile}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setBufferFile(value) | Filnamnet på den externa bufferfilen som används för att lagra binär data. Om denna fil inte specificeras kommer Aspose.3D att generera ett namn åt dig. Detta ignoreras när glTF exporteras i binärt läge. |
+
+ **Result:**
+
+
+
+---
+
+
+### getSaveExtras{#getSaveExtras}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getSaveExtras() | Spara scenobjektets dynamiska egenskaper i 'extra'-fält i den genererade glTF‑filen. Detta är användbart för att tillhandahålla applikationsspecifika data. Standardvärdet är false. |
+
+ **Result:**
+
+
+
+---
+
+
+### setSaveExtras{#setSaveExtras}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setSaveExtras(value) | Spara scenobjektets dynamiska egenskaper i 'extra'-fält i den genererade glTF‑filen. Detta är användbart för att tillhandahålla applikationsspecifika data. Standardvärdet är false. |
+
+ **Result:**
+
+
+
+---
+
+
+### getApplyUnitScale{#getApplyUnitScale}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getApplyUnitScale() | Tillämpa AssetInfo.UnitScaleFactor på meshen. Standardvärdet är falskt. |
+
+ **Result:**
+
+
+
+---
+
+
+### setApplyUnitScale{#setApplyUnitScale}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setApplyUnitScale(value) | Tillämpa AssetInfo.UnitScaleFactor på meshen. Standardvärdet är falskt. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDracoCompression{#getDracoCompression}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getDracoCompression() | Hämtar eller anger om draco‑komprimering ska aktiveras |
+
+ **Result:**
+
+
+
+---
+
+
+### setDracoCompression{#setDracoCompression}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setDracoCompression(value) | Hämtar eller anger om draco‑komprimering ska aktiveras |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportTextures{#getExportTextures}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExportTextures() | Försök att kopiera texturer som används i scenen till utdatamappen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextures{#setExportTextures}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExportTextures(value) | Försök att kopiera texturer som används i scenen till utdatamappen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileFormat() | Hämtar filformatet som anges i aktuellt Spara/Ladda-alternativ. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEncoding() | Hämtar eller anger standardkodning för textbaserade filer. Standardvärdet är null, vilket betyder att importören/exportören bestämmer vilken kodning som ska användas. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileSystem() | Tillåter användaren att hantera hur externa beroenden ska hanteras under laddning/sparning. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFileSystem(value) | Tillåter användaren att hantera hur externa beroenden ska hanteras under laddning/sparning. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getLookupPaths() | Vissa filer, som OBJ, är beroende av externa filer; sökvägarna gör det möjligt för Aspose.3D att leta efter externa filer att ladda. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileName() | Filnamnet för den exporterade/importerade scenen. Detta är valfritt, men användbart när externa resurser som OBJ:s material serialiseras. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFileName(value) | Filnamnet för den exporterade/importerade scenen. Detta är valfritt, men användbart när externa resurser som OBJ:s material serialiseras. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/hollowcircleshape/_index.md
+++ b/swedish/nodejs-java/aspose.threed/hollowcircleshape/_index.md
@@ -1,0 +1,333 @@
+---
+title: "HollowCircleShape"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/hollowcircleshape/
+---
+## HollowCircleShape class
+
+IFC-kompatibel ihålig cirkelprofil.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getWallThickness{#getWallThickness}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getWallThickness() | Hämtar eller anger skillnaden mellan den yttre och inre radien. |
+
+ **Result:**
+
+
+
+---
+
+
+### setWallThickness{#setWallThickness}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setWallThickness(value) | Hämtar eller anger skillnaden mellan den yttre och inre radien. |
+
+ **Result:**
+
+
+
+---
+
+
+### getRadius{#getRadius}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getRadius() | Hämtar eller anger radien på cirkeln. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRadius{#setRadius}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setRadius(value) | Hämtar eller anger radien på cirkeln. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNodes() | Hämtar alla föräldranoder, en entitet kan fästas vid flera föräldranoder för geometri‑instansering. Noderna. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExcluded() | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExcluded(value) | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNode() | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setParentNode(value) | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getScene() | Hämtar scenen som detta objekt tillhör |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtent{#getExtent}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExtent() | Hämtar omfattningen i x- och y-dimension. |
+
+ **Result:**
+Vector2
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEntityRendererKey() | Hämtar nyckeln för enhetens renderare som är registrerad i renderaren |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBoundingBox() | Hämtar den omgivande lådan för den aktuella enheten i dess objektrums koordinatsystem. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/hollowrectangleshape/_index.md
+++ b/swedish/nodejs-java/aspose.threed/hollowrectangleshape/_index.md
@@ -1,0 +1,411 @@
+---
+title: "HollowRectangleShape"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/hollowrectangleshape/
+---
+## HollowRectangleShape class
+
+IFC-kompatibel ihålig rektangulär form med både inre/yttre avrundade hörn.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getWallThickness{#getWallThickness}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getWallThickness() | Tjockleken mellan rektangelns gräns och det inre hålet |
+
+ **Result:**
+
+
+
+---
+
+
+### setWallThickness{#setWallThickness}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setWallThickness(value) | Tjockleken mellan rektangelns gräns och det inre hålet |
+
+ **Result:**
+
+
+
+---
+
+
+### getInnerFilletRadius{#getInnerFilletRadius}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getInnerFilletRadius() | Den inre fillet-radien för den inre rektangeln. |
+
+ **Result:**
+
+
+
+---
+
+
+### setInnerFilletRadius{#setInnerFilletRadius}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setInnerFilletRadius(value) | Den inre fillet-radien för den inre rektangeln. |
+
+ **Result:**
+
+
+
+---
+
+
+### getRoundingRadius{#getRoundingRadius}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getRoundingRadius() | Hämtar eller anger radien för de cirkulära bågarna i alla fyra hörn, mätt i grader. Standardvärdet är 0,0. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRoundingRadius{#setRoundingRadius}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setRoundingRadius(value) | Hämtar eller anger radien för de cirkulära bågarna i alla fyra hörn, mätt i grader. Standardvärdet är 0,0. |
+
+ **Result:**
+
+
+
+---
+
+
+### getXDim{#getXDim}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getXDim() | Hämtar eller anger rektangelns omfattning i x-axelns riktning. Standardvärdet är 2,0. |
+
+ **Result:**
+
+
+
+---
+
+
+### setXDim{#setXDim}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setXDim(value) | Hämtar eller anger rektangelns omfattning i x-axelns riktning. Standardvärdet är 2,0. |
+
+ **Result:**
+
+
+
+---
+
+
+### getYDim{#getYDim}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getYDim() | Hämtar eller anger rektangelns omfattning i y-axelns riktning. Standardvärdet är 2,0. |
+
+ **Result:**
+
+
+
+---
+
+
+### setYDim{#setYDim}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setYDim(value) | Hämtar eller anger rektangelns omfattning i y-axelns riktning. Standardvärdet är 2,0. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNodes() | Hämtar alla föräldranoder, en entitet kan fästas vid flera föräldranoder för geometri‑instansering. Noderna. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExcluded() | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExcluded(value) | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNode() | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setParentNode(value) | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getScene() | Hämtar scenen som detta objekt tillhör |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtent{#getExtent}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExtent() | Hämtar omfattningen i x- och y-dimension. |
+
+ **Result:**
+Vector2
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEntityRendererKey() | Hämtar nyckeln för enhetens renderare som är registrerad i renderaren |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBoundingBox() | Hämtar den omgivande lådan för den aktuella enheten i dess objektrums koordinatsystem. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/hshape/_index.md
+++ b/swedish/nodejs-java/aspose.threed/hshape/_index.md
@@ -1,0 +1,541 @@
+---
+title: "HShape"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/hshape/
+---
+## HShape class
+
+HShape tillhandahåller de definierande parametrarna för en 'H'- eller 'I'-form.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Konstruktor för HShape |
+
+ **Result:**
+
+
+
+---
+
+
+### getOverallDepth{#getOverallDepth}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getOverallDepth() | Hämtar eller anger djupets omfattning. |
+
+ **Result:**
+
+
+
+---
+
+
+### setOverallDepth{#setOverallDepth}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setOverallDepth(value) | Hämtar eller anger djupets omfattning. |
+
+ **Result:**
+
+
+
+---
+
+
+### getBottomFlangeWidth{#getBottomFlangeWidth}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBottomFlangeWidth() | Hämtar eller anger breddens omfattning. |
+
+ **Result:**
+
+
+
+---
+
+
+### setBottomFlangeWidth{#setBottomFlangeWidth}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setBottomFlangeWidth(value) | Hämtar eller anger breddens omfattning. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTopFlangeWidth{#getTopFlangeWidth}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getTopFlangeWidth() | Hämtar eller anger bredden på den övre flänsen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTopFlangeWidth{#setTopFlangeWidth}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setTopFlangeWidth(value) | Hämtar eller anger bredden på den övre flänsen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTopFlangeThickness{#getTopFlangeThickness}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getTopFlangeThickness() | Hämtar eller anger tjockleken på den övre flänsen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTopFlangeThickness{#setTopFlangeThickness}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setTopFlangeThickness(value) | Hämtar eller anger tjockleken på den övre flänsen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTopFlangeEdgeRadius{#getTopFlangeEdgeRadius}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getTopFlangeEdgeRadius() | Hämtar eller anger radien på de nedre kanterna av den övre flänsen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTopFlangeEdgeRadius{#setTopFlangeEdgeRadius}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setTopFlangeEdgeRadius(value) | Hämtar eller anger radien på de nedre kanterna av den övre flänsen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTopFlangeFilletRadius{#getTopFlangeFilletRadius}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getTopFlangeFilletRadius() | Hämtar eller anger radien på avfasningen mellan webben och den övre flänsen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTopFlangeFilletRadius{#setTopFlangeFilletRadius}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setTopFlangeFilletRadius(value) | Hämtar eller anger radien på avfasningen mellan webben och den övre flänsen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getBottomFlangeThickness{#getBottomFlangeThickness}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBottomFlangeThickness() | Hämtar eller anger flänstykkelsen för H-formen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setBottomFlangeThickness{#setBottomFlangeThickness}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setBottomFlangeThickness(value) | Hämtar eller anger flänstykkelsen för H-formen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getWebThickness{#getWebThickness}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getWebThickness() | Hämtar eller anger tjockleken på H-formens webb. |
+
+ **Result:**
+
+
+
+---
+
+
+### setWebThickness{#setWebThickness}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setWebThickness(value) | Hämtar eller anger tjockleken på H-formens webb. |
+
+ **Result:**
+
+
+
+---
+
+
+### getBottomFlangeFilletRadius{#getBottomFlangeFilletRadius}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBottomFlangeFilletRadius() | Hämtar eller anger radien på avrundningen mellan webb och nedre fläns. |
+
+ **Result:**
+
+
+
+---
+
+
+### setBottomFlangeFilletRadius{#setBottomFlangeFilletRadius}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setBottomFlangeFilletRadius(value) | Hämtar eller anger radien på avrundningen mellan webb och nedre fläns. |
+
+ **Result:**
+
+
+
+---
+
+
+### getBottomFlangeEdgeRadius{#getBottomFlangeEdgeRadius}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBottomFlangeEdgeRadius() | Hämtar eller anger radien på de övre kanterna på den nedre flänsen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setBottomFlangeEdgeRadius{#setBottomFlangeEdgeRadius}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setBottomFlangeEdgeRadius(value) | Hämtar eller anger radien på de övre kanterna på den nedre flänsen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNodes() | Hämtar alla föräldranoder, en entitet kan fästas vid flera föräldranoder för geometri‑instansering. Noderna. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExcluded() | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExcluded(value) | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNode() | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setParentNode(value) | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getScene() | Hämtar scenen som detta objekt tillhör |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtent{#getExtent}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExtent() | Hämtar omfattningen i x- och y-dimension. |
+
+ **Result:**
+Vector2
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEntityRendererKey() | Hämtar nyckeln för enhetens renderare som är registrerad i renderaren |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBoundingBox() | Hämtar den omgivande lådan för den aktuella enheten i dess objektrums koordinatsystem. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/html5saveoptions/_index.md
+++ b/swedish/nodejs-java/aspose.threed/html5saveoptions/_index.md
@@ -1,0 +1,406 @@
+---
+title: "Html5SaveOptions"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/html5saveoptions/
+---
+## Html5SaveOptions class
+
+Sparaalternativ för HTML5
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Konstruktor för Html5SaveOptions med alla standardinställningar. |
+
+ **Result:**
+
+
+
+---
+
+
+### getShowGrid{#getShowGrid}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getShowGrid() | Visar ett rutnät i scenen. Standardvärdet är true. |
+
+ **Result:**
+
+
+
+---
+
+
+### setShowGrid{#setShowGrid}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setShowGrid(value) | Visar ett rutnät i scenen. Standardvärdet är true. |
+
+ **Result:**
+
+
+
+---
+
+
+### getShowRulers{#getShowRulers}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getShowRulers() | Visar linjaler för x/y/z-axlarna i scenen för att mäta modellen. Standardvärdet är false. |
+
+ **Result:**
+
+
+
+---
+
+
+### setShowRulers{#setShowRulers}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setShowRulers(value) | Visar linjaler för x/y/z-axlarna i scenen för att mäta modellen. Standardvärdet är false. |
+
+ **Result:**
+
+
+
+---
+
+
+### getShowUI{#getShowUI}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getShowUI() | Visar ett enkelt UI i scenen. Standardvärdet är true. |
+
+ **Result:**
+
+
+
+---
+
+
+### setShowUI{#setShowUI}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setShowUI(value) | Visar ett enkelt UI i scenen. Standardvärdet är true. |
+
+ **Result:**
+
+
+
+---
+
+
+### getOrientationBox{#getOrientationBox}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getOrientationBox() | Visar en orienteringsruta. Standardvärdet är true. |
+
+ **Result:**
+
+
+
+---
+
+
+### setOrientationBox{#setOrientationBox}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setOrientationBox(value) | Visar en orienteringsruta. Standardvärdet är true. |
+
+ **Result:**
+
+
+
+---
+
+
+### getUpVector{#getUpVector}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getUpVector() | Hämtar eller anger uppvektorn, värdet kan vara "x"/"y"/"z", standardvärdet är "y" |
+
+ **Result:**
+
+
+
+---
+
+
+### setUpVector{#setUpVector}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setUpVector(value) | Hämtar eller anger uppvektorn, värdet kan vara "x"/"y"/"z", standardvärdet är "y" |
+
+ **Result:**
+
+
+
+---
+
+
+### getFarPlane{#getFarPlane}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFarPlane() | Hämtar eller anger fjärrplanet för kameran, standardvärdet är 1000. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFarPlane{#setFarPlane}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFarPlane(value) | Hämtar eller anger fjärrplanet för kameran, standardvärdet är 1000. |
+
+ **Result:**
+
+
+
+---
+
+
+### getNearPlane{#getNearPlane}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getNearPlane() | Hämtar eller anger närplanet för kameran, standardvärdet är 1. |
+
+ **Result:**
+
+
+
+---
+
+
+### setNearPlane{#setNearPlane}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setNearPlane(value) | Hämtar eller anger närplanet för kameran, standardvärdet är 1. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookAt{#getLookAt}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getLookAt() | Hämtar eller anger standard blickposition, standardvärdet är (0, 0, 0). |
+
+ **Result:**
+
+
+
+---
+
+
+### setLookAt{#setLookAt}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setLookAt(value) | Hämtar eller anger standard blickposition, standardvärdet är (0, 0, 0). |
+
+ **Result:**
+
+
+
+---
+
+
+### getCameraPosition{#getCameraPosition}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getCameraPosition() | Hämtar eller anger den initiala positionen för kameran, standardvärdet är (10, 10, 10). |
+
+ **Result:**
+
+
+
+---
+
+
+### setCameraPosition{#setCameraPosition}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setCameraPosition(value) | Hämtar eller anger den initiala positionen för kameran, standardvärdet är (10, 10, 10). |
+
+ **Result:**
+
+
+
+---
+
+
+### getFieldOfView{#getFieldOfView}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFieldOfView() | Hämtar eller anger synfältet, standardvärdet är 45, mätt i grader. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFieldOfView{#setFieldOfView}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFieldOfView(value) | Hämtar eller anger synfältet, standardvärdet är 45, mätt i grader. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportTextures{#getExportTextures}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExportTextures() | Försök att kopiera texturer som används i scenen till utdatamappen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextures{#setExportTextures}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExportTextures(value) | Försök att kopiera texturer som används i scenen till utdatamappen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileFormat() | Hämtar filformatet som anges i aktuellt Spara/Ladda-alternativ. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEncoding() | Hämtar eller anger standardkodning för textbaserade filer. Standardvärdet är null, vilket betyder att importören/exportören bestämmer vilken kodning som ska användas. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileSystem() | Tillåter användaren att hantera hur externa beroenden ska hanteras under laddning/sparning. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFileSystem(value) | Tillåter användaren att hantera hur externa beroenden ska hanteras under laddning/sparning. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getLookupPaths() | Vissa filer, som OBJ, är beroende av externa filer; sökvägarna gör det möjligt för Aspose.3D att leta efter externa filer att ladda. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileName() | Filnamnet för den exporterade/importerade scenen. Detta är valfritt, men användbart när externa resurser som OBJ:s material serialiseras. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFileName(value) | Filnamnet för den exporterade/importerade scenen. Detta är valfritt, men användbart när externa resurser som OBJ:s material serialiseras. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/imagerenderoptions/_index.md
+++ b/swedish/nodejs-java/aspose.threed/imagerenderoptions/_index.md
@@ -1,0 +1,229 @@
+---
+title: "ImageRenderOptions"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/imagerenderoptions/
+---
+## ImageRenderOptions class
+
+Alternativ för Scene.render(com.aspose.threed.Camera, java.lang.String, com.aspose.threed.Vector2, java.lang.String, com.aspose.threed.ImageRenderOptions) och  Scene.render(com.aspose.threed.Camera, com.aspose.threed.TextureData, com.aspose.threed.ImageRenderOptions)
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Initiera en instans av ImageRenderOptions |
+
+ **Result:**
+
+
+
+---
+
+
+### getBackgroundColor{#getBackgroundColor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBackgroundColor() | Bakgrundsfärgen på renderingsresultatet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setBackgroundColor{#setBackgroundColor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setBackgroundColor(value) | Bakgrundsfärgen på renderingsresultatet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAssetDirectories{#getAssetDirectories}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getAssetDirectories() | Kataloger som lagrar externa tillgångar (t.ex. texturer) |
+
+ **Result:**
+
+
+
+---
+
+
+### getEnableShadows{#getEnableShadows}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEnableShadows() | Hämtar eller anger om skuggor ska renderas. |
+
+ **Result:**
+
+
+
+---
+
+
+### setEnableShadows{#setEnableShadows}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setEnableShadows(value) | Hämtar eller anger om skuggor ska renderas. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/importexception/_index.md
+++ b/swedish/nodejs-java/aspose.threed/importexception/_index.md
@@ -1,0 +1,35 @@
+---
+title: "ImportException"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/importexception/
+---
+## ImportException class
+
+Undantag när Aspose.3D misslyckades med att öppna den angivna källan
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor(msg) | Initierar en ny instans |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| msg | Sträng | Felmeddelande |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/indexdatatype/_index.md
+++ b/swedish/nodejs-java/aspose.threed/indexdatatype/_index.md
@@ -1,0 +1,13 @@
+---
+title: "IndexDataType"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/indexdatatype/
+---
+## IndexDataType class
+
+Verktygsklass som innehåller konstanter.  Datatypen för elementen i com.aspose.threed.IIndexBuffer  @hideconstructor
+
+

--- a/swedish/nodejs-java/aspose.threed/initializationexception/_index.md
+++ b/swedish/nodejs-java/aspose.threed/initializationexception/_index.md
@@ -1,0 +1,42 @@
+---
+title: "InitializationException"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/initializationexception/
+---
+## InitializationException class
+
+Undantag vid initiering av renderingspipeline
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Initiera en InitializationException-instans |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload(msg) | Initiera en InitializationException-instans med angivet undantagsmeddelande. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/ioconfig/_index.md
+++ b/swedish/nodejs-java/aspose.threed/ioconfig/_index.md
@@ -1,0 +1,133 @@
+---
+title: "IOConfig"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/ioconfig/
+---
+## IOConfig class
+
+IO-konfiguration för serialisering/deserialisering.  Användaren kan ange detaljerade konfigurationer som beroendeuppslagningsväg  Eller formatrelaterade konfigurationer här  @hideconstructor
+
+
+## Metoder
+
+### getFileSystemFactory{#getFileSystemFactory}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileSystemFactory() | Hämtar eller anger fabrikklassen för FileSystem. Standardfabriken skapar LocalFileSystem som inte är lämplig för servermiljö. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystemFactory{#setFileSystemFactory}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFileSystemFactory(value) | Hämtar eller anger fabrikklassen för FileSystem. Standardfabriken skapar LocalFileSystem som inte är lämplig för servermiljö. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileFormat() | Hämtar filformatet som anges i aktuellt Spara/Ladda-alternativ. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEncoding() | Hämtar eller anger standardkodning för textbaserade filer. Standardvärdet är null, vilket betyder att importören/exportören bestämmer vilken kodning som ska användas. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileSystem() | Tillåter användaren att hantera hur externa beroenden ska hanteras under laddning/sparning. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFileSystem(value) | Tillåter användaren att hantera hur externa beroenden ska hanteras under laddning/sparning. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getLookupPaths() | Vissa filer, som OBJ, är beroende av externa filer; sökvägarna gör det möjligt för Aspose.3D att leta efter externa filer att ladda. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileName() | Filnamnet för den exporterade/importerade scenen. Detta är valfritt, men användbart när externa resurser som OBJ:s material serialiseras. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFileName(value) | Filnamnet för den exporterade/importerade scenen. Detta är valfritt, men användbart när externa resurser som OBJ:s material serialiseras. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/ioutils/_index.md
+++ b/swedish/nodejs-java/aspose.threed/ioutils/_index.md
@@ -1,0 +1,13 @@
+---
+title: "IOUtils"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/ioutils/
+---
+## IOUtils class
+
+Verktyg för att skriva matris/vektor till binär skrivare  @hideconstructor
+
+

--- a/swedish/nodejs-java/aspose.threed/keyframe/_index.md
+++ b/swedish/nodejs-java/aspose.threed/keyframe/_index.md
@@ -1,0 +1,439 @@
+---
+title: "KeyFrame"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/keyframe/
+---
+## KeyFrame class
+
+En nyckelram definieras huvudsakligen av en tid och ett värde, för vissa interpoleringstyper används även tangent/spänning/bias/kontinuitet vid beräkning av det slutliga samplade värdet.  Samplade värden i en tidpunkt utan nyckelram interpoleras av nyckelramar mellan föregående och nästa nyckelram.  Värden före/efter den första/sista nyckelramen beräknas av klassen Extrapolation.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor(curve, time) | Skapa en ny nyckelram på angiven kurva |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| curve | KeyframeSequence | Kurvan som nyckelbilden kommer att skapas på |
+| tid | Nummer | Tidspositionen för nyckelbilden |
+
+ **Result:**
+
+
+
+---
+
+
+### getTime{#getTime}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getTime() | Hämtar eller anger tidspositionen för list.data[index] nyckelbild, mätt i sekunder. Tiden. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTime{#setTime}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setTime(value) | Hämtar eller anger tidspositionen för list.data[index] nyckelbild, mätt i sekunder. Tiden. |
+
+ **Result:**
+
+
+
+---
+
+
+### getValue{#getValue}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getValue() | Hämtar eller anger nyckelbildens värde. Värdet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setValue{#setValue}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setValue(value) | Hämtar eller anger nyckelbildens värde. Värdet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getInterpolation{#getInterpolation}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getInterpolation() | Hämtar eller anger nyckelns interpoleringstyp, list.data[index] definierar algoritmen för hur det samplade värdet beräknas. Värdet på egenskapen är Interpolation heltalskonstant.Interpoleringen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setInterpolation{#setInterpolation}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setInterpolation(value) | Hämtar eller anger nyckelns interpoleringstyp, list.data[index] definierar algoritmen för hur det samplade värdet beräknas. Värdet på egenskapen är Interpolation heltalskonstant.Interpoleringen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTangentWeightMode{#getTangentWeightMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getTangentWeightMode() | Hämtar eller anger nyckelns tangentviktläge. Den utgående tangenten eller nästa ingående tangent kan anpassas genom att välja rätt WeightedModeVärdet på egenskapen är WeightedMode heltalskonstant.Tangentviktläget. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTangentWeightMode{#setTangentWeightMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setTangentWeightMode(value) | Hämtar eller anger nyckelns tangentviktläge. Den utgående tangenten eller nästa ingående tangent kan anpassas genom att välja rätt WeightedModeVärdet på egenskapen är WeightedMode heltalskonstant.Tangentviktläget. |
+
+ **Result:**
+
+
+
+---
+
+
+### getStepMode{#getStepMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getStepMode() | Hämtar eller anger nyckelns stegläge. Om interpoleringstypen är Interpolation.CONSTANT, bestämmer list.data[index] vilket nyckelbildsvärde som ska användas under interpolering. Ett StepMode.PREVIOUS_VALUE betyder att det vänstra nyckelbildsvärdet kommer att användas Ett StepMode.NEXT_VALUE betyder att nästa högra nyckelbildsvärde kommer att användas Värdet på egenskapen är StepMode heltalskonstant.Stegläget. |
+
+ **Result:**
+
+
+
+---
+
+
+### setStepMode{#setStepMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setStepMode(value) | Hämtar eller anger nyckelns stegläge. Om interpoleringstypen är Interpolation.CONSTANT, bestämmer list.data[index] vilket nyckelbildsvärde som ska användas under interpolering. Ett StepMode.PREVIOUS_VALUE betyder att det vänstra nyckelbildsvärdet kommer att användas Ett StepMode.NEXT_VALUE betyder att nästa högra nyckelbildsvärde kommer att användas Värdet på egenskapen är StepMode heltalskonstant.Stegläget. |
+
+ **Result:**
+
+
+
+---
+
+
+### getNextInTangent{#getNextInTangent}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getNextInTangent() | Hämtar eller anger nästa ingående (vänstra) tangent på denna nyckelbild. |
+
+ **Result:**
+
+
+
+---
+
+
+### setNextInTangent{#setNextInTangent}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setNextInTangent(value) | Hämtar eller anger nästa ingående (vänstra) tangent på denna nyckelbild. |
+
+ **Result:**
+
+
+
+---
+
+
+### getOutTangent{#getOutTangent}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getOutTangent() | Hämtar eller anger den utgående (högra) tangenten på denna nyckelbild. |
+
+ **Result:**
+
+
+
+---
+
+
+### setOutTangent{#setOutTangent}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setOutTangent(value) | Hämtar eller anger den utgående (högra) tangenten på denna nyckelbild. |
+
+ **Result:**
+
+
+
+---
+
+
+### getOutWeight{#getOutWeight}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getOutWeight() | Hämtar eller anger den utgående (högra) vikten på denna nyckelbild. |
+
+ **Result:**
+
+
+
+---
+
+
+### setOutWeight{#setOutWeight}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setOutWeight(value) | Hämtar eller anger den utgående (högra) vikten på denna nyckelbild. |
+
+ **Result:**
+
+
+
+---
+
+
+### getNextInWeight{#getNextInWeight}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getNextInWeight() | Hämtar eller anger nästa in(left) vikt på detta nyckelbild. |
+
+ **Result:**
+
+
+
+---
+
+
+### setNextInWeight{#setNextInWeight}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setNextInWeight(value) | Hämtar eller anger nästa in(left) vikt på detta nyckelbild. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTension{#getTension}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getTension() | Hämtar eller anger spänning som används i TCB-spline |
+
+ **Result:**
+
+
+
+---
+
+
+### setTension{#setTension}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setTension(value) | Hämtar eller anger spänning som används i TCB-spline |
+
+ **Result:**
+
+
+
+---
+
+
+### getContinuity{#getContinuity}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getContinuity() | Hämtar eller anger kontinuiteten som används i TCB-spline |
+
+ **Result:**
+
+
+
+---
+
+
+### setContinuity{#setContinuity}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setContinuity(value) | Hämtar eller anger kontinuiteten som används i TCB-spline |
+
+ **Result:**
+
+
+
+---
+
+
+### getBias{#getBias}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBias() | Hämtar eller anger bias som används i TCB-spline |
+
+ **Result:**
+
+
+
+---
+
+
+### setBias{#setBias}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setBias(value) | Hämtar eller anger bias som används i TCB-spline |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndependentTangent{#getIndependentTangent}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getIndependentTangent() | Hämtar eller anger att ut- och nästa in-tangenter är oberoende. |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndependentTangent{#setIndependentTangent}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setIndependentTangent(value) | Hämtar eller anger att ut- och nästa in-tangenter är oberoende. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlat{#getFlat}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFlat() | Hämta eller ange om nyckelbilden är platt. Nyckelbilden bör vara platt om nästa eller föregående nyckelbild har samma värde. En platt nyckelbild har platta tangenter och fast interpolation. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlat{#setFlat}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFlat(value) | Hämta eller ange om nyckelbilden är platt. Nyckelbilden bör vara platt om nästa eller föregående nyckelbild har samma värde. En platt nyckelbild har platta tangenter och fast interpolation. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTimeIndependentTangent{#getTimeIndependentTangent}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getTimeIndependentTangent() | Hämtar eller anger att tangenten är tidsoberoende |
+
+ **Result:**
+
+
+
+---
+
+
+### setTimeIndependentTangent{#setTimeIndependentTangent}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setTimeIndependentTangent(value) | Hämtar eller anger att tangenten är tidsoberoende |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toString() | Hämtar strängrepresentationen av nyckelbilden |
+
+ **Result:**
+Sträng
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/keyframesequence/_index.md
+++ b/swedish/nodejs-java/aspose.threed/keyframesequence/_index.md
@@ -1,0 +1,302 @@
+---
+title: "KeyframeSequence"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/keyframesequence/
+---
+## KeyframeSequence class
+
+Sekvensen av nyckelramar beskriver transformationen av ett samplat värde över tid.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor(name) | Initierar en ny instans av klassen KeyframeSequence. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| name | Sträng | Namn |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload() | Initierar en ny instans av klassen KeyframeSequence. |
+
+ **Result:**
+
+
+
+---
+
+
+### getBindPoint{#getBindPoint}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBindPoint() | Hämtar egenskapsbindningspunkten som äger denna kurva |
+
+ **Result:**
+
+
+
+---
+
+
+### getKeyFrames{#getKeyFrames}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getKeyFrames() | Hämtar nyckelramarna för denna kurva. Nycklarna. |
+
+ **Result:**
+
+
+
+---
+
+
+### getPostBehavior{#getPostBehavior}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getPostBehavior() | Hämtar postbeteendet som anger vad det samplade värdet ska vara efter den sista nyckelramen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getPreBehavior{#getPreBehavior}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getPreBehavior() | Hämtar förbeteendet som anger vad det samplade värdet ska vara innan den första nyckeln. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### add{#add}
+
+| Namn | Beskrivning |
+| --- | --- |
+| add(time, value) | Skapa en ny nyckelram med angivet värde |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| tid | Nummer | Tidsposition (uppmätt i sekunder) |
+| värde | Nummer | Värdet vid denna tidsposition |
+
+ **Result:**
+
+
+
+---
+
+
+### add{#add}
+
+| Namn | Beskrivning |
+| --- | --- |
+| add(time, value, interpolation) | Skapa en ny nyckelram med angivet värde |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| tid | Nummer | Tidsposition (uppmätt i sekunder) |
+| värde | Nummer | Värdet vid denna tidsposition |
+| interpolering | Interpolering | Interpolering |
+
+ **Result:**
+
+
+
+---
+
+
+### reset{#reset}
+
+| Namn | Beskrivning |
+| --- | --- |
+| reset() | Tar bort alla nyckelramar och återställer post-/pre‑beteenden. |
+
+ **Result:**
+
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+### iterator{#iterator}
+
+| Namn | Beskrivning |
+| --- | --- |
+| iterator() | Reserverad för internt bruk. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/lambertmaterial/_index.md
+++ b/swedish/nodejs-java/aspose.threed/lambertmaterial/_index.md
@@ -1,0 +1,378 @@
+---
+title: "LambertMaterial"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/lambertmaterial/
+---
+## LambertMaterial class
+
+Material för lambert-skuggningsmodell
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Initierar en ny instans av klassen LambertMaterial. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload(name) | Initierar en ny instans av klassen LambertMaterial. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| name | Sträng | Namn |
+
+ **Result:**
+
+
+
+---
+
+
+### getEmissiveColor{#getEmissiveColor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEmissiveColor() | Hämtar eller anger den emissiva färgen |
+
+ **Result:**
+
+
+
+---
+
+
+### setEmissiveColor{#setEmissiveColor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setEmissiveColor(value) | Hämtar eller anger den emissiva färgen |
+
+ **Result:**
+
+
+
+---
+
+
+### getAmbientColor{#getAmbientColor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getAmbientColor() | Hämtar eller anger den omgivande färgen. Exempel: var mat = new LambertMaterial(); mat.AmbientColor = new Vector3(1, 1, 1); ambient. |
+
+ **Result:**
+
+
+
+---
+
+
+### setAmbientColor{#setAmbientColor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setAmbientColor(value) | Hämtar eller anger den omgivande färgen. Exempel: var mat = new LambertMaterial(); mat.AmbientColor = new Vector3(1, 1, 1); ambient. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDiffuseColor{#getDiffuseColor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getDiffuseColor() | Hämtar eller anger den diffusa färgen Exempel: var mat = new LambertMaterial(); mat.DiffuseColor = new Vector3(1, 0, 0); diffus. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDiffuseColor{#setDiffuseColor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setDiffuseColor(value) | Hämtar eller anger den diffusa färgen Exempel: var mat = new LambertMaterial(); mat.DiffuseColor = new Vector3(1, 0, 0); diffus. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTransparentColor{#getTransparentColor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getTransparentColor() | Hämtar eller anger den transparenta färgen. Exempel: var mat = new LambertMaterial(); mat.TransparentColor = new Vector3(0.3, 0.5, 0.2); färgen på den transparenta. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTransparentColor{#setTransparentColor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setTransparentColor(value) | Hämtar eller anger den transparenta färgen. Exempel: var mat = new LambertMaterial(); mat.TransparentColor = new Vector3(0.3, 0.5, 0.2); färgen på den transparenta. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTransparency{#getTransparency}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getTransparency() | Hämtar eller anger transparensfaktorn. Faktorn bör ligga mellan 0 (0 %, helt ogenomskinlig) och 1 (100 %, helt genomskinlig). Alla ogiltiga faktorer kommer att klippas. Exempel: var mat = new LambertMaterial(); mat.Transparency = 0.3; transparensfaktor. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTransparency{#setTransparency}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setTransparency(value) | Hämtar eller anger transparensfaktorn. Faktorn bör ligga mellan 0 (0 %, helt ogenomskinlig) och 1 (100 %, helt genomskinlig). Alla ogiltiga faktorer kommer att klippas. Exempel: var mat = new LambertMaterial(); mat.Transparency = 0.3; transparensfaktor. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTexture{#getTexture}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getTexture(slotName) | Hämtar texturen från den angivna sloten, den kan vara materialets egenskapsnamn eller shaderns parameternamn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| slotName | Sträng | Slotnamn. |
+
+ **Result:**
+TextureBase
+
+
+---
+
+
+### setTexture{#setTexture}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setTexture(slotName, texture) | Anger texturen till den angivna sloten |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| slotName | Sträng | Slotnamn. |
+| texture | TextureBase | Textur. |
+
+ **Result:**
+TextureBase
+
+
+---
+
+
+### toString{#toString}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toString() | Formaterar objekt till sträng. |
+
+ **Result:**
+Sträng
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+### iterator{#iterator}
+
+| Namn | Beskrivning |
+| --- | --- |
+| iterator() | Reserverad för internt bruk. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/license/_index.md
+++ b/swedish/nodejs-java/aspose.threed/license/_index.md
@@ -1,0 +1,61 @@
+---
+title: "Licens"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/license/
+---
+## License class
+
+Tillhandahåller metoder för att licensiera komponenten.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Initierar en ny instans av den här klassen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setLicense{#setLicense}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setLicense(licenseName) | Licensierar komponenten. Försöker hitta licensen på följande platser:1. Explicit sökväg.2. Mappen som innehåller Aspose-komponentens JAR-fil.3. Mappen som innehåller klientens anropande JAR-fil. |
+
+ **Result:**
+
+
+
+---
+
+
+### setLicense{#setLicense}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setLicense(stream) | Licensierar komponenten. Använd den här metoden för att läsa in en licens från en ström. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| ström | InputStream | En ström som innehåller licensen. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/light/_index.md
+++ b/swedish/nodejs-java/aspose.threed/light/_index.md
@@ -1,0 +1,827 @@
+---
+title: "Light"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/light/
+---
+## Light class
+
+Ljuset lyser upp scenen. Formeln för att beräkna den totala dämpningen av ljuset är:  A = ConstantAttenuation + (Dist  LinearAttenuation) + ((Dist^2)  QuadraticAttenuation)
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Initierar en ny instans av Light-klassen. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload(name) | Initierar en ny instans av Light-klassen. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| name | Sträng | Namn |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload2(name, type) | Initierar en ny instans av Light-klassen. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| name | Sträng | Namn |
+| typ | LightType | LightType |
+
+ **Result:**
+
+
+
+---
+
+
+### getColor{#getColor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getColor() | Hämtar eller anger ljusets färg |
+
+ **Result:**
+
+
+
+---
+
+
+### setColor{#setColor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setColor(value) | Hämtar eller anger ljusets färg |
+
+ **Result:**
+
+
+
+---
+
+
+### getLightType{#getLightType}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getLightType() | Hämtar eller anger ljusets typ. Värdet på egenskapen är en heltalskonstant av typen LightType. |
+
+ **Result:**
+
+
+
+---
+
+
+### setLightType{#setLightType}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setLightType(value) | Hämtar eller anger ljusets typ. Värdet på egenskapen är en heltalskonstant av typen LightType. |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastLight{#getCastLight}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getCastLight() | Hämtar eller anger om den aktuella ljusinstansen kan belysa andra objekt. |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastLight{#setCastLight}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setCastLight(value) | Hämtar eller anger om den aktuella ljusinstansen kan belysa andra objekt. |
+
+ **Result:**
+
+
+
+---
+
+
+### getIntensity{#getIntensity}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getIntensity() | Hämtar eller anger ljusets intensitet, standardvärdet är 100 |
+
+ **Result:**
+
+
+
+---
+
+
+### setIntensity{#setIntensity}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setIntensity(value) | Hämtar eller anger ljusets intensitet, standardvärdet är 100 |
+
+ **Result:**
+
+
+
+---
+
+
+### getHotSpot{#getHotSpot}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getHotSpot() | Hämtar eller anger hot spot-konvinkeln (i grader). |
+
+ **Result:**
+
+
+
+---
+
+
+### setHotSpot{#setHotSpot}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setHotSpot(value) | Hämtar eller anger hot spot-konvinkeln (i grader). |
+
+ **Result:**
+
+
+
+---
+
+
+### getFalloff{#getFalloff}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFalloff() | Hämtar eller anger falloff-konvinkeln (i grader). |
+
+ **Result:**
+
+
+
+---
+
+
+### setFalloff{#setFalloff}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFalloff(value) | Hämtar eller anger falloff-konvinkeln (i grader). |
+
+ **Result:**
+
+
+
+---
+
+
+### getConstantAttenuation{#getConstantAttenuation}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getConstantAttenuation() | Hämtar eller anger den konstanta dämpningen för att beräkna den totala dämpningen av ljuset |
+
+ **Result:**
+
+
+
+---
+
+
+### setConstantAttenuation{#setConstantAttenuation}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setConstantAttenuation(value) | Hämtar eller anger den konstanta dämpningen för att beräkna den totala dämpningen av ljuset |
+
+ **Result:**
+
+
+
+---
+
+
+### getLinearAttenuation{#getLinearAttenuation}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getLinearAttenuation() | Hämtar eller anger den linjära dämpningen för att beräkna den totala dämpningen av ljuset |
+
+ **Result:**
+
+
+
+---
+
+
+### setLinearAttenuation{#setLinearAttenuation}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setLinearAttenuation(value) | Hämtar eller anger den linjära dämpningen för att beräkna den totala dämpningen av ljuset |
+
+ **Result:**
+
+
+
+---
+
+
+### getQuadraticAttenuation{#getQuadraticAttenuation}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getQuadraticAttenuation() | Hämtar eller anger den kvadratiska dämpningen för att beräkna den totala dämpningen av ljuset |
+
+ **Result:**
+
+
+
+---
+
+
+### setQuadraticAttenuation{#setQuadraticAttenuation}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setQuadraticAttenuation(value) | Hämtar eller anger den kvadratiska dämpningen för att beräkna den totala dämpningen av ljuset |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastShadows{#getCastShadows}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getCastShadows() | Hämtar eller anger om ljuset kan kasta skuggor på andra objekt. |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastShadows{#setCastShadows}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setCastShadows(value) | Hämtar eller anger om ljuset kan kasta skuggor på andra objekt. |
+
+ **Result:**
+
+
+
+---
+
+
+### getShadowColor{#getShadowColor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getShadowColor() | Hämtar eller anger skuggans färg. |
+
+ **Result:**
+
+
+
+---
+
+
+### setShadowColor{#setShadowColor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setShadowColor(value) | Hämtar eller anger skuggans färg. |
+
+ **Result:**
+
+
+
+---
+
+
+### getRotationMode{#getRotationMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getRotationMode() | Hämtar eller anger frustumens orienteringsläge. Denna egenskap fungerar endast när Target är null. Om värdet är RotationMode.FIXED_TARGET beräknas riktningen alltid av egenskapen LookAt. Annars beräknas LookAt alltid av Direction. Värdet för egenskapen är heltalskonstanten RotationMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRotationMode{#setRotationMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setRotationMode(value) | Hämtar eller anger frustumens orienteringsläge. Denna egenskap fungerar endast när Target är null. Om värdet är RotationMode.FIXED_TARGET beräknas riktningen alltid av egenskapen LookAt. Annars beräknas LookAt alltid av Direction. Värdet för egenskapen är heltalskonstanten RotationMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getNearPlane{#getNearPlane}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getNearPlane() | Hämtar eller anger frustumens närplanavstånd. |
+
+ **Result:**
+
+
+
+---
+
+
+### setNearPlane{#setNearPlane}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setNearPlane(value) | Hämtar eller anger frustumens närplanavstånd. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFarPlane{#getFarPlane}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFarPlane() | Hämtar eller anger frustumets avstånd till den fjärrplanen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFarPlane{#setFarPlane}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFarPlane(value) | Hämtar eller anger frustumets avstånd till den fjärrplanen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAspect{#getAspect}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getAspect() | Hämtar eller anger bildförhållandet för frustumen |
+
+ **Result:**
+
+
+
+---
+
+
+### setAspect{#setAspect}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setAspect(value) | Hämtar eller anger bildförhållandet för frustumen |
+
+ **Result:**
+
+
+
+---
+
+
+### getOrthoHeight{#getOrthoHeight}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getOrthoHeight() | Hämtar eller anger höjden när frustumen är i ortografisk projektion. |
+
+ **Result:**
+
+
+
+---
+
+
+### setOrthoHeight{#setOrthoHeight}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setOrthoHeight(value) | Hämtar eller anger höjden när frustumen är i ortografisk projektion. |
+
+ **Result:**
+
+
+
+---
+
+
+### getUp{#getUp}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getUp() | Hämtar eller anger kamerans uppåtriktning |
+
+ **Result:**
+
+
+
+---
+
+
+### setUp{#setUp}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setUp(value) | Hämtar eller anger kamerans uppåtriktning |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookAt{#getLookAt}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getLookAt() | Hämtar eller anger den intressanta positionen som kameran tittar på. |
+
+ **Result:**
+
+
+
+---
+
+
+### setLookAt{#setLookAt}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setLookAt(value) | Hämtar eller anger den intressanta positionen som kameran tittar på. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDirection{#getDirection}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getDirection() | Hämtar eller anger den riktning som kameran tittar mot. Ändringar av denna egenskap påverkar också LookAt och Target. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDirection{#setDirection}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setDirection(value) | Hämtar eller anger den riktning som kameran tittar mot. Ändringar av denna egenskap påverkar också LookAt och Target. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTarget{#getTarget}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getTarget() | Hämtar eller anger målet som kameran tittar på. Om användaren stöder denna egenskap bör den vara före LookAt-egenskapen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTarget{#setTarget}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setTarget(value) | Hämtar eller anger målet som kameran tittar på. Om användaren stöder denna egenskap bör den vara före LookAt-egenskapen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNodes() | Hämtar alla föräldranoder, en entitet kan fästas vid flera föräldranoder för geometri‑instansering. Noderna. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExcluded() | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExcluded(value) | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNode() | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setParentNode(value) | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getScene() | Hämtar scenen som detta objekt tillhör |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBoundingBox() | Hämtar den omgivande lådan för den aktuella enheten i dess objektrums koordinatsystem. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEntityRendererKey() | Hämtar nyckeln för enhetens renderare som är registrerad i renderaren |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/line/_index.md
+++ b/swedish/nodejs-java/aspose.threed/line/_index.md
@@ -1,0 +1,397 @@
+---
+title: "Line"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/line/
+---
+## Line class
+
+En polylinje är en bana som definieras av en uppsättning punkter med Geometry.ControlPoints och som är sammankopplade med Segment, vilket betyder att den också kan vara en uppsättning sammankopplade linjesegment. Linjen är vanligtvis ett linjärt objekt, vilket innebär att den inte kan användas för att representera en kurva; för att representera en kurva används NurbsCurve.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Initierar en ny instans av Line-klassen. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload(name) | Initierar en ny instans av Line-klassen. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| name | Sträng | Namn. |
+
+ **Result:**
+
+
+
+---
+
+
+### getControlPoints{#getControlPoints}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getControlPoints() | Hämtar alla kontrollpunkter |
+
+ **Result:**
+
+
+
+---
+
+
+### getVisible{#getVisible}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getVisible() | Hämtar eller anger om geometrin är synlig |
+
+ **Result:**
+
+
+
+---
+
+
+### setVisible{#setVisible}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setVisible(value) | Hämtar eller anger om geometrin är synlig |
+
+ **Result:**
+
+
+
+---
+
+
+### getSegments{#getSegments}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getSegments() | Hämtar segmenten i linjen |
+
+ **Result:**
+
+
+
+---
+
+
+### getColor{#getColor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getColor() | Hämtar eller anger färgen på linjen, standardvärdet är vit(1, 1, 1) |
+
+ **Result:**
+
+
+
+---
+
+
+### setColor{#setColor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setColor(value) | Hämtar eller anger färgen på linjen, standardvärdet är vit(1, 1, 1) |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNodes() | Hämtar alla föräldranoder, en entitet kan fästas vid flera föräldranoder för geometri‑instansering. Noderna. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExcluded() | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExcluded(value) | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNode() | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setParentNode(value) | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getScene() | Hämtar scenen som detta objekt tillhör |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### fromPoints{#fromPoints}
+
+| Namn | Beskrivning |
+| --- | --- |
+| fromPoints(points) | Skapa en Line-instans från en uppsättning punkter. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| point | Vector3[] | null |
+
+ **Result:**
+Line
+
+
+---
+
+
+### makeDefaultIndices{#makeDefaultIndices}
+
+| Namn | Beskrivning |
+| --- | --- |
+| makeDefaultIndices() | Generera sekvensen 0,1,2,3....Geometry.ControlPoints.Length-1 till Segments så att ControlPoints kan användas som en enda rad |
+
+ **Result:**
+Line
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEntityRendererKey() | Hämtar nyckeln för enhetens renderare som är registrerad i renderaren |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBoundingBox() | Hämtar den omgivande lådan för den aktuella enheten i dess objektrums koordinatsystem. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/linearextrusion/_index.md
+++ b/swedish/nodejs-java/aspose.threed/linearextrusion/_index.md
@@ -1,0 +1,476 @@
+---
+title: "LinearExtrusion"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/linearextrusion/
+---
+## LinearExtrusion class
+
+Linjär extrusion tar en 2D-form som indata och förlänger formen i den tredje dimensionen.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Konstruktor för instansen LinearExtrusion. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload(shape, height) | Konstruktor för instansen LinearExtrusion. |
+
+ **Result:**
+
+
+
+---
+
+
+### getShape{#getShape}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getShape() | Den grundläggande formen som ska extruderas. |
+
+ **Result:**
+
+
+
+---
+
+
+### setShape{#setShape}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setShape(value) | Den grundläggande formen som ska extruderas. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDirection{#getDirection}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getDirection() | Extruderingsriktningen, standardvärdet är (0, 0, 1) |
+
+ **Result:**
+
+
+
+---
+
+
+### setDirection{#setDirection}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setDirection(value) | Extruderingsriktningen, standardvärdet är (0, 0, 1) |
+
+ **Result:**
+
+
+
+---
+
+
+### getHeight{#getHeight}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getHeight() | Höjden på den extruderade geometrin, standardvärdet är 1.0 |
+
+ **Result:**
+
+
+
+---
+
+
+### setHeight{#setHeight}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setHeight(value) | Höjden på den extruderade geometrin, standardvärdet är 1.0 |
+
+ **Result:**
+
+
+
+---
+
+
+### getSlices{#getSlices}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getSlices() | Skivorna av den vridna extruderade geometrin, standardvärdet är 1. |
+
+ **Result:**
+
+
+
+---
+
+
+### setSlices{#setSlices}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setSlices(value) | Skivorna av den vridna extruderade geometrin, standardvärdet är 1. |
+
+ **Result:**
+
+
+
+---
+
+
+### getCenter{#getCenter}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getCenter() | Om detta värde är falskt är Z-intervallet för den linjära extrusionen från 0 till höjden, annars är intervallet från -höjd/2 till höjd/2. |
+
+ **Result:**
+
+
+
+---
+
+
+### setCenter{#setCenter}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setCenter(value) | Om detta värde är falskt är Z-intervallet för den linjära extrusionen från 0 till höjden, annars är intervallet från -höjd/2 till höjd/2. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTwistOffset{#getTwistOffset}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getTwistOffset() | Offseten som används vid vridning, standardvärdet är (0, 0, 0). |
+
+ **Result:**
+
+
+
+---
+
+
+### setTwistOffset{#setTwistOffset}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setTwistOffset(value) | Offseten som används vid vridning, standardvärdet är (0, 0, 0). |
+
+ **Result:**
+
+
+
+---
+
+
+### getTwist{#getTwist}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getTwist() | Antalet grader som formen extruderas genom. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTwist{#setTwist}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setTwist(value) | Antalet grader som formen extruderas genom. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNodes() | Hämtar alla föräldranoder, en entitet kan fästas vid flera föräldranoder för geometri‑instansering. Noderna. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExcluded() | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExcluded(value) | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNode() | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setParentNode(value) | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getScene() | Hämtar scenen som detta objekt tillhör |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### toMesh{#toMesh}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toMesh() | Konvertera extrusionen till mesh. |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBoundingBox() | Hämtar den omgivande lådan för den aktuella enheten i dess objektrums koordinatsystem. |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEntityRendererKey() | Hämtar nyckeln för enhetens renderare som är registrerad i renderaren |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/loadoptions/_index.md
+++ b/swedish/nodejs-java/aspose.threed/loadoptions/_index.md
@@ -1,0 +1,107 @@
+---
+title: "LoadOptions"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/loadoptions/
+---
+## LoadOptions class
+
+Bas-klassen för att konfigurera alternativ vid filinläsning för olika typer  @hideconstructor
+
+
+## Metoder
+
+### getFileFormat{#getFileFormat}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileFormat() | Hämtar filformatet som anges i aktuellt Spara/Ladda-alternativ. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEncoding() | Hämtar eller anger standardkodning för textbaserade filer. Standardvärdet är null, vilket betyder att importören/exportören bestämmer vilken kodning som ska användas. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileSystem() | Tillåter användaren att hantera hur externa beroenden ska hanteras under laddning/sparning. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFileSystem(value) | Tillåter användaren att hantera hur externa beroenden ska hanteras under laddning/sparning. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getLookupPaths() | Vissa filer, som OBJ, är beroende av externa filer; sökvägarna gör det möjligt för Aspose.3D att leta efter externa filer att ladda. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileName() | Filnamnet för den exporterade/importerade scenen. Detta är valfritt, men användbart när externa resurser som OBJ:s material serialiseras. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFileName(value) | Filnamnet för den exporterade/importerade scenen. Detta är valfritt, men användbart när externa resurser som OBJ:s material serialiseras. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/localfilesystem/_index.md
+++ b/swedish/nodejs-java/aspose.threed/localfilesystem/_index.md
@@ -1,0 +1,75 @@
+---
+title: "LocalFileSystem"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/localfilesystem/
+---
+## LocalFileSystem class
+
+LocalFileSystem mappar läs-/skrivoperationer till den lokala katalogen.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor(directory) | Initiera ett nytt LocalFileSystem med angiven baskatalog. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| direktör | Sträng | null |
+
+ **Result:**
+
+
+
+---
+
+
+### readFile{#readFile}
+
+| Namn | Beskrivning |
+| --- | --- |
+| readFile(fileName, options) | Skapa en ström för att läsa beroenden. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| fileNam | Sträng | null |
+| alternativ | IOConfig | null |
+
+ **Result:**
+Stream
+
+
+---
+
+
+### writeFile{#writeFile}
+
+| Namn | Beskrivning |
+| --- | --- |
+| writeFile(fileName, options) | Skapa en ström för att skriva beroenden. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| fileNam | Sträng | null |
+| alternativ | IOConfig | null |
+
+ **Result:**
+Stream
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/lshape/_index.md
+++ b/swedish/nodejs-java/aspose.threed/lshape/_index.md
@@ -1,0 +1,411 @@
+---
+title: "LShape"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/lshape/
+---
+## LShape class
+
+IFC-kompatibel L-formad profil som definieras av parametrar.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Konstruktor för LShape |
+
+ **Result:**
+
+
+
+---
+
+
+### getDepth{#getDepth}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getDepth() | Hämtar eller sätter djupet på profilen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDepth{#setDepth}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setDepth(value) | Hämtar eller sätter djupet på profilen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getWidth{#getWidth}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getWidth() | Hämtar eller sätter bredden på profilen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setWidth{#setWidth}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setWidth(value) | Hämtar eller sätter bredden på profilen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getThickness{#getThickness}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getThickness() | Hämtar eller anger tjockleken på den konstanta väggen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setThickness{#setThickness}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setThickness(value) | Hämtar eller anger tjockleken på den konstanta väggen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFilletRadius{#getFilletRadius}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFilletRadius() | Hämtar eller anger radien på avrundningen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFilletRadius{#setFilletRadius}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFilletRadius(value) | Hämtar eller anger radien på avrundningen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEdgeRadius{#getEdgeRadius}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEdgeRadius() | Hämtar eller anger radien på kanten. |
+
+ **Result:**
+
+
+
+---
+
+
+### setEdgeRadius{#setEdgeRadius}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setEdgeRadius(value) | Hämtar eller anger radien på kanten. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNodes() | Hämtar alla föräldranoder, en entitet kan fästas vid flera föräldranoder för geometri‑instansering. Noderna. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExcluded() | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExcluded(value) | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNode() | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setParentNode(value) | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getScene() | Hämtar scenen som detta objekt tillhör |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtent{#getExtent}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExtent() | Hämtar omfattningen i x- och y-dimension. |
+
+ **Result:**
+Vector2
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEntityRendererKey() | Hämtar nyckeln för enhetens renderare som är registrerad i renderaren |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBoundingBox() | Hämtar den omgivande lådan för den aktuella enheten i dess objektrums koordinatsystem. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/material/_index.md
+++ b/swedish/nodejs-java/aspose.threed/material/_index.md
@@ -1,0 +1,226 @@
+---
+title: "Material"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/material/
+---
+## Material class
+
+Material definierar de parametrar som behövs för geometrins visuella utseende. Aspose.3D tillhandahåller skuggningsmodeller för LambertMaterial, PhongMaterial och ShaderMaterial  @hideconstructor
+
+
+## Egenskaper
+
+| Namn | Beskrivning |
+| --- | --- |
+| MAP_SPECULAR | Används i setTexture(java.lang.String, com.aspose.threed.TextureBase) för att tilldela en spekulär texturkartläggning. |
+| MAP_DIFFUSE | Används i setTexture(java.lang.String, com.aspose.threed.TextureBase) för att tilldela en diffus texturkartläggning. |
+| MAP_EMISSIVE | Används i setTexture(java.lang.String, com.aspose.threed.TextureBase) för att tilldela en emissiv texturkartläggning. |
+| MAP_AMBIENT | Används i setTexture(java.lang.String, com.aspose.threed.TextureBase) för att tilldela en ambient texturkartläggning. |
+| MAP_NORMAL | Används i setTexture(java.lang.String, com.aspose.threed.TextureBase) för att tilldela en normal texturkartläggning. |
+
+## Metoder
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTexture{#getTexture}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getTexture(slotName) | Hämtar texturen från den angivna sloten, den kan vara materialets egenskapsnamn eller shaderns parameternamn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| slotName | Sträng | Slotnamn. |
+
+ **Result:**
+TextureBase
+
+
+---
+
+
+### setTexture{#setTexture}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setTexture(slotName, texture) | Anger texturen till den angivna sloten |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| slotName | Sträng | Slotnamn. |
+| texture | TextureBase | Textur. |
+
+ **Result:**
+TextureBase
+
+
+---
+
+
+### toString{#toString}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toString() | Formaterar objekt till sträng. |
+
+ **Result:**
+Sträng
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+### iterator{#iterator}
+
+| Namn | Beskrivning |
+| --- | --- |
+| iterator() | Reserverad för internt bruk. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/mathutils/_index.md
+++ b/swedish/nodejs-java/aspose.threed/mathutils/_index.md
@@ -1,0 +1,193 @@
+---
+title: "MathUtils"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/mathutils/
+---
+## MathUtils class
+
+En samling användbara matematiska verktyg.  @hideconstructor
+
+
+## Metoder
+
+### clamp{#clamp}
+
+| Namn | Beskrivning |
+| --- | --- |
+| clamp(val, min, max) | Begränsa värdet till intervallet [min, max] |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| val | Nummer | Värde att begränsa. |
+| min | Nummer | Minimalt värde. |
+| max | Nummer | Maximalt värde. |
+
+ **Result:**
+Nummer
+
+
+---
+
+
+### toDegree{#toDegree}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toDegree(radian) | Konvertera en Vector3 från radian till grad. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| radian | Vector3 | Radianvärdet. |
+
+ **Result:**
+Vector3
+
+
+---
+
+
+### toRadian{#toRadian}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toRadian(degree) | Konvertera en Vector3 från grad till radian |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| degree | Vector3 | Gradvärdet. |
+
+ **Result:**
+Vector3
+
+
+---
+
+
+### toDegree{#toDegree}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toDegree(radian) | Konvertera ett tal från radian till grad |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| radian | Nummer | Radianvärdet. |
+
+ **Result:**
+Nummer
+
+
+---
+
+
+### toDegree{#toDegree}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toDegree(radian) | Konvertera ett tal från radian till grad |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| radian | Nummer | Radianvärdet. |
+
+ **Result:**
+Nummer
+
+
+---
+
+
+### toDegree{#toDegree}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toDegree(x, y, z) | Konvertera ett tal från radian till grad |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| x | Nummer | x-komponenten i radianvärde. |
+| y | Nummer | y-komponenten i radianvärde. |
+| z | Nummer | z-komponenten i radianvärde. |
+
+ **Result:**
+Vector3
+
+
+---
+
+
+### toRadian{#toRadian}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toRadian(degree) | Konvertera ett tal från grad till radian |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| degree | Nummer | Gradvärdet. |
+
+ **Result:**
+Nummer
+
+
+---
+
+
+### toRadian{#toRadian}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toRadian(degree) | Konvertera ett tal från grad till radian |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| degree | Nummer | Gradvärdet. |
+
+ **Result:**
+Nummer
+
+
+---
+
+
+### toRadian{#toRadian}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toRadian(x, y, z) | Konvertera en vektor från grader till radianer |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| x | Nummer | x-komponenten i gradvärde. |
+| y | Nummer | y-komponenten i gradvärde. |
+| z | Nummer | z-komponenten i gradvärde. |
+
+ **Result:**
+Vector3
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/matrix4/_index.md
+++ b/swedish/nodejs-java/aspose.threed/matrix4/_index.md
@@ -1,0 +1,453 @@
+---
+title: "Matrix4"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/matrix4/
+---
+## Matrix4 class
+
+4x4-matrisimplementation.
+
+
+## Egenskaper
+
+| Namn | Beskrivning |
+| --- | --- |
+| m00 | m00‑värdet. |
+| m01 | m01‑värdet. |
+| m02 | m02‑värdet. |
+| m03 | m03‑värdet. |
+| m10 | m10‑värdet. |
+| m11 | m11‑värdet. |
+| m12 | Den m12. |
+| m13 | Den m13. |
+| m20 | Den m20. |
+| m21 | Den m21. |
+| m22 | Den m22. |
+| m23 | Den m23. |
+| m30 | Den m30. |
+| m31 | Den m31. |
+| m32 | Den m32. |
+| m33 | Den m33. |
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload(r0, r1, r2, r3) | Skapar en matris från 4 rader. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| r0 | Vector4 | R0. |
+| r1 | Vector4 | R1. |
+| r2 | Vector4 | R2. |
+| r3 | Vector4 | R3. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload2(m00, m01, m02, m03, m10, m11, m12, m13, m20, m21, m22, m23, m30, m31, m32, m33) | Initierar en ny instans av Matrix4-strukturen. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| m00 | Nummer | M00. |
+| m01 | Nummer | M01. |
+| m02 | Nummer | M02. |
+| m03 | Nummer | M03. |
+| m10 | Nummer | M10. |
+| m11 | Nummer | M11. |
+| m12 | Nummer | M12. |
+| m13 | Nummer | M13. |
+| m20 | Nummer | M20. |
+| m21 | Nummer | M21. |
+| m22 | Nummer | M22. |
+| m23 | Nummer | M23. |
+| m30 | Nummer | M30. |
+| m31 | Nummer | M31. |
+| m32 | Nummer | M32. |
+| m33 | Nummer | M33. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload3{#constructor_overload3}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload3(m) | Skapa Matrix4 från en FMatrix4-instans |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+|  | FMatrix4 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload4{#constructor_overload4}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload4(m) | Initierar en ny instans av Matrix4-strukturen. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| m | Number[] | M. |
+
+ **Result:**
+
+
+
+---
+
+
+### getIdentity{#getIdentity}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getIdentity() | Hämtar identitetsmatrisen. Identiteten. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDeterminant{#getDeterminant}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getDeterminant() | Hämtar determinanten för matrisen. Determinanten. |
+
+ **Result:**
+
+
+
+---
+
+
+### concatenate{#concatenate}
+
+| Namn | Beskrivning |
+| --- | --- |
+| concatenate(m2) | Konkatenar de två matriserna |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| m2 | Matrix4 | M2. |
+
+ **Result:**
+Matrix4
+
+
+---
+
+
+### transpose{#transpose}
+
+| Namn | Beskrivning |
+| --- | --- |
+| transpose() | Transponerar den här instansen. |
+
+ **Result:**
+Matrix4
+
+
+---
+
+
+### normalize{#normalize}
+
+| Namn | Beskrivning |
+| --- | --- |
+| normalize() | Normaliserar detta objekt. |
+
+ **Result:**
+Matrix4
+
+
+---
+
+
+### inverse{#inverse}
+
+| Namn | Beskrivning |
+| --- | --- |
+| inverse() | Inverterar detta objekt. |
+
+ **Result:**
+Matrix4
+
+
+---
+
+
+### setTRS{#setTRS}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setTRS(translation, rotation, scale) | Initierar matrisen med translation/rotation/scale |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| translation | Vector3 | Translation. |
+| rotation | Vector3 | Eulervinklar för rotation, fälten är i grader. |
+| scale | Vector3 | Scale. |
+
+ **Result:**
+Matrix4
+
+
+---
+
+
+### toArray{#toArray}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toArray() | Konverterar matris till array. |
+
+ **Result:**
+Number[]
+
+
+---
+
+
+### toString{#toString}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toString() | Returnerar en java.lang.String som representerar den aktuella Matrix4. |
+
+ **Result:**
+Sträng
+
+
+---
+
+
+### translate{#translate}
+
+| Namn | Beskrivning |
+| --- | --- |
+| translate(t) | Skapar en matris som translaterar längs x-axeln, y-axeln och z-axeln |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| t | Vector3 | Translateringsoffset |
+
+ **Result:**
+Matrix4
+
+
+---
+
+
+### translate{#translate}
+
+| Namn | Beskrivning |
+| --- | --- |
+| translate(tx, ty, tz) | Skapar en matris som translaterar längs x-axeln, y-axeln och z-axeln |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| tx | Nummer | X-koordinatförskjutning |
+| ty | Nummer | Y-koordinatens förskjutning |
+| tz | Nummer | Z-koordinatens förskjutning |
+
+ **Result:**
+Matrix4
+
+
+---
+
+
+### scale{#scale}
+
+| Namn | Beskrivning |
+| --- | --- |
+| skala(r) | Skapar en matris som skalar längs x-axeln, y-axeln och z-axeln. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| s | Vector3 | Skalningsfabriker gäller för x-axeln, y-axeln och z-axeln |
+
+ **Result:**
+Matrix4
+
+
+---
+
+
+### scale{#scale}
+
+| Namn | Beskrivning |
+| --- | --- |
+| skala(r) | Skapar en matris som skalar längs x-axeln, y-axeln och z-axeln. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| s | Nummer | Skalningsfabriker gäller för alla axlar |
+
+ **Result:**
+Matrix4
+
+
+---
+
+
+### scale{#scale}
+
+| Namn | Beskrivning |
+| --- | --- |
+| scale(sx, sy, sz) | Skapar en matris som skalar längs x-axeln, y-axeln och z-axeln. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| sx | Nummer | Skalningsfabriker gäller för x-axeln |
+| sy | Nummer | Skalningsfabriker gäller för y-axeln |
+| sz | Nummer | Skalningsfabriker gäller för z-axeln |
+
+ **Result:**
+Matrix4
+
+
+---
+
+
+### rotateFromEuler{#rotateFromEuler}
+
+| Namn | Beskrivning |
+| --- | --- |
+| rotateFromEuler(eul) | Skapa en rotationsmatris från Euler-vinkel |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| eul | Vector3 | Rotation i radian |
+
+ **Result:**
+Matrix4
+
+
+---
+
+
+### rotateFromEuler{#rotateFromEuler}
+
+| Namn | Beskrivning |
+| --- | --- |
+| rotateFromEuler(rx, ry, rz) | Skapa en rotationsmatris från Euler-vinkel |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| rx | Nummer | Rotation i x-axeln i radian |
+| ry | Nummer | Rotation i y-axeln i radian |
+| rz | Nummer | Rotation kring z-axeln i radian |
+
+ **Result:**
+Matrix4
+
+
+---
+
+
+### rotate{#rotate}
+
+| Namn | Beskrivning |
+| --- | --- |
+| rotate(angle, axis) | Skapa en rotationsmatris med rotationsvinkel och axel |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| vinkel | Nummer | Rotationsvinkel i radian |
+| axel | Vector3 | Rotationsaxel |
+
+ **Result:**
+Matrix4
+
+
+---
+
+
+### rotate{#rotate}
+
+| Namn | Beskrivning |
+| --- | --- |
+| rotate(q) | Skapa en rotationsmatris från en kvaternion |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| q | Kvaternion | Rotationskvaternion |
+
+ **Result:**
+Matrix4
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/memoryfilesystem/_index.md
+++ b/swedish/nodejs-java/aspose.threed/memoryfilesystem/_index.md
@@ -1,0 +1,101 @@
+---
+title: "MemoryFileSystem"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/memoryfilesystem/
+---
+## MemoryFileSystem class
+
+MemoryFileSystem mappar läs-/skrivoperationer till minnet.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileNames{#getFileNames}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileNames() | Filnamn som finns i detta minnesfilssystem. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileContent{#getFileContent}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileContent(fileName) | Returnerar det råa innehållet i den angivna filen. Kastar System.IO.FileNotFoundException om den angivna filen inte finns. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| fileNam | Sträng | null |
+
+ **Result:**
+byte[]
+
+
+---
+
+
+### readFile{#readFile}
+
+| Namn | Beskrivning |
+| --- | --- |
+| readFile(fileName, options) | Skapa en ström för att läsa beroenden. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| fileNam | Sträng | null |
+| alternativ | IOConfig | null |
+
+ **Result:**
+Stream
+
+
+---
+
+
+### writeFile{#writeFile}
+
+| Namn | Beskrivning |
+| --- | --- |
+| writeFile(fileName, options) | Skapa en ström för att skriva beroenden. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| fileNam | Sträng | null |
+| alternativ | IOConfig | null |
+
+ **Result:**
+Stream
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/mesh/_index.md
+++ b/swedish/nodejs-java/aspose.threed/mesh/_index.md
@@ -1,0 +1,708 @@
+---
+title: "Mesh"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/mesh/
+---
+## Mesh class
+
+Ett nätverk består av många n-sidiga polygoner.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Initierar en ny instans av Mesh-klassen. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload(name) | Initierar en ny instans av Mesh-klassen. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| name | Sträng | Namn. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEdges{#getEdges}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEdges() | Hämtar kanter av Mesh. Kant är valfri i mesh, så den kan vara tom. |
+
+ **Result:**
+
+
+
+---
+
+
+### getPolygonCount{#getPolygonCount}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getPolygonCount() | Hämtar antalet polygoner. Polygonantalet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getPolygons{#getPolygons}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getPolygons() | Hämtar polygondefinitionen för mesh |
+
+ **Result:**
+
+
+
+---
+
+
+### getVisible{#getVisible}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getVisible() | Hämtar eller anger om geometrin är synlig |
+
+ **Result:**
+
+
+
+---
+
+
+### setVisible{#setVisible}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setVisible(value) | Hämtar eller anger om geometrin är synlig |
+
+ **Result:**
+
+
+
+---
+
+
+### getDeformers{#getDeformers}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getDeformers() | Hämtar alla deformers som är associerade med denna geometri. Deformers. |
+
+ **Result:**
+
+
+
+---
+
+
+### getControlPoints{#getControlPoints}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getControlPoints() | Hämtar alla kontrollpunkter |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastShadows{#getCastShadows}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getCastShadows() | Hämtar eller anger om denna geometri kan kasta skugga |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastShadows{#setCastShadows}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setCastShadows(value) | Hämtar eller anger om denna geometri kan kasta skugga |
+
+ **Result:**
+
+
+
+---
+
+
+### getReceiveShadows{#getReceiveShadows}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getReceiveShadows() | Hämtar eller anger om denna geometri kan ta emot skugga. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReceiveShadows{#setReceiveShadows}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setReceiveShadows(value) | Hämtar eller anger om denna geometri kan ta emot skugga. |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElements{#getVertexElements}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getVertexElements() | Hämtar alla vertex elements |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNodes() | Hämtar alla föräldranoder, en entitet kan fästas vid flera föräldranoder för geometri‑instansering. Noderna. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExcluded() | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExcluded(value) | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNode() | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setParentNode(value) | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getScene() | Hämtar scenen som detta objekt tillhör |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### getPolygonSize{#getPolygonSize}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getPolygonSize(index) | Hämtar antalet hörn i den angivna polygonen. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| index | Nummer | Index. |
+
+ **Result:**
+Nummer
+
+
+---
+
+
+### createPolygon{#createPolygon}
+
+| Namn | Beskrivning |
+| --- | --- |
+| createPolygon(indices, offset, length) | Skapar en ny polygon med alla hörn definierade i index. För att skapa polygon hörn för hörn, använd PolygonBuilder. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| indices | Number[] | Array av polygonens index, där varje index pekar på en kontrollpunkt som bildar polygonen. |
+| offset | Nummer | Förskjutningen för det första polygonindexet |
+| length | Nummer | Längden på indexen |
+
+ **Result:**
+Nummer
+
+
+---
+
+
+### createPolygon{#createPolygon}
+
+| Namn | Beskrivning |
+| --- | --- |
+| createPolygon(indices) | Skapar en ny polygon med alla hörn definierade i index. För att skapa polygon hörn för hörn, använd PolygonBuilder. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| indices | Number[] | Array av polygonens index, där varje index pekar på en kontrollpunkt som bildar polygonen. |
+
+ **Result:**
+Nummer
+
+
+---
+
+
+### createPolygon{#createPolygon}
+
+| Namn | Beskrivning |
+| --- | --- |
+| createPolygon(v1, v2, v3, v4) | Skapa en polygon med 4 hörn(quad) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| v1 | Nummer | Index för det första hörnet |
+| v2 | Nummer | Index för det andra hörnet |
+| v3 | Nummer | Index för det tredje hörnet |
+| v4 | Nummer | Index för det fjärde hörnet |
+
+ **Result:**
+Nummer
+
+
+---
+
+
+### createPolygon{#createPolygon}
+
+| Namn | Beskrivning |
+| --- | --- |
+| createPolygon(v1, v2, v3) | Skapa en polygon med 3 hörn(triangel) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| v1 | Nummer | Index för det första hörnet |
+| v2 | Nummer | Index för det andra hörnet |
+| v3 | Nummer | Index för det tredje hörnet |
+
+ **Result:**
+Nummer
+
+
+---
+
+
+### toMesh{#toMesh}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toMesh() | Hämtar Mesh-instansen från den aktuella enheten. |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getElement{#getElement}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getElement(type) | Hämtar ett vertex element med angiven typ |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| typ | VertexElementType | VertexElementType |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### getVertexElementOfUV{#getVertexElementOfUV}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getVertexElementOfUV(textureMapping) | Hämtar en VertexElementUV-instans med given texture mapping-typ |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| textureMapping | TextureMapping | TextureMapping |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### createElement{#createElement}
+
+| Namn | Beskrivning |
+| --- | --- |
+| createElement(type) | Skapar ett vertex element med angiven typ och lägger till det i geometrin. Om typen är VertexElementType.UV, skapas ett VertexElementUV med texture mapping-typ till TextureMapping.DIFFUSE. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| typ | VertexElementType | VertexElementType |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### addElement{#addElement}
+
+| Namn | Beskrivning |
+| --- | --- |
+| addElement(element) | Lägger till ett befintligt vertex element i den aktuella geometrin |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| element | VertexElement | Vertex elementet att lägga till |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### createElement{#createElement}
+
+| Namn | Beskrivning |
+| --- | --- |
+| createElement(type, mappingMode, referenceMode) | Skapar ett vertex element med angiven typ och lägger till det i geometrin. Om typen är VertexElementType.UV, skapas ett VertexElementUV med texture mapping-typ till TextureMapping.DIFFUSE. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| typ | VertexElementType | VertexElementType |
+| mappingMode | MappingMode | MappingMode |
+| referenceMode | ReferenceMode | ReferenceMode |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### createElementUV{#createElementUV}
+
+| Namn | Beskrivning |
+| --- | --- |
+| createElementUV(uvMapping) | Skapar ett VertexElementUV med given texturkartläggningstyp. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| uvMapping | TextureMapping | TextureMapping |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### createElementUV{#createElementUV}
+
+| Namn | Beskrivning |
+| --- | --- |
+| createElementUV(uvMapping, mappingMode, referenceMode) | Skapar ett VertexElementUV med given texturkartläggningstyp. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| uvMapping | TextureMapping | TextureMapping |
+| mappingMode | MappingMode | MappingMode |
+| referenceMode | ReferenceMode | ReferenceMode |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBoundingBox() | Hämtar den omgivande lådan för den aktuella enheten i dess objektrums koordinatsystem. |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEntityRendererKey() | Hämtar nyckeln för enhetens renderare som är registrerad i renderaren |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+### iterator{#iterator}
+
+| Namn | Beskrivning |
+| --- | --- |
+| iterator() | Reserverad för internt bruk. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/metered/_index.md
+++ b/swedish/nodejs-java/aspose.threed/metered/_index.md
@@ -1,0 +1,75 @@
+---
+title: "Metered"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/metered/
+---
+## Metered class
+
+Tillhandahåller metoder för att ställa in mätad nyckel.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Initierar en ny instans av den här klassen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMeteredKey{#setMeteredKey}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setMeteredKey(publicKey, privateKey) | Ställer in den mätade offentliga och privata nyckeln. Om du köper en mätt licens, bör detta API anropas när applikationen startas; normalt är detta tillräckligt. Men om uppladdning av konsumtionsdata alltid misslyckas och överstiger 24 timmar, kommer licensen att sättas till utvärderingsstatus. För att undvika detta bör du regelbundet kontrollera licensstatusen, och om den är i utvärderingsstatus, anropa detta API igen. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| publicKey | Sträng | offentlig nyckel |
+| privateKey | Sträng | privat nyckel |
+
+ **Result:**
+
+
+
+---
+
+
+### getConsumptionQuantity{#getConsumptionQuantity}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getConsumptionQuantity() | Hämtar förbrukningsfilens storlek |
+
+ **Result:**
+BigDecimal
+
+
+---
+
+
+### getConsumptionCredit{#getConsumptionCredit}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getConsumptionCredit() | Hämtar förbrukningskredit |
+
+ **Result:**
+BigDecimal
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/mirroredprofile/_index.md
+++ b/swedish/nodejs-java/aspose.threed/mirroredprofile/_index.md
@@ -1,0 +1,287 @@
+---
+title: "MirroredProfile"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/mirroredprofile/
+---
+## MirroredProfile class
+
+IFC-kompatibel spegelprofil. Denna profil definierar en ny profil genom att spegla basprofilen kring y-axeln.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor(baseProfile) | Skapa ett nytt MirroredProfile från en befintlig profil. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| baseProfile | Profil | Den grundprofil som ska speglas. |
+
+ **Result:**
+
+
+
+---
+
+
+### getBaseProfile{#getBaseProfile}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBaseProfile() | Den grundprofil som ska speglas. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNodes() | Hämtar alla föräldranoder, en entitet kan fästas vid flera föräldranoder för geometri‑instansering. Noderna. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExcluded() | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExcluded(value) | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNode() | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setParentNode(value) | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getScene() | Hämtar scenen som detta objekt tillhör |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEntityRendererKey() | Hämtar nyckeln för enhetens renderare som är registrerad i renderaren |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBoundingBox() | Hämtar den omgivande lådan för den aktuella enheten i dess objektrums koordinatsystem. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/morphtargetchannel/_index.md
+++ b/swedish/nodejs-java/aspose.threed/morphtargetchannel/_index.md
@@ -1,0 +1,306 @@
+---
+title: "MorphTargetChannel"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/morphtargetchannel/
+---
+## MorphTargetChannel class
+
+En MorphTargetChannel används av MorphTargetDeformer för att organisera målgeometrierna. Vissa filformat som FBX stödjer flera kanaler parallellt. Vikt är mellan 0 och 1.0, och standardvikt för målet är 0.0;
+
+
+## Egenskaper
+
+| Namn | Beskrivning |
+| --- | --- |
+| DEFAULT_WEIGHT | Standardvikt för morph-mål. |
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor(name) | Initierar en ny instans av MorphTargetChannel-klassen. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| name | Sträng | Namn. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload() | Initierar en ny instans av MorphTargetChannel-klassen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getWeights{#getWeights}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getWeights() | Hämtar de fullständiga viktvärdena för målgeometrier. De fullständiga vikterna. |
+
+ **Result:**
+
+
+
+---
+
+
+### getChannelWeight{#getChannelWeight}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getChannelWeight() | Hämtar eller anger deformatorvikten för den här kanalen. Vikten ligger mellan 0,0 och 1,0. |
+
+ **Result:**
+
+
+
+---
+
+
+### setChannelWeight{#setChannelWeight}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setChannelWeight(value) | Hämtar eller anger deformatorvikten för den här kanalen. Vikten ligger mellan 0,0 och 1,0. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTargets{#getTargets}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getTargets() | Hämtar alla mål som är associerade med kanalen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### get{#get}
+
+| Namn | Beskrivning |
+| --- | --- |
+| get(target) |  |
+
+ **Result:**
+
+
+
+---
+
+
+### set{#set}
+
+| Namn | Beskrivning |
+| --- | --- |
+| set(target, value) |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getWeight{#getWeight}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getWeight(target) | Hämtar vikten för det angivna målet, om målet inte tillhör den här kanalen, returneras standardvärdet 0. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| mål | Form | null |
+
+ **Result:**
+Nummer
+
+
+---
+
+
+### setWeight{#setWeight}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setWeight(target, weight) | Ställer in vikten för det angivna målet, standardvärdet är 1, intervallet bör ligga mellan 0~1. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| mål | Form | null |
+| vikt | Nummer | null |
+
+ **Result:**
+Nummer
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/morphtargetdeformer/_index.md
+++ b/swedish/nodejs-java/aspose.threed/morphtargetdeformer/_index.md
@@ -1,0 +1,235 @@
+---
+title: "MorphTargetDeformer"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/morphtargetdeformer/
+---
+## MorphTargetDeformer class
+
+MorphTargetDeformer tillhandahåller per-vertex-animering. MorphTargetDeformer organiserar alla mål via MorphTargetChannel, varje kanal kan organisera flera mål. En vanlig användning av morph target-deformer är att applicera ansiktsuttryck på en karaktär. Mer detaljer finns på https://en.wikipedia.org/wiki/Morph_target_animation
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor(name) | Initierar en ny instans av klassen MorphTargetDeformer. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| name | Sträng | Namn. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload() | Initierar en ny instans av klassen MorphTargetDeformer. |
+
+ **Result:**
+
+
+
+---
+
+
+### getChannels{#getChannels}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getChannels() | Hämtar alla kanaler som finns i denna deformer. |
+
+ **Result:**
+
+
+
+---
+
+
+### getOwner{#getOwner}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getOwner() | Hämtar geometrin som äger denna deformerare |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### get{#get}
+
+| Namn | Beskrivning |
+| --- | --- |
+| get(target) |  |
+
+ **Result:**
+
+
+
+---
+
+
+### set{#set}
+
+| Namn | Beskrivning |
+| --- | --- |
+| set(target, value) |  |
+
+ **Result:**
+
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/node/_index.md
+++ b/swedish/nodejs-java/aspose.threed/node/_index.md
@@ -1,0 +1,739 @@
+---
+title: "Nod"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/node/
+---
+## Node class
+
+Representerar ett element i scengrafen. En scengraf är ett träd av Node-objekt. Trädhanteringstjänsterna är självständiga i denna klass. Observera att Aspose.3D SDK inte testar giltigheten av den konstruerade scengrafen. Det är anroparens ansvar att säkerställa att den inte genererar cykliska grafer i en nodhierarki. Förutom trädhanteringen definierar denna klass alla egenskaper som krävs för att beskriva objektets position i scenen. Denna information inkluderar de grundläggande egenskaperna Translation, Rotation och Scaling samt mer avancerade alternativ för pivoter, begränsningar och IK-leden attribut såsom styvhet och dämpning. När den först skapas är Node-objektet "tomt" (dvs. det är ett objekt utan någon grafisk representation som endast innehåller positionsinformation). I detta tillstånd kan det användas för att representera föräldrar i nodträdet men inte mycket mer. Den normala användningen av denna typ av objekt är att lägga till dem en entitet som specialiserar noden (se "Entity"). Entiteten är ett eget objekt och är kopplad till Node. Detta innebär också att samma entitet kan delas mellan flera noder. Camera, Light, Mesh osv... är alla entiteter och de är alla härledda från basklassen Entity.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Initierar en ny instans av Node-klassen. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload(name, entity) | Initierar en ny instans av Node-klassen. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| name | Sträng | Namn. |
+| entitet | Entitet | Standardentitet. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload2(name) | Initierar en ny instans av Node-klassen. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| name | Sträng | Namn. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAssetInfo{#getAssetInfo}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getAssetInfo() | Tillgångsinformation per nod |
+
+ **Result:**
+
+
+
+---
+
+
+### setAssetInfo{#setAssetInfo}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setAssetInfo(value) | Tillgångsinformation per nod |
+
+ **Result:**
+
+
+
+---
+
+
+### getVisible{#getVisible}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getVisible() | Hämtar eller anger för att visa noden |
+
+ **Result:**
+
+
+
+---
+
+
+### setVisible{#setVisible}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setVisible(value) | Hämtar eller anger för att visa noden |
+
+ **Result:**
+
+
+
+---
+
+
+### getChildNodes{#getChildNodes}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getChildNodes() | Hämtar barnnoderna. Noderna. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntity{#getEntity}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEntity() | Hämtar eller anger den första entiteten som är kopplad till denna nod, om den anges rensas andra entiteter. Nodens entitet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setEntity{#setEntity}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setEntity(value) | Hämtar eller anger den första entiteten som är kopplad till denna nod, om den anges rensas andra entiteter. Nodens entitet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExcluded() | Hämtar eller anger om denna nod och alla barnnoder/entiteter ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExcluded(value) | Hämtar eller anger om denna nod och alla barnnoder/entiteter ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntities{#getEntities}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEntities() | Hämtar alla nodentiteter. Nodentiteterna. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMetaDatas{#getMetaDatas}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getMetaDatas() | Hämtar metadata som definierats i denna nod. Metadatan. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMaterials{#getMaterials}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getMaterials() | Hämtar materialen som är associerade med denna nod. Materialen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMaterial{#getMaterial}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getMaterial() | Hämtar eller anger det första materialet som är associerat med denna nod; om det anges rensas andra material. Materialet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMaterial{#setMaterial}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setMaterial(value) | Hämtar eller anger det första materialet som är associerat med denna nod; om det anges rensas andra material. Materialet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNode() | Hämtar eller anger föräldranoden. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setParentNode(value) | Hämtar eller anger föräldranoden. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTransform{#getTransform}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getTransform() | Hämtar den lokala transformen. Transformen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getGlobalTransform{#getGlobalTransform}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getGlobalTransform() | Hämtar den globala transformen. Den globala transformen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getScene() | Hämtar scenen som detta objekt tillhör |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### createChildNode{#createChildNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| createChildNode() | Skapar en barnnod |
+
+ **Result:**
+Nod
+
+
+---
+
+
+### merge{#merge}
+
+| Namn | Beskrivning |
+| --- | --- |
+| merge(node) | Koppla loss allt under noden och fäst dem på den aktuella noden. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| nod | Nod | null |
+
+ **Result:**
+Nod
+
+
+---
+
+
+### createChildNode{#createChildNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| createChildNode(nodeName) | Skapa en ny barnnod med angivet nodnamn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| nodeName | Sträng | Det nya barnnodens namn |
+
+ **Result:**
+Nod
+
+
+---
+
+
+### createChildNode{#createChildNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| createChildNode(entity) | Skapa en ny barnnod med angiven entitet bifogad |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| entitet | Entitet | Standardentitet bifogad till noden |
+
+ **Result:**
+Nod
+
+
+---
+
+
+### createChildNode{#createChildNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| createChildNode(nodeName, entity) | Skapa en ny barnnod med angivet nodnamn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| nodeName | Sträng | Det nya barnnodens namn |
+| entitet | Entitet | Standardentitet bifogad till noden |
+
+ **Result:**
+Nod
+
+
+---
+
+
+### createChildNode{#createChildNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| createChildNode(nodeName, entity, material) | Skapa en ny barnnod med angivet nodnamn och fäst angiven entitet samt ett material |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| nodeName | Sträng | Det nya barnnodens namn |
+| entitet | Entitet | Standardentitet bifogad till noden |
+| material | Material | Materialet bifogat till noden |
+
+ **Result:**
+Nod
+
+
+---
+
+
+### evaluateGlobalTransform{#evaluateGlobalTransform}
+
+| Namn | Beskrivning |
+| --- | --- |
+| evaluateGlobalTransform(withGeometricTransform) | Utvärdera den globala transformen, inkludera den geometriska transformen eller inte. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| withGeometricTransform | boolean | Om den geometriska transformen behövs. |
+
+ **Result:**
+Matrix4
+
+
+---
+
+
+### getChild{#getChild}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getChild(index) | Hämtar barnnoden på angivet index. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| index | Nummer | Index. |
+
+ **Result:**
+Nod
+
+
+---
+
+
+### getChild{#getChild}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getChild(nodeName) | Hämtar barnnoden med det angivna namnet |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| nodeName | Sträng | Barnnamnet att hitta. |
+
+ **Result:**
+Nod
+
+
+---
+
+
+### accept{#accept}
+
+| Namn | Beskrivning |
+| --- | --- |
+| accept(visitor) | Går igenom alla underordnade noder (inklusive den aktuella noden) och anropar besökaren med noden. Besökaren kan avbryta genomgången genom att returnera falskt |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| visitor | NodeVisitor | Besöksåteruppringning för att besöka noden |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### toString{#toString}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toString() | Hämtar strängrepresentationen av denna nod. |
+
+ **Result:**
+Sträng
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBoundingBox() | Beräkna begränsningsrutan för noden |
+
+ **Result:**
+BoundingBox
+
+
+---
+
+
+### addEntity{#addEntity}
+
+| Namn | Beskrivning |
+| --- | --- |
+| addEntity(entity) | Lägg till en entitet i noden. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| entitet | Entitet | Entiteten som ska bifogas noden |
+
+ **Result:**
+BoundingBox
+
+
+---
+
+
+### addChildNode{#addChildNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| addChildNode(node) | Lägg till en barnnod till denna nod |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| nod | Nod | Barnnoden som ska bifogas |
+
+ **Result:**
+BoundingBox
+
+
+---
+
+
+### selectSingleObject{#selectSingleObject}
+
+| Namn | Beskrivning |
+| --- | --- |
+| selectSingleObject(path) | Välj ett enskilt objekt under den aktuella noden med XPath-liknande frågesyntax. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| pat | Sträng | null |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### selectObjects{#selectObjects}
+
+| Namn | Beskrivning |
+| --- | --- |
+| selectObjects(path) | Välj flera objekt under den aktuella noden med XPath-liknande frågesyntax. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| pat | Sträng | null |
+
+ **Result:**
+0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/nurbscurve/_index.md
+++ b/swedish/nodejs-java/aspose.threed/nurbscurve/_index.md
@@ -1,0 +1,494 @@
+---
+title: "NurbsCurve"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/nurbscurve/
+---
+## NurbsCurve class
+
+NURBS-kurva är en kurva som representeras av NURBS (Non-uniform rational basis spline). En NURBS-kurva definieras av dess ordning, en uppsättning viktade Geometry.ControlPoints och en KnotVectors. w-komponenten i kontrollpunkten används som kontrollpunktens vikt, oavsett om den är CurveDimension.TWO_DIMENSIONAL eller CurveDimension.THREE_DIMENSIONAL.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Initierar en ny instans av klassen NurbsCurve. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload(name) | Initierar en ny instans av klassen NurbsCurve. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| name | Sträng | Namn |
+
+ **Result:**
+
+
+
+---
+
+
+### getControlPoints{#getControlPoints}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getControlPoints() | Hämtar alla kontrollpunkter |
+
+ **Result:**
+
+
+
+---
+
+
+### getMultiplicity{#getMultiplicity}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getMultiplicity() | Hämtar multipliciteten. Multipliciteten. |
+
+ **Result:**
+
+
+
+---
+
+
+### getOrder{#getOrder}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getOrder() | Hämtar eller anger ordningen för en NURBS-kurva, den definierar antalet närliggande kontrollpunkter som påverkar varje given punkt på kurvan. Ordningen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setOrder{#setOrder}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setOrder(value) | Hämtar eller anger ordningen för en NURBS-kurva, den definierar antalet närliggande kontrollpunkter som påverkar varje given punkt på kurvan. Ordningen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDimension{#getDimension}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getDimension() | Hämtar eller anger kurvans dimension. Värdet på egenskapen är en CurveDimension heltalskonstant. För en CurveDimension.TWO_DIMENSIONAL-kurva används z-komponenten i kontrollpunkten inte. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDimension{#setDimension}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setDimension(value) | Hämtar eller anger kurvans dimension. Värdet på egenskapen är en CurveDimension heltalskonstant. För en CurveDimension.TWO_DIMENSIONAL-kurva används z-komponenten i kontrollpunkten inte. |
+
+ **Result:**
+
+
+
+---
+
+
+### getCurveType{#getCurveType}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getCurveType() | Hämtar eller anger kurvans typ. Värdet på egenskapen är NurbsType heltalskonstant. Kurvans typ. |
+
+ **Result:**
+
+
+
+---
+
+
+### setCurveType{#setCurveType}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setCurveType(value) | Hämtar eller anger kurvans typ. Värdet på egenskapen är NurbsType heltalskonstant. Kurvans typ. |
+
+ **Result:**
+
+
+
+---
+
+
+### getKnotVectors{#getKnotVectors}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getKnotVectors() | Hämtar knot-vektorn, den är en sekvens av parametervärden som bestämmer var och hur kontrollpunkterna påverkar NURBS-kurvan. |
+
+ **Result:**
+
+
+
+---
+
+
+### getRational{#getRational}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getRational() | Hämtar eller anger om den är rationell, detta värde indikerar om denna NurbsCurve är en rationell spline eller en icke‑rationell spline. Icke‑rationell B-spline är ett specialfall av rationella B-splines. true om det är en rationell spline; annars, false är en icke‑rationell spline. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRational{#setRational}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setRational(value) | Hämtar eller anger om den är rationell, detta värde indikerar om denna NurbsCurve är en rationell spline eller en icke‑rationell spline. Icke‑rationell B-spline är ett specialfall av rationella B-splines. true om det är en rationell spline; annars, false är en icke‑rationell spline. |
+
+ **Result:**
+
+
+
+---
+
+
+### getColor{#getColor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getColor() | Hämtar eller anger färgen på linjen, standardvärdet är vit(1, 1, 1) |
+
+ **Result:**
+
+
+
+---
+
+
+### setColor{#setColor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setColor(value) | Hämtar eller anger färgen på linjen, standardvärdet är vit(1, 1, 1) |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNodes() | Hämtar alla föräldranoder, en entitet kan fästas vid flera föräldranoder för geometri‑instansering. Noderna. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExcluded() | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExcluded(value) | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNode() | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setParentNode(value) | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getScene() | Hämtar scenen som detta objekt tillhör |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### evaluate{#evaluate}
+
+| Namn | Beskrivning |
+| --- | --- |
+| evaluate(steps) | Utvärdera NURBS-kurvan |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| steps | Nummer | Utvärderingsfrekvensen mellan två intilliggande knutar, standardvärdet är 20 |
+
+ **Result:**
+Vector4[]
+
+
+---
+
+
+### evaluateAt{#evaluateAt}
+
+| Namn | Beskrivning |
+| --- | --- |
+| evaluateAt(u) | Utvärdera kurvans punkt vid angiven position |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| u | Nummer | Positionen i kurvan, mellan 0 och 1 |
+
+ **Result:**
+Vector4
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEntityRendererKey() | Hämtar nyckeln för enhetens renderare som är registrerad i renderaren |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBoundingBox() | Hämtar den omgivande lådan för den aktuella enheten i dess objektrums koordinatsystem. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/nurbsdirection/_index.md
+++ b/swedish/nodejs-java/aspose.threed/nurbsdirection/_index.md
@@ -1,0 +1,159 @@
+---
+title: "NurbsDirection"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/nurbsdirection/
+---
+## NurbsDirection class
+
+En 3D NurbsSurface har två riktningar, NurbsSurface.U och NurbsSurface.V, där NurbsDirection definierar data för varje riktning. En riktning är i själva verket en NURBS-kurva, vilket betyder att den också definieras av dess ordning, en KnotVectors och en uppsättning viktade kontrollpunkter (definierade i NurbsSurface).
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getKnotVectors{#getKnotVectors}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getKnotVectors() | Hämtar knot-vektorn, den är en sekvens av parametervärden som bestämmer var och hur kontrollpunkterna påverkar NURBS-kurvan. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMultiplicity{#getMultiplicity}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getMultiplicity() | Hämtar multipliciteten. Multipliciteten. |
+
+ **Result:**
+
+
+
+---
+
+
+### getOrder{#getOrder}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getOrder() | Hämtar eller anger ordningen för en NURBS-kurva, den definierar antalet närliggande kontrollpunkter som påverkar varje given punkt på kurvan. |
+
+ **Result:**
+
+
+
+---
+
+
+### setOrder{#setOrder}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setOrder(value) | Hämtar eller anger ordningen för en NURBS-kurva, den definierar antalet närliggande kontrollpunkter som påverkar varje given punkt på kurvan. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDivisions{#getDivisions}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getDivisions() | Hämtar eller anger antalet divisioner mellan intilliggande kontrollpunkter i aktuell riktning. Steget. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDivisions{#setDivisions}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setDivisions(value) | Hämtar eller anger antalet divisioner mellan intilliggande kontrollpunkter i aktuell riktning. Steget. |
+
+ **Result:**
+
+
+
+---
+
+
+### getType{#getType}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getType() | Hämtar eller anger typen för den aktuella riktningen. Värdet på egenskapen är NurbsType heltalskonstant. |
+
+ **Result:**
+
+
+
+---
+
+
+### setType{#setType}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setType(value) | Hämtar eller anger typen för den aktuella riktningen. Värdet på egenskapen är NurbsType heltalskonstant. |
+
+ **Result:**
+
+
+
+---
+
+
+### getCount{#getCount}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getCount() | Hämtar eller anger antalet kontrollpunkter i aktuell riktning. Antalet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setCount{#setCount}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setCount(value) | Hämtar eller anger antalet kontrollpunkter i aktuell riktning. Antalet. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/nurbssurface/_index.md
+++ b/swedish/nodejs-java/aspose.threed/nurbssurface/_index.md
@@ -1,0 +1,580 @@
+---
+title: "NurbsSurface"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/nurbssurface/
+---
+## NurbsSurface class
+
+NurbsSurface är en yta som representeras av NURBS (Non-uniform rational basis spline). En NurbsSurface definieras av två NurbsDirectionU och V. w-komponenten i kontrollpunkten används som kontrollpunktens vikt, oavsett om riktningens typ är CurveDimension.TWO_DIMENSIONAL eller CurveDimension.THREE_DIMENSIONAL.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Initierar en ny instans av NurbsSurface-klassen. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload(name) | Initierar en ny instans av NurbsSurface-klassen. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| name | Sträng | Namn. |
+
+ **Result:**
+
+
+
+---
+
+
+### getU{#getU}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getU() | Hämtar NURBS-ytans U-riktning |
+
+ **Result:**
+
+
+
+---
+
+
+### getV{#getV}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getV() | Hämtar NURBS-ytans V-riktning |
+
+ **Result:**
+
+
+
+---
+
+
+### getVisible{#getVisible}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getVisible() | Hämtar eller anger om geometrin är synlig |
+
+ **Result:**
+
+
+
+---
+
+
+### setVisible{#setVisible}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setVisible(value) | Hämtar eller anger om geometrin är synlig |
+
+ **Result:**
+
+
+
+---
+
+
+### getDeformers{#getDeformers}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getDeformers() | Hämtar alla deformers som är associerade med denna geometri. Deformers. |
+
+ **Result:**
+
+
+
+---
+
+
+### getControlPoints{#getControlPoints}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getControlPoints() | Hämtar alla kontrollpunkter |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastShadows{#getCastShadows}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getCastShadows() | Hämtar eller anger om denna geometri kan kasta skugga |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastShadows{#setCastShadows}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setCastShadows(value) | Hämtar eller anger om denna geometri kan kasta skugga |
+
+ **Result:**
+
+
+
+---
+
+
+### getReceiveShadows{#getReceiveShadows}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getReceiveShadows() | Hämtar eller anger om denna geometri kan ta emot skugga. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReceiveShadows{#setReceiveShadows}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setReceiveShadows(value) | Hämtar eller anger om denna geometri kan ta emot skugga. |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElements{#getVertexElements}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getVertexElements() | Hämtar alla vertex elements |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNodes() | Hämtar alla föräldranoder, en entitet kan fästas vid flera föräldranoder för geometri‑instansering. Noderna. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExcluded() | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExcluded(value) | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNode() | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setParentNode(value) | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getScene() | Hämtar scenen som detta objekt tillhör |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### toMesh{#toMesh}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toMesh() | Konvertera NURBS-ytan till ett mesh |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getElement{#getElement}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getElement(type) | Hämtar ett vertex element med angiven typ |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| typ | VertexElementType | VertexElementType |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### getVertexElementOfUV{#getVertexElementOfUV}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getVertexElementOfUV(textureMapping) | Hämtar en VertexElementUV-instans med given texture mapping-typ |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| textureMapping | TextureMapping | TextureMapping |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### createElement{#createElement}
+
+| Namn | Beskrivning |
+| --- | --- |
+| createElement(type) | Skapar ett vertex element med angiven typ och lägger till det i geometrin. Om typen är VertexElementType.UV, skapas ett VertexElementUV med texture mapping-typ till TextureMapping.DIFFUSE. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| typ | VertexElementType | VertexElementType |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### addElement{#addElement}
+
+| Namn | Beskrivning |
+| --- | --- |
+| addElement(element) | Lägger till ett befintligt vertex element i den aktuella geometrin |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| element | VertexElement | Vertex elementet att lägga till |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### createElement{#createElement}
+
+| Namn | Beskrivning |
+| --- | --- |
+| createElement(type, mappingMode, referenceMode) | Skapar ett vertex element med angiven typ och lägger till det i geometrin. Om typen är VertexElementType.UV, skapas ett VertexElementUV med texture mapping-typ till TextureMapping.DIFFUSE. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| typ | VertexElementType | VertexElementType |
+| mappingMode | MappingMode | MappingMode |
+| referenceMode | ReferenceMode | ReferenceMode |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### createElementUV{#createElementUV}
+
+| Namn | Beskrivning |
+| --- | --- |
+| createElementUV(uvMapping) | Skapar ett VertexElementUV med given texturkartläggningstyp. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| uvMapping | TextureMapping | TextureMapping |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### createElementUV{#createElementUV}
+
+| Namn | Beskrivning |
+| --- | --- |
+| createElementUV(uvMapping, mappingMode, referenceMode) | Skapar ett VertexElementUV med given texturkartläggningstyp. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| uvMapping | TextureMapping | TextureMapping |
+| mappingMode | MappingMode | MappingMode |
+| referenceMode | ReferenceMode | ReferenceMode |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBoundingBox() | Hämtar den omgivande lådan för den aktuella enheten i dess objektrums koordinatsystem. |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEntityRendererKey() | Hämtar nyckeln för enhetens renderare som är registrerad i renderaren |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/objloadoptions/_index.md
+++ b/swedish/nodejs-java/aspose.threed/objloadoptions/_index.md
@@ -1,0 +1,224 @@
+---
+title: "ObjLoadOptions"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/objloadoptions/
+---
+## ObjLoadOptions class
+
+Läsalternativ för wavefront obj
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Konstruktor för ObjLoadOptions |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlipCoordinateSystem{#getFlipCoordinateSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFlipCoordinateSystem() | Hämtar eller anger om koordinatsystemet för kontrollpunkter/normaler ska vändas under import |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlipCoordinateSystem{#setFlipCoordinateSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFlipCoordinateSystem(value) | Hämtar eller anger om koordinatsystemet för kontrollpunkter/normaler ska vändas under import |
+
+ **Result:**
+
+
+
+---
+
+
+### getEnableMaterials{#getEnableMaterials}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEnableMaterials() | Hämtar eller anger om material ska importeras för varje objekt |
+
+ **Result:**
+
+
+
+---
+
+
+### setEnableMaterials{#setEnableMaterials}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setEnableMaterials(value) | Hämtar eller anger om material ska importeras för varje objekt |
+
+ **Result:**
+
+
+
+---
+
+
+### getScale{#getScale}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getScale() | Skalning på x/y/z-axeln, standardvärdet är 1.0 |
+
+ **Result:**
+
+
+
+---
+
+
+### setScale{#setScale}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setScale(value) | Skalning på x/y/z-axeln, standardvärdet är 1.0 |
+
+ **Result:**
+
+
+
+---
+
+
+### getNormalizeNormal{#getNormalizeNormal}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getNormalizeNormal() | Hämtar eller anger om normalvektorn ska normaliseras under inläsning. Standardvärdet är true. |
+
+ **Result:**
+
+
+
+---
+
+
+### setNormalizeNormal{#setNormalizeNormal}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setNormalizeNormal(value) | Hämtar eller anger om normalvektorn ska normaliseras under inläsning. Standardvärdet är true. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileFormat() | Hämtar filformatet som anges i aktuellt Spara/Ladda-alternativ. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEncoding() | Hämtar eller anger standardkodning för textbaserade filer. Standardvärdet är null, vilket betyder att importören/exportören bestämmer vilken kodning som ska användas. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileSystem() | Tillåter användaren att hantera hur externa beroenden ska hanteras under laddning/sparning. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFileSystem(value) | Tillåter användaren att hantera hur externa beroenden ska hanteras under laddning/sparning. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getLookupPaths() | Vissa filer, som OBJ, är beroende av externa filer; sökvägarna gör det möjligt för Aspose.3D att leta efter externa filer att ladda. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileName() | Filnamnet för den exporterade/importerade scenen. Detta är valfritt, men användbart när externa resurser som OBJ:s material serialiseras. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFileName(value) | Filnamnet för den exporterade/importerade scenen. Detta är valfritt, men användbart när externa resurser som OBJ:s material serialiseras. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/objsaveoptions/_index.md
+++ b/swedish/nodejs-java/aspose.threed/objsaveoptions/_index.md
@@ -1,0 +1,302 @@
+---
+title: "ObjSaveOptions"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/objsaveoptions/
+---
+## ObjSaveOptions class
+
+Sparaalternativ för wavefront obj-fil
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Konstruktor för ObjSaveOptions |
+
+ **Result:**
+
+
+
+---
+
+
+### getApplyUnitScale{#getApplyUnitScale}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getApplyUnitScale() | Tillämpa AssetInfo.UnitScaleFactor på meshen. Standardvärdet är falskt. |
+
+ **Result:**
+
+
+
+---
+
+
+### setApplyUnitScale{#setApplyUnitScale}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setApplyUnitScale(value) | Tillämpa AssetInfo.UnitScaleFactor på meshen. Standardvärdet är falskt. |
+
+ **Result:**
+
+
+
+---
+
+
+### getPointCloud{#getPointCloud}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getPointCloud() | Hämtar eller anger flaggan som avgör om exportören ska exportera scenen som ett punktmoln (utan topologisk struktur), standardvärdet är falskt |
+
+ **Result:**
+
+
+
+---
+
+
+### setPointCloud{#setPointCloud}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setPointCloud(value) | Hämtar eller anger flaggan som avgör om exportören ska exportera scenen som ett punktmoln (utan topologisk struktur), standardvärdet är falskt |
+
+ **Result:**
+
+
+
+---
+
+
+### getVerbose{#getVerbose}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getVerbose() | Hämtar eller anger om kommentarer ska genereras för varje sektion |
+
+ **Result:**
+
+
+
+---
+
+
+### setVerbose{#setVerbose}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setVerbose(value) | Hämtar eller anger om kommentarer ska genereras för varje sektion |
+
+ **Result:**
+
+
+
+---
+
+
+### getSerializeW{#getSerializeW}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getSerializeW() | Hämtar eller anger om W-komponenten ska serialiseras i modellens vertexposition. |
+
+ **Result:**
+
+
+
+---
+
+
+### setSerializeW{#setSerializeW}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setSerializeW(value) | Hämtar eller anger om W-komponenten ska serialiseras i modellens vertexposition. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEnableMaterials{#getEnableMaterials}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEnableMaterials() | Hämtar eller anger om material ska importeras/exporteras för varje objekt |
+
+ **Result:**
+
+
+
+---
+
+
+### setEnableMaterials{#setEnableMaterials}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setEnableMaterials(value) | Hämtar eller anger om material ska importeras/exporteras för varje objekt |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlipCoordinateSystem{#getFlipCoordinateSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFlipCoordinateSystem() | Hämtar eller anger om koordinatsystemet för kontrollpunkter/normaler ska vändas vid import/export. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlipCoordinateSystem{#setFlipCoordinateSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFlipCoordinateSystem(value) | Hämtar eller anger om koordinatsystemet för kontrollpunkter/normaler ska vändas vid import/export. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportTextures{#getExportTextures}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExportTextures() | Försök att kopiera texturer som används i scenen till utdatamappen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextures{#setExportTextures}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExportTextures(value) | Försök att kopiera texturer som används i scenen till utdatamappen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileFormat() | Hämtar filformatet som anges i aktuellt Spara/Ladda-alternativ. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEncoding() | Hämtar eller anger standardkodning för textbaserade filer. Standardvärdet är null, vilket betyder att importören/exportören bestämmer vilken kodning som ska användas. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileSystem() | Tillåter användaren att hantera hur externa beroenden ska hanteras under laddning/sparning. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFileSystem(value) | Tillåter användaren att hantera hur externa beroenden ska hanteras under laddning/sparning. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getLookupPaths() | Vissa filer, som OBJ, är beroende av externa filer; sökvägarna gör det möjligt för Aspose.3D att leta efter externa filer att ladda. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileName() | Filnamnet för den exporterade/importerade scenen. Detta är valfritt, men användbart när externa resurser som OBJ:s material serialiseras. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFileName(value) | Filnamnet för den exporterade/importerade scenen. Detta är valfritt, men användbart när externa resurser som OBJ:s material serialiseras. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/parameterizedprofile/_index.md
+++ b/swedish/nodejs-java/aspose.threed/parameterizedprofile/_index.md
@@ -1,0 +1,268 @@
+---
+title: "ParameterizedProfile"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/parameterizedprofile/
+---
+## ParameterizedProfile class
+
+Bas-klassen för alla parametriserade profiler.  @hideconstructor
+
+
+## Metoder
+
+### getParentNodes{#getParentNodes}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNodes() | Hämtar alla föräldranoder, en entitet kan fästas vid flera föräldranoder för geometri‑instansering. Noderna. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExcluded() | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExcluded(value) | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNode() | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setParentNode(value) | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getScene() | Hämtar scenen som detta objekt tillhör |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtent{#getExtent}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExtent() | Hämtar omfattningen i x- och y-dimension. |
+
+ **Result:**
+Vector2
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEntityRendererKey() | Hämtar nyckeln för enhetens renderare som är registrerad i renderaren |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBoundingBox() | Hämtar den omgivande lådan för den aktuella enheten i dess objektrums koordinatsystem. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/parseexception/_index.md
+++ b/swedish/nodejs-java/aspose.threed/parseexception/_index.md
@@ -1,0 +1,35 @@
+---
+title: "ParseException"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/parseexception/
+---
+## ParseException class
+
+Undantag när Aspose.3D misslyckades med att tolka indata.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor(msg) | Konstruktor för ParseException |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| ms | Sträng | null |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/patch/_index.md
+++ b/swedish/nodejs-java/aspose.threed/patch/_index.md
@@ -1,0 +1,567 @@
+---
+title: "Patch"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/patch/
+---
+## Patch class
+
+En Patch är en parametrisk modelleringsyta, liknande NurbsSurface, den definieras också av två PatchDirection, U och V. Men skillnaden mellan Patch och NurbsSurface är att PatchDirection-kurvan kan vara en av PatchDirectionType.BEZIER, PatchDirectionType.QUADRATIC_BEZIER, PatchDirectionType.BASIS_SPLINE, PatchDirectionType.CARDINAL_SPLINE och PatchDirectionType.LINEAR
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Initierar en ny instans av klassen Patch. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload(name) | Initierar en ny instans av klassen Patch. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| name | Sträng | Namn. |
+
+ **Result:**
+
+
+
+---
+
+
+### getU{#getU}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getU() | Hämtar u-riktningen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getV{#getV}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getV() | Hämtar v-riktningen. v:et. |
+
+ **Result:**
+
+
+
+---
+
+
+### getVisible{#getVisible}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getVisible() | Hämtar eller anger om geometrin är synlig |
+
+ **Result:**
+
+
+
+---
+
+
+### setVisible{#setVisible}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setVisible(value) | Hämtar eller anger om geometrin är synlig |
+
+ **Result:**
+
+
+
+---
+
+
+### getDeformers{#getDeformers}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getDeformers() | Hämtar alla deformers som är associerade med denna geometri. Deformers. |
+
+ **Result:**
+
+
+
+---
+
+
+### getControlPoints{#getControlPoints}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getControlPoints() | Hämtar alla kontrollpunkter |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastShadows{#getCastShadows}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getCastShadows() | Hämtar eller anger om denna geometri kan kasta skugga |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastShadows{#setCastShadows}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setCastShadows(value) | Hämtar eller anger om denna geometri kan kasta skugga |
+
+ **Result:**
+
+
+
+---
+
+
+### getReceiveShadows{#getReceiveShadows}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getReceiveShadows() | Hämtar eller anger om denna geometri kan ta emot skugga. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReceiveShadows{#setReceiveShadows}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setReceiveShadows(value) | Hämtar eller anger om denna geometri kan ta emot skugga. |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElements{#getVertexElements}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getVertexElements() | Hämtar alla vertex elements |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNodes() | Hämtar alla föräldranoder, en entitet kan fästas vid flera föräldranoder för geometri‑instansering. Noderna. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExcluded() | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExcluded(value) | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNode() | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setParentNode(value) | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getScene() | Hämtar scenen som detta objekt tillhör |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### getElement{#getElement}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getElement(type) | Hämtar ett vertex element med angiven typ |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| typ | VertexElementType | VertexElementType |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### getVertexElementOfUV{#getVertexElementOfUV}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getVertexElementOfUV(textureMapping) | Hämtar en VertexElementUV-instans med given texture mapping-typ |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| textureMapping | TextureMapping | TextureMapping |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### createElement{#createElement}
+
+| Namn | Beskrivning |
+| --- | --- |
+| createElement(type) | Skapar ett vertex element med angiven typ och lägger till det i geometrin. Om typen är VertexElementType.UV, skapas ett VertexElementUV med texture mapping-typ till TextureMapping.DIFFUSE. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| typ | VertexElementType | VertexElementType |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### addElement{#addElement}
+
+| Namn | Beskrivning |
+| --- | --- |
+| addElement(element) | Lägger till ett befintligt vertex element i den aktuella geometrin |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| element | VertexElement | Vertex elementet att lägga till |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### createElement{#createElement}
+
+| Namn | Beskrivning |
+| --- | --- |
+| createElement(type, mappingMode, referenceMode) | Skapar ett vertex element med angiven typ och lägger till det i geometrin. Om typen är VertexElementType.UV, skapas ett VertexElementUV med texture mapping-typ till TextureMapping.DIFFUSE. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| typ | VertexElementType | VertexElementType |
+| mappingMode | MappingMode | MappingMode |
+| referenceMode | ReferenceMode | ReferenceMode |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### createElementUV{#createElementUV}
+
+| Namn | Beskrivning |
+| --- | --- |
+| createElementUV(uvMapping) | Skapar ett VertexElementUV med given texturkartläggningstyp. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| uvMapping | TextureMapping | TextureMapping |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### createElementUV{#createElementUV}
+
+| Namn | Beskrivning |
+| --- | --- |
+| createElementUV(uvMapping, mappingMode, referenceMode) | Skapar ett VertexElementUV med given texturkartläggningstyp. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| uvMapping | TextureMapping | TextureMapping |
+| mappingMode | MappingMode | MappingMode |
+| referenceMode | ReferenceMode | ReferenceMode |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBoundingBox() | Hämtar den omgivande lådan för den aktuella enheten i dess objektrums koordinatsystem. |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEntityRendererKey() | Hämtar nyckeln för enhetens renderare som är registrerad i renderaren |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/patchdirection/_index.md
+++ b/swedish/nodejs-java/aspose.threed/patchdirection/_index.md
@@ -1,0 +1,133 @@
+---
+title: "PatchDirection"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/patchdirection/
+---
+## PatchDirection class
+
+Patchens U- och V-riktning.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getType{#getType}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getType() | Hämtar eller anger patchens typ. Värdet på egenskapen är PatchDirectionType heltalskonstant.Typen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setType{#setType}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setType(value) | Hämtar eller anger patchens typ. Värdet på egenskapen är PatchDirectionType heltalskonstant.Typen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDivisions{#getDivisions}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getDivisions() | Hämtar eller anger antalet divisioner mellan intilliggande kontrollpunkter. Steget. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDivisions{#setDivisions}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setDivisions(value) | Hämtar eller anger antalet divisioner mellan intilliggande kontrollpunkter. Steget. |
+
+ **Result:**
+
+
+
+---
+
+
+### getControlPoints{#getControlPoints}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getControlPoints() | Hämtar eller anger antalet kontrollpunkter i aktuell riktning. Antalet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setControlPoints{#setControlPoints}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setControlPoints(value) | Hämtar eller anger antalet kontrollpunkter i aktuell riktning. Antalet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getClosed{#getClosed}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getClosed() | Hämtar eller anger ett värde som indikerar om denna PatchDirection är en sluten kurva. |
+
+ **Result:**
+
+
+
+---
+
+
+### setClosed{#setClosed}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setClosed(value) | Hämtar eller anger ett värde som indikerar om denna PatchDirection är en sluten kurva. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/pbrmaterial/_index.md
+++ b/swedish/nodejs-java/aspose.threed/pbrmaterial/_index.md
@@ -1,0 +1,579 @@
+---
+title: "PbrMaterial"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/pbrmaterial/
+---
+## PbrMaterial class
+
+Material för fysiskt baserad rendering baserat på albedofärg/metallisk/roughness
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Skapa en standardinstans av PBR-material |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload(albedo) | Skapa ett standard PBR-material med angivet albedofärgvärde. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| albedo | Vector3 | Standardvärdet för albedofärgen |
+
+ **Result:**
+
+
+
+---
+
+
+### getTransparency{#getTransparency}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getTransparency() | Hämtar eller anger transparensfaktorn. Faktorn bör ligga mellan 0 (0 %, helt ogenomskinlig) och 1 (100 %, helt genomskinlig). Eventuellt ogiltigt faktorsvärde kommer att klippas. Transparensfaktorn. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTransparency{#setTransparency}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setTransparency(value) | Hämtar eller anger transparensfaktorn. Faktorn bör ligga mellan 0 (0 %, helt ogenomskinlig) och 1 (100 %, helt genomskinlig). Eventuellt ogiltigt faktorsvärde kommer att klippas. Transparensfaktorn. |
+
+ **Result:**
+
+
+
+---
+
+
+### getNormalTexture{#getNormalTexture}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getNormalTexture() | Hämtar eller anger texturen för normalmappning |
+
+ **Result:**
+
+
+
+---
+
+
+### setNormalTexture{#setNormalTexture}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setNormalTexture(value) | Hämtar eller anger texturen för normalmappning |
+
+ **Result:**
+
+
+
+---
+
+
+### getSpecularTexture{#getSpecularTexture}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getSpecularTexture() | Hämtar eller anger texturen för spekulär färg |
+
+ **Result:**
+
+
+
+---
+
+
+### setSpecularTexture{#setSpecularTexture}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setSpecularTexture(value) | Hämtar eller anger texturen för spekulär färg |
+
+ **Result:**
+
+
+
+---
+
+
+### getAlbedoTexture{#getAlbedoTexture}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getAlbedoTexture() | Hämtar eller anger texturen för albedo |
+
+ **Result:**
+
+
+
+---
+
+
+### setAlbedoTexture{#setAlbedoTexture}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setAlbedoTexture(value) | Hämtar eller anger texturen för albedo |
+
+ **Result:**
+
+
+
+---
+
+
+### getAlbedo{#getAlbedo}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getAlbedo() | Hämtar eller anger basfärgen för materialet |
+
+ **Result:**
+
+
+
+---
+
+
+### setAlbedo{#setAlbedo}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setAlbedo(value) | Hämtar eller anger basfärgen för materialet |
+
+ **Result:**
+
+
+
+---
+
+
+### getOcclusionTexture{#getOcclusionTexture}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getOcclusionTexture() | Hämtar eller anger texturen för omgivningsoskultning |
+
+ **Result:**
+
+
+
+---
+
+
+### setOcclusionTexture{#setOcclusionTexture}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setOcclusionTexture(value) | Hämtar eller anger texturen för omgivningsoskultning |
+
+ **Result:**
+
+
+
+---
+
+
+### getOcclusionFactor{#getOcclusionFactor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getOcclusionFactor() | Hämtar eller anger faktorn för ambient occlusion |
+
+ **Result:**
+
+
+
+---
+
+
+### setOcclusionFactor{#setOcclusionFactor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setOcclusionFactor(value) | Hämtar eller anger faktorn för ambient occlusion |
+
+ **Result:**
+
+
+
+---
+
+
+### getMetallicFactor{#getMetallicFactor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getMetallicFactor() | Hämtar eller anger metalligheten för materialet, ett värde på 1 betyder att materialet är en metall och ett värde på 0 betyder att materialet är ett dielektrikum. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMetallicFactor{#setMetallicFactor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setMetallicFactor(value) | Hämtar eller anger metalligheten för materialet, ett värde på 1 betyder att materialet är en metall och ett värde på 0 betyder att materialet är ett dielektrikum. |
+
+ **Result:**
+
+
+
+---
+
+
+### getRoughnessFactor{#getRoughnessFactor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getRoughnessFactor() | Hämtar eller anger materialets grovhet, ett värde på 1 betyder att materialet är helt grovt och ett värde på 0 betyder att materialet är helt slätt. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRoughnessFactor{#setRoughnessFactor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setRoughnessFactor(value) | Hämtar eller anger materialets grovhet, ett värde på 1 betyder att materialet är helt grovt och ett värde på 0 betyder att materialet är helt slätt. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMetallicRoughness{#getMetallicRoughness}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getMetallicRoughness() | Hämtar eller anger texturen för metallic (i R-kanalen) och roughness (i G-kanalen) |
+
+ **Result:**
+
+
+
+---
+
+
+### setMetallicRoughness{#setMetallicRoughness}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setMetallicRoughness(value) | Hämtar eller anger texturen för metallic (i R-kanalen) och roughness (i G-kanalen) |
+
+ **Result:**
+
+
+
+---
+
+
+### getEmissiveTexture{#getEmissiveTexture}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEmissiveTexture() | Hämtar eller anger texturen för emissiv |
+
+ **Result:**
+
+
+
+---
+
+
+### setEmissiveTexture{#setEmissiveTexture}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setEmissiveTexture(value) | Hämtar eller anger texturen för emissiv |
+
+ **Result:**
+
+
+
+---
+
+
+### getEmissiveColor{#getEmissiveColor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEmissiveColor() | Hämtar eller anger den emissiva färgen |
+
+ **Result:**
+
+
+
+---
+
+
+### setEmissiveColor{#setEmissiveColor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setEmissiveColor(value) | Hämtar eller anger den emissiva färgen |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### fromMaterial{#fromMaterial}
+
+| Namn | Beskrivning |
+| --- | --- |
+| fromMaterial(material) | Tillåter konvertering av annat material till PbrMaterial |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| materia | Material | null |
+
+ **Result:**
+PbrMaterial
+
+
+---
+
+
+### getTexture{#getTexture}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getTexture(slotName) | Hämtar texturen från den angivna sloten, den kan vara materialets egenskapsnamn eller shaderns parameternamn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| slotName | Sträng | Slotnamn. |
+
+ **Result:**
+TextureBase
+
+
+---
+
+
+### setTexture{#setTexture}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setTexture(slotName, texture) | Anger texturen till den angivna sloten |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| slotName | Sträng | Slotnamn. |
+| texture | TextureBase | Textur. |
+
+ **Result:**
+TextureBase
+
+
+---
+
+
+### toString{#toString}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toString() | Formaterar objekt till sträng. |
+
+ **Result:**
+Sträng
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+### iterator{#iterator}
+
+| Namn | Beskrivning |
+| --- | --- |
+| iterator() | Reserverad för internt bruk. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/pbrspecularmaterial/_index.md
+++ b/swedish/nodejs-java/aspose.threed/pbrspecularmaterial/_index.md
@@ -1,0 +1,469 @@
+---
+title: "PbrSpecularMaterial"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/pbrspecularmaterial/
+---
+## PbrSpecularMaterial class
+
+Material för fysiskt baserad rendering baserat på diffus färg/specular/glossiness
+
+
+## Egenskaper
+
+| Namn | Beskrivning |
+| --- | --- |
+| MAP_SPECULAR_GLOSSINESS | Texturkartan för spekulär glans |
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Konstruktor för PbrSpecularMaterial |
+
+ **Result:**
+
+
+
+---
+
+
+### getTransparency{#getTransparency}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getTransparency() | Hämtar eller anger transparensfaktorn. Faktorn bör ligga mellan 0 (0 %, helt ogenomskinlig) och 1 (100 %, helt genomskinlig). Eventuellt ogiltigt faktorsvärde kommer att klippas. Transparensfaktorn. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTransparency{#setTransparency}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setTransparency(value) | Hämtar eller anger transparensfaktorn. Faktorn bör ligga mellan 0 (0 %, helt ogenomskinlig) och 1 (100 %, helt genomskinlig). Eventuellt ogiltigt faktorsvärde kommer att klippas. Transparensfaktorn. |
+
+ **Result:**
+
+
+
+---
+
+
+### getNormalTexture{#getNormalTexture}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getNormalTexture() | Hämtar eller anger texturen för normalmappning |
+
+ **Result:**
+
+
+
+---
+
+
+### setNormalTexture{#setNormalTexture}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setNormalTexture(value) | Hämtar eller anger texturen för normalmappning |
+
+ **Result:**
+
+
+
+---
+
+
+### getSpecularGlossinessTexture{#getSpecularGlossinessTexture}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getSpecularGlossinessTexture() | Hämtar eller anger texturen för spekulär färg, kanal RGB lagrar den spekulära färgen och kanal A lagrar glansigheten. |
+
+ **Result:**
+
+
+
+---
+
+
+### setSpecularGlossinessTexture{#setSpecularGlossinessTexture}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setSpecularGlossinessTexture(value) | Hämtar eller anger texturen för spekulär färg, kanal RGB lagrar den spekulära färgen och kanal A lagrar glansigheten. |
+
+ **Result:**
+
+
+
+---
+
+
+### getGlossinessFactor{#getGlossinessFactor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getGlossinessFactor() | Hämtar eller anger glansigheten (slätheten) för materialet, 1 betyder helt slät och 0 betyder helt grov, standardvärdet är 1, intervallet är [0, 1] |
+
+ **Result:**
+
+
+
+---
+
+
+### setGlossinessFactor{#setGlossinessFactor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setGlossinessFactor(value) | Hämtar eller anger glansigheten (slätheten) för materialet, 1 betyder helt slät och 0 betyder helt grov, standardvärdet är 1, intervallet är [0, 1] |
+
+ **Result:**
+
+
+
+---
+
+
+### getSpecular{#getSpecular}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getSpecular() | Hämtar eller anger den spekulära färgen för materialet, standardvärdet är (1, 1, 1). |
+
+ **Result:**
+
+
+
+---
+
+
+### setSpecular{#setSpecular}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setSpecular(value) | Hämtar eller anger den spekulära färgen för materialet, standardvärdet är (1, 1, 1). |
+
+ **Result:**
+
+
+
+---
+
+
+### getDiffuseTexture{#getDiffuseTexture}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getDiffuseTexture() | Hämtar eller anger texturen för diffus |
+
+ **Result:**
+
+
+
+---
+
+
+### setDiffuseTexture{#setDiffuseTexture}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setDiffuseTexture(value) | Hämtar eller anger texturen för diffus |
+
+ **Result:**
+
+
+
+---
+
+
+### getDiffuse{#getDiffuse}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getDiffuse() | Hämtar eller anger den diffusa färgen för materialet, standardvärdet är (1, 1, 1) |
+
+ **Result:**
+
+
+
+---
+
+
+### setDiffuse{#setDiffuse}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setDiffuse(value) | Hämtar eller anger den diffusa färgen för materialet, standardvärdet är (1, 1, 1) |
+
+ **Result:**
+
+
+
+---
+
+
+### getEmissiveTexture{#getEmissiveTexture}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEmissiveTexture() | Hämtar eller anger texturen för emissiv |
+
+ **Result:**
+
+
+
+---
+
+
+### setEmissiveTexture{#setEmissiveTexture}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setEmissiveTexture(value) | Hämtar eller anger texturen för emissiv |
+
+ **Result:**
+
+
+
+---
+
+
+### getEmissiveColor{#getEmissiveColor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEmissiveColor() | Hämtar eller anger den emissiva färgen, standardvärdet är (0, 0, 0) |
+
+ **Result:**
+
+
+
+---
+
+
+### setEmissiveColor{#setEmissiveColor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setEmissiveColor(value) | Hämtar eller anger den emissiva färgen, standardvärdet är (0, 0, 0) |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTexture{#getTexture}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getTexture(slotName) | Hämtar texturen från den angivna sloten, den kan vara materialets egenskapsnamn eller shaderns parameternamn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| slotName | Sträng | Slotnamn. |
+
+ **Result:**
+TextureBase
+
+
+---
+
+
+### setTexture{#setTexture}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setTexture(slotName, texture) | Anger texturen till den angivna sloten |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| slotName | Sträng | Slotnamn. |
+| texture | TextureBase | Textur. |
+
+ **Result:**
+TextureBase
+
+
+---
+
+
+### toString{#toString}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toString() | Formaterar objekt till sträng. |
+
+ **Result:**
+Sträng
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+### iterator{#iterator}
+
+| Namn | Beskrivning |
+| --- | --- |
+| iterator() | Reserverad för internt bruk. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/pdfformat/_index.md
+++ b/swedish/nodejs-java/aspose.threed/pdfformat/_index.md
@@ -1,0 +1,179 @@
+---
+title: "PdfFormat"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/pdfformat/
+---
+## PdfFormat class
+
+Adobes Portable Document Format  @hideconstructor
+
+
+## Metoder
+
+### getVersion{#getVersion}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getVersion() | Hämtar filformatversion |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtension{#getExtension}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExtension() | Hämtar filändelsens namn för den här typen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtensions{#getExtensions}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExtensions() | Hämtar filändelserna för den här typen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getContentType{#getContentType}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getContentType() | Hämtar filformatets innehållstyp. Värdet på egenskapen är heltalskonstanten FileContentType. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormatType{#getFileFormatType}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileFormatType() | Hämtar filformattyp |
+
+ **Result:**
+
+
+
+---
+
+
+### extract{#extract}
+
+| Namn | Beskrivning |
+| --- | --- |
+| extract(fileName, password) | Extrahera rå 3D-innehåll från PDF-fil. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| fileNam | Sträng | null |
+| lösenord | byte[] | null |
+
+ **Result:**
+0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]
+
+
+---
+
+
+### extractScene{#extractScene}
+
+| Namn | Beskrivning |
+| --- | --- |
+| extractScene(fileName) | Extrahera 3D-scener från PDF-fil. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| fileNam | Sträng | null |
+
+ **Result:**
+0, Culture=neutral, PublicKeyToken=f071c641d0b4582b]]
+
+
+---
+
+
+### extractScene{#extractScene}
+
+| Namn | Beskrivning |
+| --- | --- |
+| extractScene(fileName, password) | Extrahera 3D-scener från PDF-fil. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| fileNam | Sträng | null |
+| lösenord | byte[] | null |
+
+ **Result:**
+0, Culture=neutral, PublicKeyToken=f071c641d0b4582b]]
+
+
+---
+
+
+### createLoadOptions{#createLoadOptions}
+
+| Namn | Beskrivning |
+| --- | --- |
+| createLoadOptions() | Skapa standardalternativ för inläsning för detta filformat. |
+
+ **Result:**
+LoadOptions
+
+
+---
+
+
+### createSaveOptions{#createSaveOptions}
+
+| Namn | Beskrivning |
+| --- | --- |
+| createSaveOptions() | Skapa standardalternativ för sparning för detta filformat. |
+
+ **Result:**
+SaveOptions
+
+
+---
+
+
+### toString{#toString}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toString() | Formaterar till sträng |
+
+ **Result:**
+Sträng
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/pdfloadoptions/_index.md
+++ b/swedish/nodejs-java/aspose.threed/pdfloadoptions/_index.md
@@ -1,0 +1,146 @@
+---
+title: "PdfLoadOptions"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/pdfloadoptions/
+---
+## PdfLoadOptions class
+
+Alternativ för PDF-inläsning
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Konstruktor för PdfLoadOptions |
+
+ **Result:**
+
+
+
+---
+
+
+### getPassword{#getPassword}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getPassword() | Lösenordet för att låsa upp den krypterade PDF-filen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setPassword{#setPassword}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setPassword(value) | Lösenordet för att låsa upp den krypterade PDF-filen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileFormat() | Hämtar filformatet som anges i aktuellt Spara/Ladda-alternativ. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEncoding() | Hämtar eller anger standardkodning för textbaserade filer. Standardvärdet är null, vilket betyder att importören/exportören bestämmer vilken kodning som ska användas. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileSystem() | Tillåter användaren att hantera hur externa beroenden ska hanteras under laddning/sparning. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFileSystem(value) | Tillåter användaren att hantera hur externa beroenden ska hanteras under laddning/sparning. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getLookupPaths() | Vissa filer, som OBJ, är beroende av externa filer; sökvägarna gör det möjligt för Aspose.3D att leta efter externa filer att ladda. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileName() | Filnamnet för den exporterade/importerade scenen. Detta är valfritt, men användbart när externa resurser som OBJ:s material serialiseras. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFileName(value) | Filnamnet för den exporterade/importerade scenen. Detta är valfritt, men användbart när externa resurser som OBJ:s material serialiseras. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/pdfsaveoptions/_index.md
+++ b/swedish/nodejs-java/aspose.threed/pdfsaveoptions/_index.md
@@ -1,0 +1,328 @@
+---
+title: "PdfSaveOptions"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/pdfsaveoptions/
+---
+## PdfSaveOptions class
+
+Sparaalternativen vid PDF-export.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Konstruktor för PdfSaveOptions |
+
+ **Result:**
+
+
+
+---
+
+
+### getRenderMode{#getRenderMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getRenderMode() | Renderingsläge specificerar stilen i vilken 3D-konstverket renderas. Värdet på egenskapen är heltalskonstanten PdfRenderMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRenderMode{#setRenderMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setRenderMode(value) | Renderingsläge specificerar stilen i vilken 3D-konstverket renderas. Värdet på egenskapen är heltalskonstanten PdfRenderMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLightingScheme{#getLightingScheme}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getLightingScheme() | LightingScheme specificerar belysningen som ska tillämpas på 3D-konstverket. Värdet på egenskapen är heltalskonstanten PdfLightingScheme. |
+
+ **Result:**
+
+
+
+---
+
+
+### setLightingScheme{#setLightingScheme}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setLightingScheme(value) | LightingScheme specificerar belysningen som ska tillämpas på 3D-konstverket. Värdet på egenskapen är heltalskonstanten PdfLightingScheme. |
+
+ **Result:**
+
+
+
+---
+
+
+### getBackgroundColor{#getBackgroundColor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBackgroundColor() | Bakgrundsfärg för 3D-vyn i PDF-filen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setBackgroundColor{#setBackgroundColor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setBackgroundColor(value) | Bakgrundsfärg för 3D-vyn i PDF-filen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFaceColor{#getFaceColor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFaceColor() | Hämtar eller anger ansiktsfärgen som ska användas vid rendering av 3D-innehållet. Detta är endast relevant när RenderMode har värdet Illustration. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFaceColor{#setFaceColor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFaceColor(value) | Hämtar eller anger ansiktsfärgen som ska användas vid rendering av 3D-innehållet. Detta är endast relevant när RenderMode har värdet Illustration. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAuxiliaryColor{#getAuxiliaryColor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getAuxiliaryColor() | Hämtar eller anger den hjälpfärg som ska användas vid rendering av 3D-innehållet. Tolkningen av denna färg beror på RenderMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setAuxiliaryColor{#setAuxiliaryColor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setAuxiliaryColor(value) | Hämtar eller anger den hjälpfärg som ska användas vid rendering av 3D-innehållet. Tolkningen av denna färg beror på RenderMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlipCoordinateSystem{#getFlipCoordinateSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFlipCoordinateSystem() | Hämtar eller anger för att vända koordinatsystemet för scenen vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlipCoordinateSystem{#setFlipCoordinateSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFlipCoordinateSystem(value) | Hämtar eller anger för att vända koordinatsystemet för scenen vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEmbedTextures{#getEmbedTextures}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEmbedTextures() | Bädda in de externa texturerna i PDF-filen, standardvärdet är falskt. |
+
+ **Result:**
+
+
+
+---
+
+
+### setEmbedTextures{#setEmbedTextures}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setEmbedTextures(value) | Bädda in de externa texturerna i PDF-filen, standardvärdet är falskt. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportTextures{#getExportTextures}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExportTextures() | Försök att kopiera texturer som används i scenen till utdatamappen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextures{#setExportTextures}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExportTextures(value) | Försök att kopiera texturer som används i scenen till utdatamappen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileFormat() | Hämtar filformatet som anges i aktuellt Spara/Ladda-alternativ. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEncoding() | Hämtar eller anger standardkodning för textbaserade filer. Standardvärdet är null, vilket betyder att importören/exportören bestämmer vilken kodning som ska användas. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileSystem() | Tillåter användaren att hantera hur externa beroenden ska hanteras under laddning/sparning. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFileSystem(value) | Tillåter användaren att hantera hur externa beroenden ska hanteras under laddning/sparning. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getLookupPaths() | Vissa filer, som OBJ, är beroende av externa filer; sökvägarna gör det möjligt för Aspose.3D att leta efter externa filer att ladda. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileName() | Filnamnet för den exporterade/importerade scenen. Detta är valfritt, men användbart när externa resurser som OBJ:s material serialiseras. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFileName(value) | Filnamnet för den exporterade/importerade scenen. Detta är valfritt, men användbart när externa resurser som OBJ:s material serialiseras. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/phongmaterial/_index.md
+++ b/swedish/nodejs-java/aspose.threed/phongmaterial/_index.md
@@ -1,0 +1,508 @@
+---
+title: "PhongMaterial"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/phongmaterial/
+---
+## PhongMaterial class
+
+Material för blinn-phong skuggningsmodell.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Initierar en ny instans av klassen PhongMaterial. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload(name) | Initierar en ny instans av klassen PhongMaterial. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| name | Sträng | Namn |
+
+ **Result:**
+
+
+
+---
+
+
+### getSpecularColor{#getSpecularColor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getSpecularColor() | Hämtar eller anger den speculära färgen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setSpecularColor{#setSpecularColor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setSpecularColor(value) | Hämtar eller anger den speculära färgen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getSpecularFactor{#getSpecularFactor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getSpecularFactor() | Hämtar eller anger den speculära faktorn. Formeln för spekular: SpecularColor SpecularFactor (N dot H) ^ Shininess |
+
+ **Result:**
+
+
+
+---
+
+
+### setSpecularFactor{#setSpecularFactor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setSpecularFactor(value) | Hämtar eller anger den speculära faktorn. Formeln för spekular: SpecularColor SpecularFactor (N dot H) ^ Shininess |
+
+ **Result:**
+
+
+
+---
+
+
+### getShininess{#getShininess}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getShininess() | Hämtar eller anger glansnivån, detta styr storleken på den spekulära högdpunkten. Formeln för spekular: SpecularColor SpecularFactor (N dot H) ^ Shininess Glansnivån. |
+
+ **Result:**
+
+
+
+---
+
+
+### setShininess{#setShininess}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setShininess(value) | Hämtar eller anger glansnivån, detta styr storleken på den spekulära högdpunkten. Formeln för spekular: SpecularColor SpecularFactor (N dot H) ^ Shininess Glansnivån. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReflectionColor{#getReflectionColor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getReflectionColor() | Hämtar eller anger reflektionsfärgen. Reflektionen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReflectionColor{#setReflectionColor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setReflectionColor(value) | Hämtar eller anger reflektionsfärgen. Reflektionen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReflectionFactor{#getReflectionFactor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getReflectionFactor() | Hämtar eller anger dämpningen av reflektionsfärgen. Reflektionsfaktorn. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReflectionFactor{#setReflectionFactor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setReflectionFactor(value) | Hämtar eller anger dämpningen av reflektionsfärgen. Reflektionsfaktorn. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEmissiveColor{#getEmissiveColor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEmissiveColor() | Hämtar eller anger den emissiva färgen |
+
+ **Result:**
+
+
+
+---
+
+
+### setEmissiveColor{#setEmissiveColor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setEmissiveColor(value) | Hämtar eller anger den emissiva färgen |
+
+ **Result:**
+
+
+
+---
+
+
+### getAmbientColor{#getAmbientColor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getAmbientColor() | Hämtar eller anger den omgivande färgen. Exempel: var mat = new LambertMaterial(); mat.AmbientColor = new Vector3(1, 1, 1); ambient. |
+
+ **Result:**
+
+
+
+---
+
+
+### setAmbientColor{#setAmbientColor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setAmbientColor(value) | Hämtar eller anger den omgivande färgen. Exempel: var mat = new LambertMaterial(); mat.AmbientColor = new Vector3(1, 1, 1); ambient. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDiffuseColor{#getDiffuseColor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getDiffuseColor() | Hämtar eller anger den diffusa färgen Exempel: var mat = new LambertMaterial(); mat.DiffuseColor = new Vector3(1, 0, 0); diffus. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDiffuseColor{#setDiffuseColor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setDiffuseColor(value) | Hämtar eller anger den diffusa färgen Exempel: var mat = new LambertMaterial(); mat.DiffuseColor = new Vector3(1, 0, 0); diffus. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTransparentColor{#getTransparentColor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getTransparentColor() | Hämtar eller anger den transparenta färgen. Exempel: var mat = new LambertMaterial(); mat.TransparentColor = new Vector3(0.3, 0.5, 0.2); färgen på den transparenta. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTransparentColor{#setTransparentColor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setTransparentColor(value) | Hämtar eller anger den transparenta färgen. Exempel: var mat = new LambertMaterial(); mat.TransparentColor = new Vector3(0.3, 0.5, 0.2); färgen på den transparenta. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTransparency{#getTransparency}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getTransparency() | Hämtar eller anger transparensfaktorn. Faktorn bör ligga mellan 0 (0 %, helt ogenomskinlig) och 1 (100 %, helt genomskinlig). Alla ogiltiga faktorer kommer att klippas. Exempel: var mat = new LambertMaterial(); mat.Transparency = 0.3; transparensfaktor. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTransparency{#setTransparency}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setTransparency(value) | Hämtar eller anger transparensfaktorn. Faktorn bör ligga mellan 0 (0 %, helt ogenomskinlig) och 1 (100 %, helt genomskinlig). Alla ogiltiga faktorer kommer att klippas. Exempel: var mat = new LambertMaterial(); mat.Transparency = 0.3; transparensfaktor. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTexture{#getTexture}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getTexture(slotName) | Hämtar texturen från den angivna sloten, den kan vara materialets egenskapsnamn eller shaderns parameternamn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| slotName | Sträng | Slotnamn. |
+
+ **Result:**
+TextureBase
+
+
+---
+
+
+### setTexture{#setTexture}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setTexture(slotName, texture) | Anger texturen till den angivna sloten |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| slotName | Sträng | Slotnamn. |
+| texture | TextureBase | Textur. |
+
+ **Result:**
+TextureBase
+
+
+---
+
+
+### toString{#toString}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toString() | Formaterar objekt till sträng. |
+
+ **Result:**
+Sträng
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+### iterator{#iterator}
+
+| Namn | Beskrivning |
+| --- | --- |
+| iterator() | Reserverad för internt bruk. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/pixelmapping/_index.md
+++ b/swedish/nodejs-java/aspose.threed/pixelmapping/_index.md
@@ -1,0 +1,68 @@
+---
+title: "PixelMapping"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/pixelmapping/
+---
+## PixelMapping class
+
+@hideconstructor
+
+
+## Metoder
+
+### getStride{#getStride}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getStride() | Byte av pixlar i en rad. |
+
+ **Result:**
+
+
+
+---
+
+
+### getHeight{#getHeight}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getHeight() | Rader av pixlar |
+
+ **Result:**
+
+
+
+---
+
+
+### getWidth{#getWidth}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getWidth() | Kolumner av pixlar |
+
+ **Result:**
+
+
+
+---
+
+
+### getData{#getData}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getData() | De mappade byten av pixlar. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/plane/_index.md
+++ b/swedish/nodejs-java/aspose.threed/plane/_index.md
@@ -1,0 +1,506 @@
+---
+title: "Plane"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/plane/
+---
+## Plane class
+
+Parametriserat plan.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Initierar en ny instans av Plane med standardstorlek 1x1. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload(length, width) | Initierar en ny instans av Plane. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| length | Nummer | Längd på planet. |
+| bredd | Nummer | Bredd på planet. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload2(name, length, width, lengthSegments, widthSegments) | Initierar en ny instans av Plane. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| name | Sträng | Namn. |
+| length | Nummer | Längd på planet. |
+| bredd | Nummer | Bredd på planet. |
+| lengthSegments | Nummer | Längdsegment. |
+| widthSegments | Nummer | Breddsegment. |
+
+ **Result:**
+
+
+
+---
+
+
+### getUp{#getUp}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getUp() | Hämtar eller anger uppvektorn för planet, standardvärdet är (0, 1, 0), detta påverkar genereringen av planet |
+
+ **Result:**
+
+
+
+---
+
+
+### setUp{#setUp}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setUp(value) | Hämtar eller anger uppvektorn för planet, standardvärdet är (0, 1, 0), detta påverkar genereringen av planet |
+
+ **Result:**
+
+
+
+---
+
+
+### getLength{#getLength}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getLength() | Hämtar eller anger längden på planet. Längden. |
+
+ **Result:**
+
+
+
+---
+
+
+### setLength{#setLength}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setLength(value) | Hämtar eller anger längden på planet. Längden. |
+
+ **Result:**
+
+
+
+---
+
+
+### getWidth{#getWidth}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getWidth() | Hämtar eller anger bredden på planet. Bredden. |
+
+ **Result:**
+
+
+
+---
+
+
+### setWidth{#setWidth}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setWidth(value) | Hämtar eller anger bredden på planet. Bredden. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLengthSegments{#getLengthSegments}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getLengthSegments() | Hämtar eller anger längdsegmenten. Längdsegmenten. |
+
+ **Result:**
+
+
+
+---
+
+
+### setLengthSegments{#setLengthSegments}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setLengthSegments(value) | Hämtar eller anger längdsegmenten. Längdsegmenten. |
+
+ **Result:**
+
+
+
+---
+
+
+### getWidthSegments{#getWidthSegments}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getWidthSegments() | Hämtar eller anger breddsegmenten. Breddsegmenten. |
+
+ **Result:**
+
+
+
+---
+
+
+### setWidthSegments{#setWidthSegments}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setWidthSegments(value) | Hämtar eller anger breddsegmenten. Breddsegmenten. |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastShadows{#getCastShadows}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getCastShadows() | Hämtar eller anger om denna geometri kan kasta skugga |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastShadows{#setCastShadows}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setCastShadows(value) | Hämtar eller anger om denna geometri kan kasta skugga |
+
+ **Result:**
+
+
+
+---
+
+
+### getReceiveShadows{#getReceiveShadows}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getReceiveShadows() | Hämtar eller anger om denna geometri kan ta emot skugga. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReceiveShadows{#setReceiveShadows}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setReceiveShadows(value) | Hämtar eller anger om denna geometri kan ta emot skugga. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNodes() | Hämtar alla föräldranoder, en entitet kan fästas vid flera föräldranoder för geometri‑instansering. Noderna. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExcluded() | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExcluded(value) | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNode() | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setParentNode(value) | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getScene() | Hämtar scenen som detta objekt tillhör |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### toMesh{#toMesh}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toMesh() | Konvertera aktuellt objekt till mesh |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBoundingBox() | Hämtar den omgivande lådan för den aktuella enheten i dess objektrums koordinatsystem. |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEntityRendererKey() | Hämtar nyckeln för enhetens renderare som är registrerad i renderaren |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/plyformat/_index.md
+++ b/swedish/nodejs-java/aspose.threed/plyformat/_index.md
@@ -1,0 +1,200 @@
+---
+title: "PlyFormat"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/plyformat/
+---
+## PlyFormat class
+
+PLY-formatet.  @hideconstructor
+
+
+## Metoder
+
+### getVersion{#getVersion}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getVersion() | Hämtar filformatversion |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtension{#getExtension}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExtension() | Hämtar filändelsens namn för den här typen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtensions{#getExtensions}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExtensions() | Hämtar filändelserna för den här typen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getContentType{#getContentType}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getContentType() | Hämtar filformatets innehållstyp. Värdet på egenskapen är heltalskonstanten FileContentType. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormatType{#getFileFormatType}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileFormatType() | Hämtar filformattyp |
+
+ **Result:**
+
+
+
+---
+
+
+### encode{#encode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| encode(entity, fileName) | Koda enheten och spara resultatet i en extern fil. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| entitet | Entitet | Entiteten att koda |
+| fileName | Sträng | Filen att skriva till |
+
+ **Result:**
+
+
+
+---
+
+
+### encode{#encode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| encode(entity, fileName, opt) | Koda enheten och spara resultatet i en extern fil. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| entitet | Entitet | Entiteten att koda |
+| fileName | Sträng | Filen att skriva till |
+| opt | PlySaveOptions | Spara alternativ |
+
+ **Result:**
+
+
+
+---
+
+
+### decode{#decode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| decode(fileName) | Dekoda ett punktmoln eller nät från den angivna strömmen. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| fileName | Sträng | Inmatningsströmmen |
+
+ **Result:**
+Geometry
+
+
+---
+
+
+### decode{#decode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| decode(fileName, opt) | Dekoda ett punktmoln eller nät från den angivna strömmen. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| fileName | Sträng | Inmatningsströmmen |
+| opt | PlyLoadOptions | Laddningsalternativ för PLY-format |
+
+ **Result:**
+Geometry
+
+
+---
+
+
+### createLoadOptions{#createLoadOptions}
+
+| Namn | Beskrivning |
+| --- | --- |
+| createLoadOptions() | Skapa standardalternativ för inläsning för detta filformat. |
+
+ **Result:**
+LoadOptions
+
+
+---
+
+
+### createSaveOptions{#createSaveOptions}
+
+| Namn | Beskrivning |
+| --- | --- |
+| createSaveOptions() | Skapa standardalternativ för sparning för detta filformat. |
+
+ **Result:**
+SaveOptions
+
+
+---
+
+
+### toString{#toString}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toString() | Formaterar till sträng |
+
+ **Result:**
+Sträng
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/plyloadoptions/_index.md
+++ b/swedish/nodejs-java/aspose.threed/plyloadoptions/_index.md
@@ -1,0 +1,146 @@
+---
+title: "PlyLoadOptions"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/plyloadoptions/
+---
+## PlyLoadOptions class
+
+Läsalternativ för PLY-filer
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Konstruktor för PlyLoadOptions |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlipCoordinateSystem{#getFlipCoordinateSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFlipCoordinateSystem() | Hämtar eller anger vändning av koordinatsystemet för kontrollpunkter/normaler under import/export. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlipCoordinateSystem{#setFlipCoordinateSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFlipCoordinateSystem(value) | Hämtar eller anger vändning av koordinatsystemet för kontrollpunkter/normaler under import/export. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileFormat() | Hämtar filformatet som anges i aktuellt Spara/Ladda-alternativ. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEncoding() | Hämtar eller anger standardkodning för textbaserade filer. Standardvärdet är null, vilket betyder att importören/exportören bestämmer vilken kodning som ska användas. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileSystem() | Tillåter användaren att hantera hur externa beroenden ska hanteras under laddning/sparning. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFileSystem(value) | Tillåter användaren att hantera hur externa beroenden ska hanteras under laddning/sparning. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getLookupPaths() | Vissa filer, som OBJ, är beroende av externa filer; sökvägarna gör det möjligt för Aspose.3D att leta efter externa filer att ladda. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileName() | Filnamnet för den exporterade/importerade scenen. Detta är valfritt, men användbart när externa resurser som OBJ:s material serialiseras. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFileName(value) | Filnamnet för den exporterade/importerade scenen. Detta är valfritt, men användbart när externa resurser som OBJ:s material serialiseras. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/plysaveoptions/_index.md
+++ b/swedish/nodejs-java/aspose.threed/plysaveoptions/_index.md
@@ -1,0 +1,347 @@
+---
+title: "PlySaveOptions"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/plysaveoptions/
+---
+## PlySaveOptions class
+
+Sparaalternativ för att exportera scen som PLY-fil.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Konstruktor för PlySaveOptions |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload(contentType) | Konstruktor för PlySaveOptions |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| contentType | FileContentType | FileContentType |
+
+ **Result:**
+
+
+
+---
+
+
+### getPointCloud{#getPointCloud}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getPointCloud() | Exportera scenen som punktmoln, standardvärdet är false. |
+
+ **Result:**
+
+
+
+---
+
+
+### setPointCloud{#setPointCloud}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setPointCloud(value) | Exportera scenen som punktmoln, standardvärdet är false. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlipCoordinate{#getFlipCoordinate}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFlipCoordinate() | Vänd koordinaten vid sparande av scenen, standardvärdet är true |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlipCoordinate{#setFlipCoordinate}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFlipCoordinate(value) | Vänd koordinaten vid sparande av scenen, standardvärdet är true |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElement{#getVertexElement}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getVertexElement() | Elementnamnet för vertex‑data, standardvärdet är "vertex" |
+
+ **Result:**
+
+
+
+---
+
+
+### setVertexElement{#setVertexElement}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setVertexElement(value) | Elementnamnet för vertex‑data, standardvärdet är "vertex" |
+
+ **Result:**
+
+
+
+---
+
+
+### getPositionComponents{#getPositionComponents}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getPositionComponents() | Komponentnamnen för positionsdata, standardvärdet är ("x", "y", "z") |
+
+ **Result:**
+
+
+
+---
+
+
+### getNormalComponents{#getNormalComponents}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getNormalComponents() | Komponentnamnen för normaldata, standardvärdet är ("nx", "ny", "nz") |
+
+ **Result:**
+
+
+
+---
+
+
+### getTextureCoordinateComponents{#getTextureCoordinateComponents}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getTextureCoordinateComponents() | Komponentnamnen för texturkoordinatdata, standardvärdet är ("u", "v") |
+
+ **Result:**
+
+
+
+---
+
+
+### getColorComponents{#getColorComponents}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getColorComponents() | Komponentnamnen för vertexfärg, standardvärdet är ("red", "green", "blue") |
+
+ **Result:**
+
+
+
+---
+
+
+### getFaceElement{#getFaceElement}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFaceElement() | Elementnamnet för ansiktsdata, standardvärdet är "face" |
+
+ **Result:**
+
+
+
+---
+
+
+### setFaceElement{#setFaceElement}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFaceElement(value) | Elementnamnet för ansiktsdata, standardvärdet är "face" |
+
+ **Result:**
+
+
+
+---
+
+
+### getFaceProperty{#getFaceProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFaceProperty() | Egenskapsnamnet för ansiktsdata, standardvärdet är "vertex_index" |
+
+ **Result:**
+
+
+
+---
+
+
+### setFaceProperty{#setFaceProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFaceProperty(value) | Egenskapsnamnet för ansiktsdata, standardvärdet är "vertex_index" |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportTextures{#getExportTextures}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExportTextures() | Försök att kopiera texturer som används i scenen till utdatamappen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextures{#setExportTextures}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExportTextures(value) | Försök att kopiera texturer som används i scenen till utdatamappen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileFormat() | Hämtar filformatet som anges i aktuellt Spara/Ladda-alternativ. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEncoding() | Hämtar eller anger standardkodning för textbaserade filer. Standardvärdet är null, vilket betyder att importören/exportören bestämmer vilken kodning som ska användas. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileSystem() | Tillåter användaren att hantera hur externa beroenden ska hanteras under laddning/sparning. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFileSystem(value) | Tillåter användaren att hantera hur externa beroenden ska hanteras under laddning/sparning. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getLookupPaths() | Vissa filer, som OBJ, är beroende av externa filer; sökvägarna gör det möjligt för Aspose.3D att leta efter externa filer att ladda. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileName() | Filnamnet för den exporterade/importerade scenen. Detta är valfritt, men användbart när externa resurser som OBJ:s material serialiseras. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFileName(value) | Filnamnet för den exporterade/importerade scenen. Detta är valfritt, men användbart när externa resurser som OBJ:s material serialiseras. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/pointcloud/_index.md
+++ b/swedish/nodejs-java/aspose.threed/pointcloud/_index.md
@@ -1,0 +1,580 @@
+---
+title: "PointCloud"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/pointcloud/
+---
+## PointCloud class
+
+Punktmolnet innehåller ingen topologiinformation utan endast kontrollpunkterna och vertex-elementen.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor(name) | Konstruktor för PointCloud |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| name | Sträng | Namnet på denna entitet |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload() | Konstruktor för PointCloud |
+
+ **Result:**
+
+
+
+---
+
+
+### getVisible{#getVisible}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getVisible() | Hämtar eller anger om geometrin är synlig |
+
+ **Result:**
+
+
+
+---
+
+
+### setVisible{#setVisible}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setVisible(value) | Hämtar eller anger om geometrin är synlig |
+
+ **Result:**
+
+
+
+---
+
+
+### getDeformers{#getDeformers}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getDeformers() | Hämtar alla deformers som är associerade med denna geometri. Deformers. |
+
+ **Result:**
+
+
+
+---
+
+
+### getControlPoints{#getControlPoints}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getControlPoints() | Hämtar alla kontrollpunkter |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastShadows{#getCastShadows}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getCastShadows() | Hämtar eller anger om denna geometri kan kasta skugga |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastShadows{#setCastShadows}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setCastShadows(value) | Hämtar eller anger om denna geometri kan kasta skugga |
+
+ **Result:**
+
+
+
+---
+
+
+### getReceiveShadows{#getReceiveShadows}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getReceiveShadows() | Hämtar eller anger om denna geometri kan ta emot skugga. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReceiveShadows{#setReceiveShadows}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setReceiveShadows(value) | Hämtar eller anger om denna geometri kan ta emot skugga. |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElements{#getVertexElements}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getVertexElements() | Hämtar alla vertex elements |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNodes() | Hämtar alla föräldranoder, en entitet kan fästas vid flera föräldranoder för geometri‑instansering. Noderna. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExcluded() | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExcluded(value) | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNode() | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setParentNode(value) | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getScene() | Hämtar scenen som detta objekt tillhör |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEntityRendererKey() | Hämtar nyckeln för enhetens renderare som är registrerad i renderaren |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### fromGeometry{#fromGeometry}
+
+| Namn | Beskrivning |
+| --- | --- |
+| fromGeometry(g) | Skapa en ny PointCloud-instans från ett geometriskt objekt |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+|  | Geometry | null |
+
+ **Result:**
+PointCloud
+
+
+---
+
+
+### fromGeometry{#fromGeometry}
+
+| Namn | Beskrivning |
+| --- | --- |
+| fromGeometry(g, density) | Skapa en ny point cloud-instans från ett geometriskt objekt. Täthet är antalet punkter per enhetstriangel(Enhetstriangel är den triangel med maximal yta i meshen) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| g | Geometry | Mesh eller annan geometrisk instans |
+| density | Nummer | Antal punkter per enhetstriangel |
+
+ **Result:**
+PointCloud
+
+
+---
+
+
+### getElement{#getElement}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getElement(type) | Hämtar ett vertex element med angiven typ |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| typ | VertexElementType | VertexElementType |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### getVertexElementOfUV{#getVertexElementOfUV}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getVertexElementOfUV(textureMapping) | Hämtar en VertexElementUV-instans med given texture mapping-typ |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| textureMapping | TextureMapping | TextureMapping |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### createElement{#createElement}
+
+| Namn | Beskrivning |
+| --- | --- |
+| createElement(type) | Skapar ett vertex element med angiven typ och lägger till det i geometrin. Om typen är VertexElementType.UV, skapas ett VertexElementUV med texture mapping-typ till TextureMapping.DIFFUSE. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| typ | VertexElementType | VertexElementType |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### addElement{#addElement}
+
+| Namn | Beskrivning |
+| --- | --- |
+| addElement(element) | Lägger till ett befintligt vertex element i den aktuella geometrin |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| element | VertexElement | Vertex elementet att lägga till |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### createElement{#createElement}
+
+| Namn | Beskrivning |
+| --- | --- |
+| createElement(type, mappingMode, referenceMode) | Skapar ett vertex element med angiven typ och lägger till det i geometrin. Om typen är VertexElementType.UV, skapas ett VertexElementUV med texture mapping-typ till TextureMapping.DIFFUSE. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| typ | VertexElementType | VertexElementType |
+| mappingMode | MappingMode | MappingMode |
+| referenceMode | ReferenceMode | ReferenceMode |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### createElementUV{#createElementUV}
+
+| Namn | Beskrivning |
+| --- | --- |
+| createElementUV(uvMapping) | Skapar ett VertexElementUV med given texturkartläggningstyp. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| uvMapping | TextureMapping | TextureMapping |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### createElementUV{#createElementUV}
+
+| Namn | Beskrivning |
+| --- | --- |
+| createElementUV(uvMapping, mappingMode, referenceMode) | Skapar ett VertexElementUV med given texturkartläggningstyp. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| uvMapping | TextureMapping | TextureMapping |
+| mappingMode | MappingMode | MappingMode |
+| referenceMode | ReferenceMode | ReferenceMode |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBoundingBox() | Hämtar den omgivande lådan för den aktuella enheten i dess objektrums koordinatsystem. |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/polygonbuilder/_index.md
+++ b/swedish/nodejs-java/aspose.threed/polygonbuilder/_index.md
@@ -1,0 +1,80 @@
+---
+title: "PolygonBuilder"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/polygonbuilder/
+---
+## PolygonBuilder class
+
+En hjälparklass för att bygga polygoner för Mesh
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor(mesh) | Initierar en ny instans av klassen PolygonBuilder. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| mesh | Mesh | På vilket mesh polygonen ska byggas. |
+
+ **Result:**
+
+
+
+---
+
+
+### begin{#begin}
+
+| Namn | Beskrivning |
+| --- | --- |
+| begin() | Påbörjar att lägga till en ny polygon |
+
+ **Result:**
+
+
+
+---
+
+
+### addVertex{#addVertex}
+
+| Namn | Beskrivning |
+| --- | --- |
+| addVertex(index) | Lägger till ett vertex-index till polygonen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| inde | Nummer | null |
+
+ **Result:**
+
+
+
+---
+
+
+### end{#end}
+
+| Namn | Beskrivning |
+| --- | --- |
+| end() | Avslutar skapandet av polygonen |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/polygonmodifier/_index.md
+++ b/swedish/nodejs-java/aspose.threed/polygonmodifier/_index.md
@@ -1,0 +1,266 @@
+---
+title: "PolygonModifier"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/polygonmodifier/
+---
+## PolygonModifier class
+
+Verktyg för att modifiera polygoner  @hideconstructor
+
+
+## Metoder
+
+### triangulate{#triangulate}
+
+| Namn | Beskrivning |
+| --- | --- |
+| triangulate(scene) | Konvertera alla polygonbaserade mesh till en fullständig triangulär mesh |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| scen | Scene | Scenen att bearbeta |
+
+ **Result:**
+
+
+
+---
+
+
+### triangulate{#triangulate}
+
+| Namn | Beskrivning |
+| --- | --- |
+| triangulate(mesh) | Konvertera ett polygonbaserat mesh till en fullständig triangulär mesh |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| mesh | Mesh | Det ursprungliga icke-triangulära meshet |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### mergeMesh{#mergeMesh}
+
+| Namn | Beskrivning |
+| --- | --- |
+| mergeMesh(scene) | Konvertera en hel scen till ett enda transformerat mesh. Vertex-element som normal-/texturkoordinater stöds ännu inte |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| scen | Scene | Scenen att slå ihop |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### mergeMesh{#mergeMesh}
+
+| Namn | Beskrivning |
+| --- | --- |
+| mergeMesh(node) | Konvertera en hel nod till ett enda transformerat mesh. Vertex-element som normal-/texturkoordinater stöds ännu inte |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| nod | Nod | Noden att slå ihop |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### scale{#scale}
+
+| Namn | Beskrivning |
+| --- | --- |
+| scale(scene, scale) | Skala alla geometrier (Skala kontrollpunkterna, inte transformationsmatrisen) i denna scen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| scen | Scene | Scenen att skala |
+| scale | Vector3 | Skalfaktorn |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### scale{#scale}
+
+| Namn | Beskrivning |
+| --- | --- |
+| scale(node, scale) | Skala alla geometrier (Skala kontrollpunkterna, inte transformationsmatrisen) i denna nod |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| nod | Nod | Noden att skala |
+| scale | Vector3 | Skalfaktorn |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### generateNormal{#generateNormal}
+
+| Namn | Beskrivning |
+| --- | --- |
+| generateNormal(mesh) | Generera normaldata från Mesh-definitionen |
+
+ **Result:**
+VertexElementNormal
+
+
+---
+
+
+### generateUV{#generateUV}
+
+| Namn | Beskrivning |
+| --- | --- |
+| generateUV(mesh, normals) | Generera UV-data från den givna inmatningsmeshen och den specificerade normaldatan. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| mesh | Mesh | Den inmatningsmeshen |
+| normaler | VertexElementNormal | Normaldatan |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### generateUV{#generateUV}
+
+| Namn | Beskrivning |
+| --- | --- |
+| generateUV(mesh) | Generera UV-data från den givna inmatningsmeshen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| mesh | Mesh | Den inmatningsmeshen |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### splitMesh{#splitMesh}
+
+| Namn | Beskrivning |
+| --- | --- |
+| splitMesh(node, policy, createChildNodes, removeOldMesh) | Dela mesh i del-meshar med VertexElementMaterial. Varje del-mesh kommer att använda endast ett material. Utför meshdelning på en nod. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| nod | Nod | null |
+| policy | SplitMeshPolicy | SplitMeshPolicy |
+| createChildNodes | boolean | Skapa barnnoder för varje del-mesh. |
+| removeOldMesh | boolean | Ta bort den gamla meshen efter delning, om denna parameter är falsk, kommer den gamla och den nya meshen att existera samtidigt. |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### splitMesh{#splitMesh}
+
+| Namn | Beskrivning |
+| --- | --- |
+| splitMesh(scene, policy, removeOldMesh) | Dela mesh i del-meshar med VertexElementMaterial. Varje del-mesh kommer att använda endast ett material. Utför meshdelning på alla noder i scenen. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| scen | Scene | null |
+| policy | SplitMeshPolicy | SplitMeshPolicy |
+| removeOldMes | boolean | null |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### splitMesh{#splitMesh}
+
+| Namn | Beskrivning |
+| --- | --- |
+| splitMesh(mesh, policy) | Dela mesh i del-meshar med VertexElementMaterial. Varje del-mesh kommer att använda endast ett material. Den ursprungliga meshen kommer inte att ändras. |
+
+ **Result:**
+Mesh[]
+
+
+---
+
+
+### buildTangentBinormal{#buildTangentBinormal}
+
+| Namn | Beskrivning |
+| --- | --- |
+| buildTangentBinormal(scene) | Detta kommer att skapa tangent och binormal på alla meshar i scenen. Normal är krävd, om normal inte finns på meshen, kommer den också att skapa normaldata från position. UV är också krävt, meshen kommer att ignoreras om ingen UV är definierad. |
+
+ **Result:**
+Mesh[]
+
+
+---
+
+
+### buildTangentBinormal{#buildTangentBinormal}
+
+| Namn | Beskrivning |
+| --- | --- |
+| buildTangentBinormal(mesh) | Det här kommer att skapa tangent och binormal på meshen. Normal krävs; om normal inte finns på meshen kommer den också att skapa normaldata från positionen. UV krävs också, ett undantag kommer att kastas om ingen UV hittas. |
+
+ **Result:**
+Mesh[]
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/pose/_index.md
+++ b/swedish/nodejs-java/aspose.threed/pose/_index.md
@@ -1,0 +1,263 @@
+---
+title: "Pose"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/pose/
+---
+## Pose class
+
+Posen används för att lagra transformationsmatrisen när geometrin är skinad. Posen är en uppsättning BonePose, där varje BonePose sparar den konkreta transformationsinformationen för ben-noden.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor(name) | Initierar en ny instans av klassen Pose. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| name | Sträng | Namn |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload() | Initierar en ny instans av klassen Pose. |
+
+ **Result:**
+
+
+
+---
+
+
+### getPoseType{#getPoseType}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getPoseType() | Hämtar eller anger typen av posen. Värdet på egenskapen är PoseType heltalskonstant. Typen av posen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setPoseType{#setPoseType}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setPoseType(value) | Hämtar eller anger typen av posen. Värdet på egenskapen är PoseType heltalskonstant. Typen av posen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getBonePoses{#getBonePoses}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBonePoses() | Hämtar alla BonePose. Noderna. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### addBonePose{#addBonePose}
+
+| Namn | Beskrivning |
+| --- | --- |
+| addBonePose(node, matrix, localMatrix) | Sparar posens transformationsmatris för den angivna bennoden. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| nod | Nod | Bennod. |
+| matrix | Matrix4 | Transformationsmatris. |
+| localMatrix | boolean | Om inställt på |
+
+ **Result:**
+
+
+
+---
+
+
+### addBonePose{#addBonePose}
+
+| Namn | Beskrivning |
+| --- | --- |
+| addBonePose(node, matrix) | Sparar posens transformationsmatris för den angivna benknuten. Global transformationsmatris antas. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| nod | Nod | Bennod. |
+| matrix | Matrix4 | Transformationsmatris. |
+
+ **Result:**
+
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/postprocessing/_index.md
+++ b/swedish/nodejs-java/aspose.threed/postprocessing/_index.md
@@ -1,0 +1,177 @@
+---
+title: "PostProcessing"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/postprocessing/
+---
+## PostProcessing class
+
+Efterbehandlingseffekterna  @hideconstructor
+
+
+## Metoder
+
+### getInput{#getInput}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getInput() | Inmatning för denna efterbehandling |
+
+ **Result:**
+
+
+
+---
+
+
+### setInput{#setInput}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setInput(value) | Inmatning för denna efterbehandling |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/primitive/_index.md
+++ b/swedish/nodejs-java/aspose.threed/primitive/_index.md
@@ -1,0 +1,339 @@
+---
+title: "Primitive"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/primitive/
+---
+## Primitive class
+
+Basklass för alla primitiv.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor(name) | Initierar en ny instans av klassen Primitive. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| name | Sträng | Namn. |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastShadows{#getCastShadows}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getCastShadows() | Hämtar eller anger om denna geometri kan kasta skugga |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastShadows{#setCastShadows}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setCastShadows(value) | Hämtar eller anger om denna geometri kan kasta skugga |
+
+ **Result:**
+
+
+
+---
+
+
+### getReceiveShadows{#getReceiveShadows}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getReceiveShadows() | Hämtar eller anger om denna geometri kan ta emot skugga. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReceiveShadows{#setReceiveShadows}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setReceiveShadows(value) | Hämtar eller anger om denna geometri kan ta emot skugga. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNodes() | Hämtar alla föräldranoder, en entitet kan fästas vid flera föräldranoder för geometri‑instansering. Noderna. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExcluded() | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExcluded(value) | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNode() | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setParentNode(value) | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getScene() | Hämtar scenen som detta objekt tillhör |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### toMesh{#toMesh}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toMesh() | Konvertera aktuellt objekt till mesh |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBoundingBox() | Hämtar den omgivande lådan för den aktuella enheten i dess objektrums koordinatsystem. |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEntityRendererKey() | Hämtar nyckeln för enhetens renderare som är registrerad i renderaren |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/profile/_index.md
+++ b/swedish/nodejs-java/aspose.threed/profile/_index.md
@@ -1,0 +1,255 @@
+---
+title: "Profil"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/profile/
+---
+## Profile class
+
+2D-profil i xy-planet  @hideconstructor
+
+
+## Metoder
+
+### getParentNodes{#getParentNodes}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNodes() | Hämtar alla föräldranoder, en entitet kan fästas vid flera föräldranoder för geometri‑instansering. Noderna. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExcluded() | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExcluded(value) | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNode() | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setParentNode(value) | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getScene() | Hämtar scenen som detta objekt tillhör |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEntityRendererKey() | Hämtar nyckeln för enhetens renderare som är registrerad i renderaren |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBoundingBox() | Hämtar den omgivande lådan för den aktuella enheten i dess objektrums koordinatsystem. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/property/_index.md
+++ b/swedish/nodejs-java/aspose.threed/property/_index.md
@@ -1,0 +1,230 @@
+---
+title: "Property"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/property/
+---
+## Property class
+
+Klass för att hålla användardefinierade egenskaper.  @hideconstructor
+
+
+## Metoder
+
+### getValue{#getValue}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getValue() | Hämtar eller anger värdet. Värdet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setValue{#setValue}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setValue(value) | Hämtar eller anger värdet. Värdet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getValueType{#getValueType}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getValueType() | Hämtar typen av egenskapsvärdet. Typen av värdet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### getBindPoint{#getBindPoint}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBindPoint(anim, create) | Hämtar egenskapens bindningspunkt på den angivna animationsinstansen. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| anim | AnimationNode | På vilken animation som bindpunkten ska skapas. |
+| skapa | boolean | Skapa egenskapsbindpunkten om den inte finns. |
+
+ **Result:**
+BindPoint
+
+
+---
+
+
+### getKeyframeSequence{#getKeyframeSequence}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getKeyframeSequence(anim, create) | Hämtar nyckelbildssekvensen för den angivna animationsinstansen. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| anim | AnimationNode | På vilken animation som nyckelbildssekvensen ska skapas. |
+| skapa | boolean | Skapa nyckelbildssekvensen om den inte finns. |
+
+ **Result:**
+KeyframeSequence
+
+
+---
+
+
+### toString{#toString}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toString() | Returnerar en sträng som representerar den aktuella egenskapen. |
+
+ **Result:**
+Sträng
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/propertycollection/_index.md
+++ b/swedish/nodejs-java/aspose.threed/propertycollection/_index.md
@@ -1,0 +1,125 @@
+---
+title: "PropertyCollection"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/propertycollection/
+---
+## PropertyCollection class
+
+Samlingen av egenskaper  @hideconstructor
+
+
+## Metoder
+
+### get{#get}
+
+| Namn | Beskrivning |
+| --- | --- |
+| get(idx) |  |
+
+ **Result:**
+
+
+
+---
+
+
+### get{#get}
+
+| Namn | Beskrivning |
+| --- | --- |
+| get(property) |  |
+
+ **Result:**
+
+
+
+---
+
+
+### set{#set}
+
+| Namn | Beskrivning |
+| --- | --- |
+| set(property, value) |  |
+
+ **Result:**
+
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(property) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### iterator{#iterator}
+
+| Namn | Beskrivning |
+| --- | --- |
+| iterator() | Reserverad för internt bruk. |
+
+ **Result:**
+boolean
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/pushconstant/_index.md
+++ b/swedish/nodejs-java/aspose.threed/pushconstant/_index.md
@@ -1,0 +1,166 @@
+---
+title: "PushConstant"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/pushconstant/
+---
+## PushConstant class
+
+Ett verktyg för att tillhandahålla data till shader genom push constant.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Konstruktor för PushConstant |
+
+ **Result:**
+
+
+
+---
+
+
+### write{#write}
+
+| Namn | Beskrivning |
+| --- | --- |
+| write(mat) | Skriv matrisen till konstanten |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| mat | FMatrix4 | Matrisen att skriva |
+
+ **Result:**
+
+
+
+---
+
+
+### write{#write}
+
+| Namn | Beskrivning |
+| --- | --- |
+| write(n) | Skriv ett int‑värde till konstanten |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+|  | Nummer | null |
+
+ **Result:**
+
+
+
+---
+
+
+### write{#write}
+
+| Namn | Beskrivning |
+| --- | --- |
+| write(f) | Skriv ett float‑värde till konstanten |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+|  | Nummer | null |
+
+ **Result:**
+
+
+
+---
+
+
+### write{#write}
+
+| Namn | Beskrivning |
+| --- | --- |
+| write(vec) | Skriv en 4‑komponentsvektor till konstanten |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| ve | FVector4 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### write{#write}
+
+| Namn | Beskrivning |
+| --- | --- |
+| write(vec) | Skriv en 3‑komponentsvektor till konstanten |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| ve | FVector3 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### write{#write}
+
+| Namn | Beskrivning |
+| --- | --- |
+| write(x, y, z, w) | Skriv en 4‑komponentsvektor till konstanten |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+|  | Nummer | null |
+|  | Nummer | null |
+|  | Nummer | null |
+|  | Nummer | null |
+
+ **Result:**
+
+
+
+---
+
+
+### commit{#commit}
+
+| Namn | Beskrivning |
+| --- | --- |
+| commit(stage, commandList) | Skicka förberedda data till grafikpipeline. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| stage | Nummer | ShaderStage |
+| commandLis | ICommandList | null |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/pyramid/_index.md
+++ b/swedish/nodejs-java/aspose.threed/pyramid/_index.md
@@ -1,0 +1,505 @@
+---
+title: "Pyramid"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/pyramid/
+---
+## Pyramid class
+
+Parametriserad pyramid.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Skapa en ny pyramidinstans med standard bottenområde (10, 10) och standardhöjd (5) |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload(xbottom, ybottom, height) | Skapa en ny pyramidinstans med angivet bottenområde |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| xbottom | Nummer | Längden i x-riktning för botten |
+| ybottom | Nummer | Längden i y-riktning för botten |
+| height | Nummer | Pyramidens höjd |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload2(xbottom, ybottom, xtop, ytop, height) | Skapa en ny pyramidinstans med angivet bottenområde, topområde och höjd. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| xbottom | Nummer | Längden i x-riktning för bottenområdet |
+| ybottom | Nummer | Längden i y-riktning för bottenområdet |
+| xtop | Nummer | Längden i x-riktning för topområdet |
+| ytop | Nummer | Längden i y-riktning för topområdet |
+| height | Nummer | Pyramidens höjd |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload3{#constructor_overload3}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload3(name, xbottom, ybottom, xtop, ytop, height) | Skapa en ny pyramidinstans med angivet bottenområde, topområde och höjd. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| name | Sträng | Namnet på pyramiden |
+| xbottom | Nummer | Längden i x-riktning för bottenområdet |
+| ybottom | Nummer | Längden i y-riktning för bottenområdet |
+| xtop | Nummer | Längden i x-riktning för topområdet |
+| ytop | Nummer | Längden i y-riktning för topområdet |
+| height | Nummer | Pyramidens höjd |
+
+ **Result:**
+
+
+
+---
+
+
+### getBottomArea{#getBottomArea}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBottomArea() | Area av bottenkåpan |
+
+ **Result:**
+
+
+
+---
+
+
+### setBottomArea{#setBottomArea}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setBottomArea(value) | Area av bottenkåpan |
+
+ **Result:**
+
+
+
+---
+
+
+### getTopArea{#getTopArea}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getTopArea() | Area av topkåpan |
+
+ **Result:**
+
+
+
+---
+
+
+### setTopArea{#setTopArea}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setTopArea(value) | Area av topkåpan |
+
+ **Result:**
+
+
+
+---
+
+
+### getBottomOffset{#getBottomOffset}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBottomOffset() | Offset för bottenhörnpunkter |
+
+ **Result:**
+
+
+
+---
+
+
+### setBottomOffset{#setBottomOffset}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setBottomOffset(value) | Offset för bottenhörnpunkter |
+
+ **Result:**
+
+
+
+---
+
+
+### getHeight{#getHeight}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getHeight() | Höjd på pyramiden |
+
+ **Result:**
+
+
+
+---
+
+
+### setHeight{#setHeight}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setHeight(value) | Höjd på pyramiden |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastShadows{#getCastShadows}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getCastShadows() | Hämtar eller anger om denna geometri kan kasta skugga |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastShadows{#setCastShadows}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setCastShadows(value) | Hämtar eller anger om denna geometri kan kasta skugga |
+
+ **Result:**
+
+
+
+---
+
+
+### getReceiveShadows{#getReceiveShadows}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getReceiveShadows() | Hämtar eller anger om denna geometri kan ta emot skugga. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReceiveShadows{#setReceiveShadows}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setReceiveShadows(value) | Hämtar eller anger om denna geometri kan ta emot skugga. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNodes() | Hämtar alla föräldranoder, en entitet kan fästas vid flera föräldranoder för geometri‑instansering. Noderna. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExcluded() | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExcluded(value) | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNode() | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setParentNode(value) | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getScene() | Hämtar scenen som detta objekt tillhör |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### toMesh{#toMesh}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toMesh() | Konvertera aktuellt objekt till mesh |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBoundingBox() | Hämtar den omgivande lådan för den aktuella enheten i dess objektrums koordinatsystem. |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEntityRendererKey() | Hämtar nyckeln för enhetens renderare som är registrerad i renderaren |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/quaternion/_index.md
+++ b/swedish/nodejs-java/aspose.threed/quaternion/_index.md
@@ -1,0 +1,323 @@
+---
+title: "Kvaternion"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/quaternion/
+---
+## Quaternion class
+
+Quaternion används vanligtvis för att utföra rotation i datorgrafik.
+
+
+## Egenskaper
+
+| Namn | Beskrivning |
+| --- | --- |
+| w | w-komponenten. |
+| x | x-komponenten. |
+| y | y-komponenten. |
+| z | z-komponenten. |
+| IDENTITY | Identitetskvaternionen. |
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload(w, x, y, z) | Initierar en ny instans av Quaternion-klassen. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| w | Nummer | w-komponent av kvaternionen |
+| x | Nummer | x-komponent av kvaternionen |
+| y | Nummer | y-komponent av kvaternionen |
+| z | Nummer | z-komponent av kvaternionen |
+
+ **Result:**
+
+
+
+---
+
+
+### getLength{#getLength}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getLength() | Hämtar längden på kvaternionen |
+
+ **Result:**
+
+
+
+---
+
+
+### equals{#equals}
+
+| Namn | Beskrivning |
+| --- | --- |
+| equals(obj) | Kontrollera om två kvaternioner är lika |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| obj | Objekt | Objektet för att kontrollera likhet. |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### hashCode{#hashCode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| hashCode() | Hämtar hashkoden för Quaternion |
+
+ **Result:**
+Nummer
+
+
+---
+
+
+### conjugate{#conjugate}
+
+| Namn | Beskrivning |
+| --- | --- |
+| conjugate() | Returnerar en konjugerad kvaternion av den aktuella kvaternionen |
+
+ **Result:**
+Kvaternion
+
+
+---
+
+
+### inverse{#inverse}
+
+| Namn | Beskrivning |
+| --- | --- |
+| inverse() | Returnerar en invers kvaternion av den aktuella kvaternionen |
+
+ **Result:**
+Kvaternion
+
+
+---
+
+
+### dot{#dot}
+
+| Namn | Beskrivning |
+| --- | --- |
+| dot(q) | Punktprodukt |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| q | Kvaternion | Kvaternionen |
+
+ **Result:**
+Nummer
+
+
+---
+
+
+### eulerAngles{#eulerAngles}
+
+| Namn | Beskrivning |
+| --- | --- |
+| eulerAngles() | Konverterar kvaternion till rotation representerad av Eulervinklar. Alla komponenter är i radian |
+
+ **Result:**
+Vector3
+
+
+---
+
+
+### normalize{#normalize}
+
+| Namn | Beskrivning |
+| --- | --- |
+| normalize() | Normalisera kvaternionen |
+
+ **Result:**
+Kvaternion
+
+
+---
+
+
+### concat{#concat}
+
+| Namn | Beskrivning |
+| --- | --- |
+| concat(rhs) | Konkatenera två kvaternioner |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| rh | Kvaternion | null |
+
+ **Result:**
+Kvaternion
+
+
+---
+
+
+### fromAngleAxis{#fromAngleAxis}
+
+| Namn | Beskrivning |
+| --- | --- |
+| fromAngleAxis(a, axis) | Skapar en kvaternion kring given axel och roterar medurs |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| a | Nummer | Medurs rotation i radian |
+| axel | Vector3 | Axel |
+
+ **Result:**
+Kvaternion
+
+
+---
+
+
+### fromRotation{#fromRotation}
+
+| Namn | Beskrivning |
+| --- | --- |
+| fromRotation(orig, dest) | Skapar en kvaternion som roterar från ursprunglig till destinationsriktning |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| orig | Vector3 | Ursprunglig riktning |
+| dest | Vector3 | Destinationsriktning |
+
+ **Result:**
+Kvaternion
+
+
+---
+
+
+### fromEulerAngle{#fromEulerAngle}
+
+| Namn | Beskrivning |
+| --- | --- |
+| fromEulerAngle(pitch, yaw, roll) | Skapar kvaternion från given Eulervinkel |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| pitch | Nummer | Pitch i radian |
+| yaw | Nummer | Yaw i radian |
+| rulla | Nummer | Rullning i radian |
+
+ **Result:**
+Kvaternion
+
+
+---
+
+
+### fromEulerAngle{#fromEulerAngle}
+
+| Namn | Beskrivning |
+| --- | --- |
+| fromEulerAngle(eulerAngle) | Skapar kvaternion från given Eulervinkel |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| eulerAngle | Vector3 | Euler-vinkel i radian |
+
+ **Result:**
+Kvaternion
+
+
+---
+
+
+### toMatrix{#toMatrix}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toMatrix() | Konvertera rotationen som presenteras av kvaternion till transformationsmatris. |
+
+ **Result:**
+Matrix4
+
+
+---
+
+
+### toString{#toString}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toString() | Hämtar representationen av kvaternion som sträng |
+
+ **Result:**
+Sträng
+
+
+---
+
+
+### interpolate{#interpolate}
+
+| Namn | Beskrivning |
+| --- | --- |
+| interpolate(t, from, to) | Fyller denna kvaternion med det interpolerade värdet mellan de givna kvaternionargumenten för ett t mellan från och till. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| t | Nummer | Koeficienten för interpolation. |
+| from | Kvaternion | Källkvaternion. |
+| to | Kvaternion | Målkvaternion. |
+
+ **Result:**
+Kvaternion
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/rect/_index.md
+++ b/swedish/nodejs-java/aspose.threed/rect/_index.md
@@ -1,0 +1,227 @@
+---
+title: "Rect"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/rect/
+---
+## Rect class
+
+En klass för att representera rektangeln
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload(x, y, width, height) | Konstruktor för klassen Rect |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+|  | Nummer | null |
+|  | Nummer | null |
+| bredd | Nummer | null |
+| höjd | Nummer | null |
+
+ **Result:**
+
+
+
+---
+
+
+### getWidth{#getWidth}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getWidth() | Hämtar eller anger bredden på storleken |
+
+ **Result:**
+
+
+
+---
+
+
+### setWidth{#setWidth}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setWidth(value) | Hämtar eller anger bredden på storleken |
+
+ **Result:**
+
+
+
+---
+
+
+### getHeight{#getHeight}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getHeight() | Hämtar eller anger höjden på storleken |
+
+ **Result:**
+
+
+
+---
+
+
+### setHeight{#setHeight}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setHeight(value) | Hämtar eller anger höjden på storleken |
+
+ **Result:**
+
+
+
+---
+
+
+### getX{#getX}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getX() | Hämtar eller anger x för storleken |
+
+ **Result:**
+
+
+
+---
+
+
+### setX{#setX}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setX(value) | Hämtar eller anger x för storleken |
+
+ **Result:**
+
+
+
+---
+
+
+### getY{#getY}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getY() | Hämtar eller anger y för storleken |
+
+ **Result:**
+
+
+
+---
+
+
+### setY{#setY}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setY(value) | Hämtar eller anger y för storleken |
+
+ **Result:**
+
+
+
+---
+
+
+### getLeft{#getLeft}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getLeft() | Hämtar vänsterkanten av rektangeln |
+
+ **Result:**
+
+
+
+---
+
+
+### getRight{#getRight}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getRight() | Hämtar högra kanten av rektangeln |
+
+ **Result:**
+
+
+
+---
+
+
+### getTop{#getTop}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getTop() | Hämtar toppen av rektangeln |
+
+ **Result:**
+
+
+
+---
+
+
+### getBottom{#getBottom}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBottom() | Hämtar botten av rektangeln |
+
+ **Result:**
+
+
+
+---
+
+
+### contains{#contains}
+
+| Namn | Beskrivning |
+| --- | --- |
+| contains(x, y) | Return true om den angivna punkten ligger inom rektangeln. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+|  | Nummer | null |
+|  | Nummer | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/rectangleshape/_index.md
+++ b/swedish/nodejs-java/aspose.threed/rectangleshape/_index.md
@@ -1,0 +1,359 @@
+---
+title: "RectangleShape"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/rectangleshape/
+---
+## RectangleShape class
+
+IFC-kompatibel rektangulär form med avrundade hörn.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Konstruktor för RectangleShape |
+
+ **Result:**
+
+
+
+---
+
+
+### getRoundingRadius{#getRoundingRadius}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getRoundingRadius() | Hämtar eller anger radien för de cirkulära bågarna i alla fyra hörn, mätt i grader. Standardvärdet är 0,0. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRoundingRadius{#setRoundingRadius}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setRoundingRadius(value) | Hämtar eller anger radien för de cirkulära bågarna i alla fyra hörn, mätt i grader. Standardvärdet är 0,0. |
+
+ **Result:**
+
+
+
+---
+
+
+### getXDim{#getXDim}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getXDim() | Hämtar eller anger rektangelns omfattning i x-axelns riktning. Standardvärdet är 2,0. |
+
+ **Result:**
+
+
+
+---
+
+
+### setXDim{#setXDim}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setXDim(value) | Hämtar eller anger rektangelns omfattning i x-axelns riktning. Standardvärdet är 2,0. |
+
+ **Result:**
+
+
+
+---
+
+
+### getYDim{#getYDim}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getYDim() | Hämtar eller anger rektangelns omfattning i y-axelns riktning. Standardvärdet är 2,0. |
+
+ **Result:**
+
+
+
+---
+
+
+### setYDim{#setYDim}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setYDim(value) | Hämtar eller anger rektangelns omfattning i y-axelns riktning. Standardvärdet är 2,0. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNodes() | Hämtar alla föräldranoder, en entitet kan fästas vid flera föräldranoder för geometri‑instansering. Noderna. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExcluded() | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExcluded(value) | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNode() | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setParentNode(value) | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getScene() | Hämtar scenen som detta objekt tillhör |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtent{#getExtent}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExtent() | Hämtar omfattningen i x- och y-dimension. |
+
+ **Result:**
+Vector2
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEntityRendererKey() | Hämtar nyckeln för enhetens renderare som är registrerad i renderaren |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBoundingBox() | Hämtar den omgivande lådan för den aktuella enheten i dess objektrums koordinatsystem. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/rectangulartorus/_index.md
+++ b/swedish/nodejs-java/aspose.threed/rectangulartorus/_index.md
@@ -1,0 +1,502 @@
+---
+title: "RectangularTorus"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/rectangulartorus/
+---
+## RectangularTorus class
+
+Parametriserad rektangulär torus.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Konstruktor för RectangularTorus |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload(name) | Konstruktor för RectangularTorus |
+
+ **Result:**
+
+
+
+---
+
+
+### getInnerRadius{#getInnerRadius}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getInnerRadius() | Den inre radien på den rektangulära torusen Standardvärdet är 17 |
+
+ **Result:**
+
+
+
+---
+
+
+### setInnerRadius{#setInnerRadius}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setInnerRadius(value) | Den inre radien på den rektangulära torusen Standardvärdet är 17 |
+
+ **Result:**
+
+
+
+---
+
+
+### getOuterRadius{#getOuterRadius}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getOuterRadius() | Den yttre radien på den rektangulära torusen Standardvärdet är 20 |
+
+ **Result:**
+
+
+
+---
+
+
+### setOuterRadius{#setOuterRadius}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setOuterRadius(value) | Den yttre radien på den rektangulära torusen Standardvärdet är 20 |
+
+ **Result:**
+
+
+
+---
+
+
+### getHeight{#getHeight}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getHeight() | Höjden på den rektangulära torusen. Standardvärdet är 20 |
+
+ **Result:**
+
+
+
+---
+
+
+### setHeight{#setHeight}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setHeight(value) | Höjden på den rektangulära torusen. Standardvärdet är 20 |
+
+ **Result:**
+
+
+
+---
+
+
+### getArc{#getArc}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getArc() | Den totala vinkeln på bågen, mätt i radianer. Standardvärdet är PI |
+
+ **Result:**
+
+
+
+---
+
+
+### setArc{#setArc}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setArc(value) | Den totala vinkeln på bågen, mätt i radianer. Standardvärdet är PI |
+
+ **Result:**
+
+
+
+---
+
+
+### getAngleStart{#getAngleStart}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getAngleStart() | Startvinkeln på bågen, mätt i radianer. Standardvärdet är 0 |
+
+ **Result:**
+
+
+
+---
+
+
+### setAngleStart{#setAngleStart}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setAngleStart(value) | Startvinkeln på bågen, mätt i radianer. Standardvärdet är 0 |
+
+ **Result:**
+
+
+
+---
+
+
+### getRadialSegments{#getRadialSegments}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getRadialSegments() | De radiella segmenten, standardvärdet är 10 |
+
+ **Result:**
+
+
+
+---
+
+
+### setRadialSegments{#setRadialSegments}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setRadialSegments(value) | De radiella segmenten, standardvärdet är 10 |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastShadows{#getCastShadows}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getCastShadows() | Hämtar eller anger om denna geometri kan kasta skugga |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastShadows{#setCastShadows}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setCastShadows(value) | Hämtar eller anger om denna geometri kan kasta skugga |
+
+ **Result:**
+
+
+
+---
+
+
+### getReceiveShadows{#getReceiveShadows}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getReceiveShadows() | Hämtar eller anger om denna geometri kan ta emot skugga. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReceiveShadows{#setReceiveShadows}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setReceiveShadows(value) | Hämtar eller anger om denna geometri kan ta emot skugga. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNodes() | Hämtar alla föräldranoder, en entitet kan fästas vid flera föräldranoder för geometri‑instansering. Noderna. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExcluded() | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExcluded(value) | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNode() | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setParentNode(value) | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getScene() | Hämtar scenen som detta objekt tillhör |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### toMesh{#toMesh}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toMesh() |  |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBoundingBox() | Hämtar den omgivande lådan för den aktuella enheten i dess objektrums koordinatsystem. |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEntityRendererKey() | Hämtar nyckeln för enhetens renderare som är registrerad i renderaren |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/relativerectangle/_index.md
+++ b/swedish/nodejs-java/aspose.threed/relativerectangle/_index.md
@@ -1,0 +1,316 @@
+---
+title: "RelativeRectangle"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/relativerectangle/
+---
+## RelativeRectangle class
+
+Relativ rektangel  Formeln mellan relativ komponent och absolut värde är:  Scale  (Reference Width) + offset  Så om vi vill att den ska representera ett absolut värde, lämna alla scale-fält noll, och använd offset-fält istället.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload(left, top, width, height) | Skapa en RelativeRectangle |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| vänster | Nummer | null |
+| to | Nummer | null |
+| bredd | Nummer | null |
+| höjd | Nummer | null |
+
+ **Result:**
+
+
+
+---
+
+
+### getScaleX{#getScaleX}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getScaleX() | Relativ koordinat X |
+
+ **Result:**
+
+
+
+---
+
+
+### setScaleX{#setScaleX}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setScaleX(value) | Relativ koordinat X |
+
+ **Result:**
+
+
+
+---
+
+
+### getScaleY{#getScaleY}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getScaleY() | Relativ koordinat Y |
+
+ **Result:**
+
+
+
+---
+
+
+### setScaleY{#setScaleY}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setScaleY(value) | Relativ koordinat Y |
+
+ **Result:**
+
+
+
+---
+
+
+### getScaleWidth{#getScaleWidth}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getScaleWidth() | Relativ bredd |
+
+ **Result:**
+
+
+
+---
+
+
+### setScaleWidth{#setScaleWidth}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setScaleWidth(value) | Relativ bredd |
+
+ **Result:**
+
+
+
+---
+
+
+### getScaleHeight{#getScaleHeight}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getScaleHeight() | Relativ höjd |
+
+ **Result:**
+
+
+
+---
+
+
+### setScaleHeight{#setScaleHeight}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setScaleHeight(value) | Relativ höjd |
+
+ **Result:**
+
+
+
+---
+
+
+### getOffsetX{#getOffsetX}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getOffsetX() | Hämtar eller anger förskjutningen för koordinat X |
+
+ **Result:**
+
+
+
+---
+
+
+### setOffsetX{#setOffsetX}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setOffsetX(value) | Hämtar eller anger förskjutningen för koordinat X |
+
+ **Result:**
+
+
+
+---
+
+
+### getOffsetY{#getOffsetY}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getOffsetY() | Hämtar eller anger förskjutningen för koordinat Y |
+
+ **Result:**
+
+
+
+---
+
+
+### setOffsetY{#setOffsetY}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setOffsetY(value) | Hämtar eller anger förskjutningen för koordinat Y |
+
+ **Result:**
+
+
+
+---
+
+
+### getOffsetWidth{#getOffsetWidth}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getOffsetWidth() | Hämtar eller anger förskjutningen för bredd |
+
+ **Result:**
+
+
+
+---
+
+
+### setOffsetWidth{#setOffsetWidth}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setOffsetWidth(value) | Hämtar eller anger förskjutningen för bredd |
+
+ **Result:**
+
+
+
+---
+
+
+### getOffsetHeight{#getOffsetHeight}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getOffsetHeight() | Hämtar eller anger förskjutningen för höjd |
+
+ **Result:**
+
+
+
+---
+
+
+### setOffsetHeight{#setOffsetHeight}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setOffsetHeight(value) | Hämtar eller anger förskjutningen för höjd |
+
+ **Result:**
+
+
+
+---
+
+
+### toAbsolute{#toAbsolute}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toAbsolute(left, top, width, height) | Konvertera den relativa rektangeln till en absolut rektangel |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| vänster | Nummer | Vänster på rektangeln |
+| överkant | Nummer | Överst på rektangeln |
+| bredd | Nummer | Bredd på rektangeln |
+| height | Nummer | Höjd på rektangeln |
+
+ **Result:**
+Rect
+
+
+---
+
+
+### fromScale{#fromScale}
+
+| Namn | Beskrivning |
+| --- | --- |
+| fromScale(scaleX, scaleY, scaleWidth, scaleHeight) | Skapa en RelativeRectangle med alla förskjutningsfält noll och skalafält från angivna parametrar. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| scale | Nummer | null |
+| scale | Nummer | null |
+| scaleWidt | Nummer | null |
+| scaleHeigh | Nummer | null |
+
+ **Result:**
+RelativeRectangle
+
+
+---
+
+
+### toString{#toString}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toString() | Konverterar värdet av denna instans till en java.lang.String. |
+
+ **Result:**
+RelativeRectangle
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/renderer/_index.md
+++ b/swedish/nodejs-java/aspose.threed/renderer/_index.md
@@ -1,0 +1,398 @@
+---
+title: "Renderare"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/renderer/
+---
+## Renderer class
+
+Kontexten om renderaren.  @hideconstructor
+
+
+## Metoder
+
+### getShaderSet{#getShaderSet}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getShaderSet() | Hämtar eller anger shader-uppsättningen som används för att rendera scenen |
+
+ **Result:**
+
+
+
+---
+
+
+### setShaderSet{#setShaderSet}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setShaderSet(value) | Hämtar eller anger shader-uppsättningen som används för att rendera scenen |
+
+ **Result:**
+
+
+
+---
+
+
+### getVariables{#getVariables}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getVariables() | Åtkomst till de interna variablerna som används för rendering |
+
+ **Result:**
+
+
+
+---
+
+
+### getPresetShaders{#getPresetShaders}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getPresetShaders() | Hämtar eller anger den förinställda shader-uppsättningen. Värdet på egenskapen är heltalskonstanten PresetShaders. |
+
+ **Result:**
+
+
+
+---
+
+
+### setPresetShaders{#setPresetShaders}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setPresetShaders(value) | Hämtar eller anger den förinställda shader-uppsättningen. Värdet på egenskapen är heltalskonstanten PresetShaders. |
+
+ **Result:**
+
+
+
+---
+
+
+### getRenderFactory{#getRenderFactory}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getRenderFactory() | Hämtar fabriken för att skapa renderingsrelaterade objekt. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAssetDirectories{#getAssetDirectories}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getAssetDirectories() | Kataloger som lagrar externa resurser |
+
+ **Result:**
+
+
+
+---
+
+
+### getPostProcessings{#getPostProcessings}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getPostProcessings() | Aktiv efterbehandlingskedja |
+
+ **Result:**
+
+
+
+---
+
+
+### getEnableShadows{#getEnableShadows}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEnableShadows() | Hämtar eller anger om skuggor ska aktiveras. |
+
+ **Result:**
+
+
+
+---
+
+
+### setEnableShadows{#setEnableShadows}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setEnableShadows(value) | Hämtar eller anger om skuggor ska aktiveras. |
+
+ **Result:**
+
+
+
+---
+
+
+### getRenderTarget{#getRenderTarget}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getRenderTarget() | Ange render‑målet som de följande renderingsoperationerna kommer att utföras på. |
+
+ **Result:**
+
+
+
+---
+
+
+### getNode{#getNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getNode() | Hämtar eller anger Node‑instansen som används för att tillhandahålla världstransformmatrisen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setNode{#setNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setNode(value) | Hämtar eller anger Node‑instansen som används för att tillhandahålla världstransformmatrisen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFrustum{#getFrustum}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFrustum() | Hämtar eller anger frustum som används för att tillhandahålla vy‑matrisen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFrustum{#setFrustum}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFrustum(value) | Hämtar eller anger frustum som används för att tillhandahålla vy‑matrisen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getRenderStage{#getRenderStage}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getRenderStage() | Hämtar det aktuella renderingsstadiet. Värdet på egenskapen är en heltalskonstant för RenderStage. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMaterial{#getMaterial}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getMaterial() | Hämtar eller anger materialet som används för att tillhandahålla materialinformation som shaders använder. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMaterial{#setMaterial}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setMaterial(value) | Hämtar eller anger materialet som används för att tillhandahålla materialinformation som shaders använder. |
+
+ **Result:**
+
+
+
+---
+
+
+### getShader{#getShader}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getShader() | Hämtar eller anger shader‑instansen som används för att rendera geometrin. |
+
+ **Result:**
+
+
+
+---
+
+
+### setShader{#setShader}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setShader(value) | Hämtar eller anger shader‑instansen som används för att rendera geometrin. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFallbackEntityRenderer{#getFallbackEntityRenderer}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFallbackEntityRenderer() | Hämtar eller anger reserv‑entity‑renderaren när enheten inte har någon speciell renderare definierad. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFallbackEntityRenderer{#setFallbackEntityRenderer}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFallbackEntityRenderer(value) | Hämtar eller anger reserv‑entity‑renderaren när enheten inte har någon speciell renderare definierad. |
+
+ **Result:**
+
+
+
+---
+
+
+### clearCache{#clearCache}
+
+| Namn | Beskrivning |
+| --- | --- |
+| clearCache() | Rensa cachen manuellt. Aspose.3D kommer att cacha vissa objekt som material/geometrier i interna typer som är kompatibla med renderings‑pipen. Detta bör anropas manuellt när scenen har större förändringar. |
+
+ **Result:**
+
+
+
+---
+
+
+### getPostProcessing{#getPostProcessing}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getPostProcessing(name) | Hämtar en inbyggd post‑processor som stöds av renderaren. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| nam | Sträng | null |
+
+ **Result:**
+PostProcessing
+
+
+---
+
+
+### execute{#execute}
+
+| Namn | Beskrivning |
+| --- | --- |
+| execute(postProcessing, result) | Utför en efterbehandling på angivet render‑mål. |
+
+ **Result:**
+PostProcessing
+
+
+---
+
+
+### createRenderer{#createRenderer}
+
+| Namn | Beskrivning |
+| --- | --- |
+| createRenderer() | Skapar en ny Renderer med standardprofil. |
+
+ **Result:**
+Renderare
+
+
+---
+
+
+### registerEntityRenderer{#registerEntityRenderer}
+
+| Namn | Beskrivning |
+| --- | --- |
+| registerEntityRenderer(renderer) | Registrera enhetsrenderaren för angiven entitet |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| rendere | EntityRenderer | null |
+
+ **Result:**
+Renderare
+
+
+---
+
+
+### render{#render}
+
+| Namn | Beskrivning |
+| --- | --- |
+| render(renderTarget) | Rendera det angivna målet |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| renderTarge | IRenderTarget | null |
+
+ **Result:**
+Renderare
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/renderervariablemanager/_index.md
+++ b/swedish/nodejs-java/aspose.threed/renderervariablemanager/_index.md
@@ -1,0 +1,328 @@
+---
+title: "RendererVariableManager"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/renderervariablemanager/
+---
+## RendererVariableManager class
+
+Denna klass hanterar variabler som används vid rendering  @hideconstructor
+
+
+## Metoder
+
+### getWorldTime{#getWorldTime}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getWorldTime() | Tid i sekunder |
+
+ **Result:**
+
+
+
+---
+
+
+### setWorldTime{#setWorldTime}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setWorldTime(value) | Tid i sekunder |
+
+ **Result:**
+
+
+
+---
+
+
+### getShadowCaster{#getShadowCaster}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getShadowCaster() | Position för skuggkastaren i världens koordinatsystem |
+
+ **Result:**
+
+
+
+---
+
+
+### setShadowCaster{#setShadowCaster}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setShadowCaster(value) | Position för skuggkastaren i världens koordinatsystem |
+
+ **Result:**
+
+
+
+---
+
+
+### getShadowmap{#getShadowmap}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getShadowmap() | Djuptexturen som används för skuggkartläggning |
+
+ **Result:**
+
+
+
+---
+
+
+### setShadowmap{#setShadowmap}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setShadowmap(value) | Djuptexturen som används för skuggkartläggning |
+
+ **Result:**
+
+
+
+---
+
+
+### getMatrixLightSpace{#getMatrixLightSpace}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getMatrixLightSpace() | Matris för ljusutrymmestransformation |
+
+ **Result:**
+
+
+
+---
+
+
+### setMatrixLightSpace{#setMatrixLightSpace}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setMatrixLightSpace(value) | Matris för ljusutrymmestransformation |
+
+ **Result:**
+
+
+
+---
+
+
+### getMatrixViewProjection{#getMatrixViewProjection}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getMatrixViewProjection() | Matris för vy- och projektionstransformation. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMatrixWorldViewProjection{#getMatrixWorldViewProjection}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getMatrixWorldViewProjection() | Matris för världsvy och projektionstransformation |
+
+ **Result:**
+
+
+
+---
+
+
+### getMatrixWorld{#getMatrixWorld}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getMatrixWorld() | Matris för världstransformation |
+
+ **Result:**
+
+
+
+---
+
+
+### getMatrixWorldNormal{#getMatrixWorldNormal}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getMatrixWorldNormal() | Matris för att konvertera normal från objekt till världsutrymme. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMatrixProjection{#getMatrixProjection}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getMatrixProjection() | Matris för projektionstransformation |
+
+ **Result:**
+
+
+
+---
+
+
+### setMatrixProjection{#setMatrixProjection}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setMatrixProjection(value) | Matris för projektionstransformation |
+
+ **Result:**
+
+
+
+---
+
+
+### getMatrixView{#getMatrixView}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getMatrixView() | Matris för vytransformation |
+
+ **Result:**
+
+
+
+---
+
+
+### setMatrixView{#setMatrixView}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setMatrixView(value) | Matris för vytransformation |
+
+ **Result:**
+
+
+
+---
+
+
+### getCameraPosition{#getCameraPosition}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getCameraPosition() | Kamerans position i världens koordinatsystem |
+
+ **Result:**
+
+
+
+---
+
+
+### setCameraPosition{#setCameraPosition}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setCameraPosition(value) | Kamerans position i världens koordinatsystem |
+
+ **Result:**
+
+
+
+---
+
+
+### getDepthBias{#getDepthBias}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getDepthBias() | Djupförskjutning för skuggkartläggning, standardvärdet är 0,001 |
+
+ **Result:**
+
+
+
+---
+
+
+### setDepthBias{#setDepthBias}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setDepthBias(value) | Djupförskjutning för skuggkartläggning, standardvärdet är 0,001 |
+
+ **Result:**
+
+
+
+---
+
+
+### getViewportSize{#getViewportSize}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getViewportSize() | Storlek på visningsområdet, mätt i pixlar |
+
+ **Result:**
+
+
+
+---
+
+
+### setViewportSize{#setViewportSize}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setViewportSize(value) | Storlek på visningsområdet, mätt i pixlar |
+
+ **Result:**
+
+
+
+---
+
+
+### getWorldAmbient{#getWorldAmbient}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getWorldAmbient() | Omgivningsfärg definierad i visningsområdet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setWorldAmbient{#setWorldAmbient}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setWorldAmbient(value) | Omgivningsfärg definierad i visningsområdet. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/renderfactory/_index.md
+++ b/swedish/nodejs-java/aspose.threed/renderfactory/_index.md
@@ -1,0 +1,243 @@
+---
+title: "RenderFactory"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/renderfactory/
+---
+## RenderFactory class
+
+RenderFactory skapar alla resurser som representeras i renderingspipeline.  @hideconstructor
+
+
+## Metoder
+
+### createRenderTexture{#createRenderTexture}
+
+| Namn | Beskrivning |
+| --- | --- |
+| createRenderTexture(parameters, targets, width, height) | Skapa ett renderingsmål som renderar till texturen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| parametrar | RenderParameters | Renderingsparametrar för att skapa rendertexturen |
+| mål | Nummer | Hur många färgoutputmål |
+| bredd | Nummer | Rendertexturens bredd |
+| height | Nummer | Rendertexturens höjd |
+
+ **Result:**
+IRenderTexture
+
+
+---
+
+
+### createRenderTexture{#createRenderTexture}
+
+| Namn | Beskrivning |
+| --- | --- |
+| createRenderTexture(parameters, width, height) | Skapa ett renderingsmål som innehåller 1 mål och renderar till texturen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| parametrar | RenderParameters | Renderingsparametrar för att skapa rendertexturen |
+| bredd | Nummer | Rendertexturens bredd |
+| height | Nummer | Rendertexturens höjd |
+
+ **Result:**
+IRenderTexture
+
+
+---
+
+
+### createDescriptorSet{#createDescriptorSet}
+
+| Namn | Beskrivning |
+| --- | --- |
+| createDescriptorSet(shader) | Skapa descriptor-setet för specificerat shaderprogram. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| shader | ShaderProgram | Shaderprogrammet |
+
+ **Result:**
+IDescriptorSet
+
+
+---
+
+
+### createCubeRenderTexture{#createCubeRenderTexture}
+
+| Namn | Beskrivning |
+| --- | --- |
+| createCubeRenderTexture(parameters, width, height) | Skapa ett renderingsmål som innehåller 1 kubtextur |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| parametrar | RenderParameters | Renderingsparametrar för att skapa rendertexturen |
+| bredd | Nummer | Rendertexturens bredd |
+| height | Nummer | Rendertexturens höjd |
+
+ **Result:**
+IRenderTexture
+
+
+---
+
+
+### createRenderWindow{#createRenderWindow}
+
+| Namn | Beskrivning |
+| --- | --- |
+| createRenderWindow(parameters, handle) | Skapa ett renderingsmål som renderar till det inbyggda fönstret. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| parametrar | RenderParameters | Renderingsparametrar för att skapa renderfönstret |
+| handtag | WindowHandle | Handtaget för fönstret som ska renderas |
+
+ **Result:**
+IRenderWindow
+
+
+---
+
+
+### createVertexBuffer{#createVertexBuffer}
+
+| Namn | Beskrivning |
+| --- | --- |
+| createVertexBuffer(declaration) | Skapa en com.aspose.threed.IVertexBuffer-instans för att lagra polygonens vertexinformation. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| declaratio | VertexDeclaration | null |
+
+ **Result:**
+IVertexBuffer
+
+
+---
+
+
+### createIndexBuffer{#createIndexBuffer}
+
+| Namn | Beskrivning |
+| --- | --- |
+| createIndexBuffer() | Skapa en com.aspose.threed.IIndexBuffer-instans för att lagra polygonens ytinformation. |
+
+ **Result:**
+IIndexBuffer
+
+
+---
+
+
+### createTextureUnit{#createTextureUnit}
+
+| Namn | Beskrivning |
+| --- | --- |
+| createTextureUnit(textureType) | Skapa en texture-enhet som kan nås av shader. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| textureType | TextureType | TextureType |
+
+ **Result:**
+ITextureUnit
+
+
+---
+
+
+### createTextureUnit{#createTextureUnit}
+
+| Namn | Beskrivning |
+| --- | --- |
+| createTextureUnit() | Skapa en 2D texture-enhet som kan nås av shader. |
+
+ **Result:**
+ITextureUnit
+
+
+---
+
+
+### createShaderProgram{#createShaderProgram}
+
+| Namn | Beskrivning |
+| --- | --- |
+| createShaderProgram(shaderSource) | Skapa ett ShaderProgram-objekt |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| shaderSource | ShaderSource | Källkoden för shadern |
+
+ **Result:**
+ShaderProgram
+
+
+---
+
+
+### createPipeline{#createPipeline}
+
+| Namn | Beskrivning |
+| --- | --- |
+| createPipeline(shader, renderState, vertexDeclaration, drawOperation) | Skapa en förkonfigurerad grafikpipeline med förkonfigurerad shader/render state/vertex declaration och draw operations. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| shader | ShaderProgram | Shadern som används i rendering |
+| renderState | RenderState | Render state som används i rendering |
+| vertexDeclaration | VertexDeclaration | Vertex declaration för indata vertexdata |
+| drawOperation | DrawOperation | DrawOperation |
+
+ **Result:**
+IPipeline
+
+
+---
+
+
+### createUniformBuffer{#createUniformBuffer}
+
+| Namn | Beskrivning |
+| --- | --- |
+| createUniformBuffer(size) | Skapa en ny uniform buffer på GPU-sidan med förallokerad storlek. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| storlek | Nummer | Storleken på uniform buffer |
+
+ **Result:**
+IBuffer
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/renderparameters/_index.md
+++ b/swedish/nodejs-java/aspose.threed/renderparameters/_index.md
@@ -1,0 +1,133 @@
+---
+title: "RenderParameters"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/renderparameters/
+---
+## RenderParameters class
+
+Beskriv parametrarna för renderingsmålet
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| konstruktor(doubleBuffering, colorBits, depthBits, stencilBits) | Initiera en instans av PixelFormat |
+
+ **Result:**
+
+
+
+---
+
+
+### getDoubleBuffering{#getDoubleBuffering}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getDoubleBuffering() | Hämtar eller anger om dubbelbuffring används. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDoubleBuffering{#setDoubleBuffering}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setDoubleBuffering(value) | Hämtar eller anger om dubbelbuffring används. |
+
+ **Result:**
+
+
+
+---
+
+
+### getColorBits{#getColorBits}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getColorBits() | Hämtar eller anger hur många bitar som ska användas av färgbufferten. |
+
+ **Result:**
+
+
+
+---
+
+
+### setColorBits{#setColorBits}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setColorBits(value) | Hämtar eller anger hur många bitar som ska användas av färgbufferten. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDepthBits{#getDepthBits}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getDepthBits() | Hämtar eller anger hur många bitar som ska användas av djupbufferten. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDepthBits{#setDepthBits}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setDepthBits(value) | Hämtar eller anger hur många bitar som ska användas av djupbufferten. |
+
+ **Result:**
+
+
+
+---
+
+
+### getStencilBits{#getStencilBits}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getStencilBits() | Hämtar eller anger hur många bitar som ska användas i stencilbufferten. |
+
+ **Result:**
+
+
+
+---
+
+
+### setStencilBits{#setStencilBits}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setStencilBits(value) | Hämtar eller anger hur många bitar som ska användas i stencilbufferten. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/renderresource/_index.md
+++ b/swedish/nodejs-java/aspose.threed/renderresource/_index.md
@@ -1,0 +1,13 @@
+---
+title: "RenderResource"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/renderresource/
+---
+## RenderResource class
+
+Den abstrakta klassen för alla renderingsresurser  Alla renderingsresurser kommer att tas bort när renderaren släpps.  Klasser som Mesh/Texture kommer att ha en motsvarande RenderResource  @hideconstructor
+
+

--- a/swedish/nodejs-java/aspose.threed/renderstate/_index.md
+++ b/swedish/nodejs-java/aspose.threed/renderstate/_index.md
@@ -1,0 +1,477 @@
+---
+title: "RenderState"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/renderstate/
+---
+## RenderState class
+
+Renderingsstatus för att bygga pipeline  Ändringarna som görs på renderingsstatusen kommer inte att påverka de skapade pipeline-instanserna.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Konstruktor för RenderState |
+
+ **Result:**
+
+
+
+---
+
+
+### getBlend{#getBlend}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBlend() | Aktivera eller inaktivera fragmentblandning. |
+
+ **Result:**
+
+
+
+---
+
+
+### setBlend{#setBlend}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setBlend(value) | Aktivera eller inaktivera fragmentblandning. |
+
+ **Result:**
+
+
+
+---
+
+
+### getBlendColor{#getBlendColor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBlendColor() | Hämtar eller anger blandningsfärgen där den används i BlendFactor.CONSTANT_COLOR |
+
+ **Result:**
+
+
+
+---
+
+
+### setBlendColor{#setBlendColor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setBlendColor(value) | Hämtar eller anger blandningsfärgen där den används i BlendFactor.CONSTANT_COLOR |
+
+ **Result:**
+
+
+
+---
+
+
+### getSourceBlendFactor{#getSourceBlendFactor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getSourceBlendFactor() | Hämtar eller anger hur färgen blandas. Värdet på egenskapen är en heltalskonstant från BlendFactor. |
+
+ **Result:**
+
+
+
+---
+
+
+### setSourceBlendFactor{#setSourceBlendFactor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setSourceBlendFactor(value) | Hämtar eller anger hur färgen blandas. Värdet på egenskapen är en heltalskonstant från BlendFactor. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDestinationBlendFactor{#getDestinationBlendFactor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getDestinationBlendFactor() | Hämtar eller anger hur färgen blandas. Värdet på egenskapen är en heltalskonstant från BlendFactor. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDestinationBlendFactor{#setDestinationBlendFactor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setDestinationBlendFactor(value) | Hämtar eller anger hur färgen blandas. Värdet på egenskapen är en heltalskonstant från BlendFactor. |
+
+ **Result:**
+
+
+
+---
+
+
+### getCullFace{#getCullFace}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getCullFace() | Aktivera eller inaktivera cull face |
+
+ **Result:**
+
+
+
+---
+
+
+### setCullFace{#setCullFace}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setCullFace(value) | Aktivera eller inaktivera cull face |
+
+ **Result:**
+
+
+
+---
+
+
+### getCullFaceMode{#getCullFaceMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getCullFaceMode() | Hämtar eller anger vilken yta som ska tas bort. Värdet på egenskapen är CullFaceMode heltalskonstant. |
+
+ **Result:**
+
+
+
+---
+
+
+### setCullFaceMode{#setCullFaceMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setCullFaceMode(value) | Hämtar eller anger vilken yta som ska tas bort. Värdet på egenskapen är CullFaceMode heltalskonstant. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFrontFace{#getFrontFace}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFrontFace() | Hämtar eller anger vilken ordning som är frontyta. Värdet på egenskapen är FrontFace heltalskonstant. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFrontFace{#setFrontFace}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFrontFace(value) | Hämtar eller anger vilken ordning som är frontyta. Värdet på egenskapen är FrontFace heltalskonstant. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDepthTest{#getDepthTest}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getDepthTest() | Aktivera eller inaktivera djuptestet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDepthTest{#setDepthTest}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setDepthTest(value) | Aktivera eller inaktivera djuptestet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDepthMask{#getDepthMask}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getDepthMask() | Aktivera eller inaktivera djupskrivning. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDepthMask{#setDepthMask}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setDepthMask(value) | Aktivera eller inaktivera djupskrivning. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDepthFunction{#getDepthFunction}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getDepthFunction() | Hämtar eller anger jämförelsefunktionen som används i djuptestet. Värdet på egenskapen är CompareFunction heltalskonstant. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDepthFunction{#setDepthFunction}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setDepthFunction(value) | Hämtar eller anger jämförelsefunktionen som används i djuptestet. Värdet på egenskapen är CompareFunction heltalskonstant. |
+
+ **Result:**
+
+
+
+---
+
+
+### getStencilTest{#getStencilTest}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getStencilTest() | Aktivera eller inaktivera stenciltestet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setStencilTest{#setStencilTest}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setStencilTest(value) | Aktivera eller inaktivera stenciltestet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getStencilReference{#getStencilReference}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getStencilReference() | Hämtar eller anger referensvärdet för stenciltestet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setStencilReference{#setStencilReference}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setStencilReference(value) | Hämtar eller anger referensvärdet för stenciltestet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getStencilMask{#getStencilMask}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getStencilMask() | Hämtar eller anger masken som ANDas med både referens- och lagrat stencilvärde när testet är klart. |
+
+ **Result:**
+
+
+
+---
+
+
+### getStencilFrontFace{#getStencilFrontFace}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getStencilFrontFace() | Hämtar stencilstatus för frontyta. |
+
+ **Result:**
+
+
+
+---
+
+
+### getStencilBackFace{#getStencilBackFace}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getStencilBackFace() | Hämtar stencil‑tillståndet för baksidan. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScissorTest{#getScissorTest}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getScissorTest() | Aktivera eller inaktivera scissor-testet |
+
+ **Result:**
+
+
+
+---
+
+
+### setScissorTest{#setScissorTest}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setScissorTest(value) | Aktivera eller inaktivera scissor-testet |
+
+ **Result:**
+
+
+
+---
+
+
+### getPolygonMode{#getPolygonMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getPolygonMode() | Hämtar eller anger polygonens renderingsläge. Värdet på egenskapen är heltalskonstanten PolygonMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setPolygonMode{#setPolygonMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setPolygonMode(value) | Hämtar eller anger polygonens renderingsläge. Värdet på egenskapen är heltalskonstanten PolygonMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### equals{#equals}
+
+| Namn | Beskrivning |
+| --- | --- |
+| equals(obj) | Returnerar ett värde som indikerar om den här instansen är lika med ett angivet objekt. |
+
+ **Result:**
+
+
+
+---
+
+
+### hashCode{#hashCode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| hashCode() | Returnerar hash‑koden för den här instansen. |
+
+ **Result:**
+
+
+
+---
+
+
+### compareTo{#compareTo}
+
+| Namn | Beskrivning |
+| --- | --- |
+| compareTo(other) | Jämför renderingsstatusen med en annan instans |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| othe | RenderState | null |
+
+ **Result:**
+Nummer
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/revolvedareasolid/_index.md
+++ b/swedish/nodejs-java/aspose.threed/revolvedareasolid/_index.md
@@ -1,0 +1,411 @@
+---
+title: "RevolvedAreaSolid"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/revolvedareasolid/
+---
+## RevolvedAreaSolid class
+
+Denna klass representerar en solid modell genom att rotera ett tvärsnitt som tillhandahålls av en profil kring en axel.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getAngleStart{#getAngleStart}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getAngleStart() | Hämtar eller anger startvinkeln för rotationsproceduren, mätt i radian, standardvärdet är 0. |
+
+ **Result:**
+
+
+
+---
+
+
+### setAngleStart{#setAngleStart}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setAngleStart(value) | Hämtar eller anger startvinkeln för rotationsproceduren, mätt i radian, standardvärdet är 0. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAngleEnd{#getAngleEnd}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getAngleEnd() | Hämtar eller anger slutvinkeln för rotationsproceduren, mätt i radian, standardvärdet är pi. |
+
+ **Result:**
+
+
+
+---
+
+
+### setAngleEnd{#setAngleEnd}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setAngleEnd(value) | Hämtar eller anger slutvinkeln för rotationsproceduren, mätt i radian, standardvärdet är pi. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAxis{#getAxis}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getAxis() | Hämtar eller anger axelns riktning, standardvärdet är (0, 1, 0). |
+
+ **Result:**
+
+
+
+---
+
+
+### setAxis{#setAxis}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setAxis(value) | Hämtar eller anger axelns riktning, standardvärdet är (0, 1, 0). |
+
+ **Result:**
+
+
+
+---
+
+
+### getOrigin{#getOrigin}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getOrigin() | Hämtar eller anger ursprungspunkten för rotationen, standardvärdet är (0, 0, 0). |
+
+ **Result:**
+
+
+
+---
+
+
+### setOrigin{#setOrigin}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setOrigin(value) | Hämtar eller anger ursprungspunkten för rotationen, standardvärdet är (0, 0, 0). |
+
+ **Result:**
+
+
+
+---
+
+
+### getShape{#getShape}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getShape() | Hämtar eller anger basprofilen som används för rotation. |
+
+ **Result:**
+
+
+
+---
+
+
+### setShape{#setShape}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setShape(value) | Hämtar eller anger basprofilen som används för rotation. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNodes() | Hämtar alla föräldranoder, en entitet kan fästas vid flera föräldranoder för geometri‑instansering. Noderna. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExcluded() | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExcluded(value) | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNode() | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setParentNode(value) | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getScene() | Hämtar scenen som detta objekt tillhör |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### toMesh{#toMesh}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toMesh() | Konvertera RevolvedAreaSolid till ett nät. |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBoundingBox() | Hämtar den omgivande lådan för den aktuella enheten i dess objektrums koordinatsystem. |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEntityRendererKey() | Hämtar nyckeln för enhetens renderare som är registrerad i renderaren |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/rvmformat/_index.md
+++ b/swedish/nodejs-java/aspose.threed/rvmformat/_index.md
@@ -1,0 +1,141 @@
+---
+title: "RvmFormat"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/rvmformat/
+---
+## RvmFormat class
+
+RVM-formatet  @hideconstructor
+
+
+## Metoder
+
+### getVersion{#getVersion}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getVersion() | Hämtar filformatversion |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtension{#getExtension}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExtension() | Hämtar filändelsens namn för den här typen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtensions{#getExtensions}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExtensions() | Hämtar filändelserna för den här typen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getContentType{#getContentType}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getContentType() | Hämtar filformatets innehållstyp. Värdet på egenskapen är heltalskonstanten FileContentType. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormatType{#getFileFormatType}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileFormatType() | Hämtar filformattyp |
+
+ **Result:**
+
+
+
+---
+
+
+### loadAttributes{#loadAttributes}
+
+| Namn | Beskrivning |
+| --- | --- |
+| loadAttributes(scene, fileName, prefix) | Läs in attributen från angivet filnamn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| scen | Scene | Scenen där attributen kommer att tillämpas på |
+| fileName | Sträng | Filens namn som innehåller attributen |
+| prefix | Sträng | Prefixet för attributen som används för att undvika namnkonflikter, standardvärdet är "rvm:" |
+
+ **Result:**
+
+
+
+---
+
+
+### createLoadOptions{#createLoadOptions}
+
+| Namn | Beskrivning |
+| --- | --- |
+| createLoadOptions() | Skapa standardalternativ för inläsning för detta filformat. |
+
+ **Result:**
+LoadOptions
+
+
+---
+
+
+### createSaveOptions{#createSaveOptions}
+
+| Namn | Beskrivning |
+| --- | --- |
+| createSaveOptions() | Skapa standardalternativ för sparning för detta filformat. |
+
+ **Result:**
+SaveOptions
+
+
+---
+
+
+### toString{#toString}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toString() | Formaterar till sträng |
+
+ **Result:**
+Sträng
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/rvmloadoptions/_index.md
+++ b/swedish/nodejs-java/aspose.threed/rvmloadoptions/_index.md
@@ -1,0 +1,373 @@
+---
+title: "RvmLoadOptions"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/rvmloadoptions/
+---
+## RvmLoadOptions class
+
+Läsalternativ för AVEVA Plant Design Management Systems RVM-fil.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor(contentType) | Skapa en RvmLoadOptions-instans |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| contentType | FileContentType | FileContentType |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload() | Skapa en RvmLoadOptions-instans |
+
+ **Result:**
+
+
+
+---
+
+
+### getGenerateMaterials{#getGenerateMaterials}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getGenerateMaterials() | Generera material med slumpmässiga färger för varje objekt i scenen om färgtabellen inte exporteras i RVM-filen. Standardvärdet är true |
+
+ **Result:**
+
+
+
+---
+
+
+### setGenerateMaterials{#setGenerateMaterials}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setGenerateMaterials(value) | Generera material med slumpmässiga färger för varje objekt i scenen om färgtabellen inte exporteras i RVM-filen. Standardvärdet är true |
+
+ **Result:**
+
+
+
+---
+
+
+### getCylinderRadialSegments{#getCylinderRadialSegments}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getCylinderRadialSegments() | Hämtar eller anger antalet radiala segment i cylindern, standardvärdet är 16 |
+
+ **Result:**
+
+
+
+---
+
+
+### setCylinderRadialSegments{#setCylinderRadialSegments}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setCylinderRadialSegments(value) | Hämtar eller anger antalet radiala segment i cylindern, standardvärdet är 16 |
+
+ **Result:**
+
+
+
+---
+
+
+### getDishLongitudeSegments{#getDishLongitudeSegments}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getDishLongitudeSegments() | Hämtar eller anger antalet longitudsegment för tallriken, standardvärdet är 12 |
+
+ **Result:**
+
+
+
+---
+
+
+### setDishLongitudeSegments{#setDishLongitudeSegments}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setDishLongitudeSegments(value) | Hämtar eller anger antalet longitudsegment för tallriken, standardvärdet är 12 |
+
+ **Result:**
+
+
+
+---
+
+
+### getDishLatitudeSegments{#getDishLatitudeSegments}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getDishLatitudeSegments() | Hämtar eller anger antalet latitudsegment för tallriken, standardvärdet är 8 |
+
+ **Result:**
+
+
+
+---
+
+
+### setDishLatitudeSegments{#setDishLatitudeSegments}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setDishLatitudeSegments(value) | Hämtar eller anger antalet latitudsegment för tallriken, standardvärdet är 8 |
+
+ **Result:**
+
+
+
+---
+
+
+### getTorusTubularSegments{#getTorusTubularSegments}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getTorusTubularSegments() | Hämtar eller anger antalet rörsegment för torusen, standardvärdet är 20 |
+
+ **Result:**
+
+
+
+---
+
+
+### setTorusTubularSegments{#setTorusTubularSegments}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setTorusTubularSegments(value) | Hämtar eller anger antalet rörsegment för torusen, standardvärdet är 20 |
+
+ **Result:**
+
+
+
+---
+
+
+### getRectangularTorusSegments{#getRectangularTorusSegments}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getRectangularTorusSegments() | Hämtar eller anger antalet radiala segment för den rektangulära torusen, standardvärdet är 20 |
+
+ **Result:**
+
+
+
+---
+
+
+### setRectangularTorusSegments{#setRectangularTorusSegments}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setRectangularTorusSegments(value) | Hämtar eller anger antalet radiala segment för den rektangulära torusen, standardvärdet är 20 |
+
+ **Result:**
+
+
+
+---
+
+
+### getCenterScene{#getCenterScene}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getCenterScene() | Centrera scenen efter att den har laddats. |
+
+ **Result:**
+
+
+
+---
+
+
+### setCenterScene{#setCenterScene}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setCenterScene(value) | Centrera scenen efter att den har laddats. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAttributePrefix{#getAttributePrefix}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getAttributePrefix() | Hämtar eller anger prefixet för attributen som definierades i externa attributfiler. Prefixet används för att undvika namnkonflikter, standardvärdet är "rvm:" |
+
+ **Result:**
+
+
+
+---
+
+
+### setAttributePrefix{#setAttributePrefix}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setAttributePrefix(value) | Hämtar eller anger prefixet för attributen som definierades i externa attributfiler. Prefixet används för att undvika namnkonflikter, standardvärdet är "rvm:" |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupAttributes{#getLookupAttributes}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getLookupAttributes() | Hämtar eller anger huruvida attribut ska läsas in från extern attributlistfil (.att/.attrib/.txt), standardvärdet är true. |
+
+ **Result:**
+
+
+
+---
+
+
+### setLookupAttributes{#setLookupAttributes}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setLookupAttributes(value) | Hämtar eller anger huruvida attribut ska läsas in från extern attributlistfil (.att/.attrib/.txt), standardvärdet är true. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileFormat() | Hämtar filformatet som anges i aktuellt Spara/Ladda-alternativ. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEncoding() | Hämtar eller anger standardkodning för textbaserade filer. Standardvärdet är null, vilket betyder att importören/exportören bestämmer vilken kodning som ska användas. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileSystem() | Tillåter användaren att hantera hur externa beroenden ska hanteras under laddning/sparning. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFileSystem(value) | Tillåter användaren att hantera hur externa beroenden ska hanteras under laddning/sparning. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getLookupPaths() | Vissa filer, som OBJ, är beroende av externa filer; sökvägarna gör det möjligt för Aspose.3D att leta efter externa filer att ladda. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileName() | Filnamnet för den exporterade/importerade scenen. Detta är valfritt, men användbart när externa resurser som OBJ:s material serialiseras. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFileName(value) | Filnamnet för den exporterade/importerade scenen. Detta är valfritt, men användbart när externa resurser som OBJ:s material serialiseras. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/rvmsaveoptions/_index.md
+++ b/swedish/nodejs-java/aspose.threed/rvmsaveoptions/_index.md
@@ -1,0 +1,321 @@
+---
+title: "RvmSaveOptions"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/rvmsaveoptions/
+---
+## RvmSaveOptions class
+
+Sparaalternativ för Aveva PDMS RVM-fil.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Konstruktor för RvmSaveOptions |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload(contentType) | Konstruktor för RvmSaveOptions |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| contentType | FileContentType | FileContentType |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileNote{#getFileNote}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileNote() | Filanteckning i filhuvudet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileNote{#setFileNote}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFileNote(value) | Filanteckning i filhuvudet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAuthor{#getAuthor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getAuthor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### setAuthor{#setAuthor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setAuthor(value) |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getCreationTime{#getCreationTime}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getCreationTime() | Tidsstämpeln som exporterade den här filen, standardvärdet är aktuell tid. |
+
+ **Result:**
+
+
+
+---
+
+
+### setCreationTime{#setCreationTime}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setCreationTime(value) | Tidsstämpeln som exporterade den här filen, standardvärdet är aktuell tid. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAttributePrefix{#getAttributePrefix}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getAttributePrefix() | Hämtar eller anger prefixet för vilka attribut som ska exporteras, den exporterade egenskapen kommer inte att innehålla något prefix, anpassade egenskaper med annat prefix exporteras inte, standardvärdet är 'rvm:'. Till exempel om en egenskap är rvm:Refno=345, kommer det exporterade attributet att vara Refno = 345, prefixet tas bort. |
+
+ **Result:**
+
+
+
+---
+
+
+### setAttributePrefix{#setAttributePrefix}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setAttributePrefix(value) | Hämtar eller anger prefixet för vilka attribut som ska exporteras, den exporterade egenskapen kommer inte att innehålla något prefix, anpassade egenskaper med annat prefix exporteras inte, standardvärdet är 'rvm:'. Till exempel om en egenskap är rvm:Refno=345, kommer det exporterade attributet att vara Refno = 345, prefixet tas bort. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAttributeListFile{#getAttributeListFile}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getAttributeListFile() | Hämtar eller anger filnamnet för attributlistfilen, exportören kommer att generera ett namn baserat på .rvm-filnamnet när denna egenskap är odefinierad, standardvärdet är null. |
+
+ **Result:**
+
+
+
+---
+
+
+### setAttributeListFile{#setAttributeListFile}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setAttributeListFile(value) | Hämtar eller anger filnamnet för attributlistfilen, exportören kommer att generera ett namn baserat på .rvm-filnamnet när denna egenskap är odefinierad, standardvärdet är null. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportAttributes{#getExportAttributes}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExportAttributes() | Hämtar eller anger huruvida attributlistan ska exporteras till en extern .att-fil, standardvärdet är false. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportAttributes{#setExportAttributes}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExportAttributes(value) | Hämtar eller anger huruvida attributlistan ska exporteras till en extern .att-fil, standardvärdet är false. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportTextures{#getExportTextures}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExportTextures() | Försök att kopiera texturer som används i scenen till utdatamappen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextures{#setExportTextures}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExportTextures(value) | Försök att kopiera texturer som används i scenen till utdatamappen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileFormat() | Hämtar filformatet som anges i aktuellt Spara/Ladda-alternativ. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEncoding() | Hämtar eller anger standardkodning för textbaserade filer. Standardvärdet är null, vilket betyder att importören/exportören bestämmer vilken kodning som ska användas. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileSystem() | Tillåter användaren att hantera hur externa beroenden ska hanteras under laddning/sparning. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFileSystem(value) | Tillåter användaren att hantera hur externa beroenden ska hanteras under laddning/sparning. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getLookupPaths() | Vissa filer, som OBJ, är beroende av externa filer; sökvägarna gör det möjligt för Aspose.3D att leta efter externa filer att ladda. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileName() | Filnamnet för den exporterade/importerade scenen. Detta är valfritt, men användbart när externa resurser som OBJ:s material serialiseras. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFileName(value) | Filnamnet för den exporterade/importerade scenen. Detta är valfritt, men användbart när externa resurser som OBJ:s material serialiseras. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/saveoptions/_index.md
+++ b/swedish/nodejs-java/aspose.threed/saveoptions/_index.md
@@ -1,0 +1,133 @@
+---
+title: "SaveOptions"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/saveoptions/
+---
+## SaveOptions class
+
+Bas-klassen för att konfigurera alternativ vid filsparande för olika typer  @hideconstructor
+
+
+## Metoder
+
+### getExportTextures{#getExportTextures}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExportTextures() | Försök att kopiera texturer som används i scenen till utdatamappen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextures{#setExportTextures}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExportTextures(value) | Försök att kopiera texturer som används i scenen till utdatamappen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileFormat() | Hämtar filformatet som anges i aktuellt Spara/Ladda-alternativ. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEncoding() | Hämtar eller anger standardkodning för textbaserade filer. Standardvärdet är null, vilket betyder att importören/exportören bestämmer vilken kodning som ska användas. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileSystem() | Tillåter användaren att hantera hur externa beroenden ska hanteras under laddning/sparning. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFileSystem(value) | Tillåter användaren att hantera hur externa beroenden ska hanteras under laddning/sparning. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getLookupPaths() | Vissa filer, som OBJ, är beroende av externa filer; sökvägarna gör det möjligt för Aspose.3D att leta efter externa filer att ladda. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileName() | Filnamnet för den exporterade/importerade scenen. Detta är valfritt, men användbart när externa resurser som OBJ:s material serialiseras. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFileName(value) | Filnamnet för den exporterade/importerade scenen. Detta är valfritt, men användbart när externa resurser som OBJ:s material serialiseras. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/scene/_index.md
+++ b/swedish/nodejs-java/aspose.threed/scene/_index.md
@@ -1,0 +1,626 @@
+---
+title: "Scene"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/scene/
+---
+## Scene class
+
+En scen är ett top‑nivåobjekt som innehåller noder, geometrier, material, texturer, animationer, poser, under‑scener etc.  Scenen kan ha under‑scener, fungerar som stöd för flera dokument i filer som collada/blender/fbx.  Nodhierarkin kan nås via RootNodeLibrary som används för att hålla en referens till oanslutna objekt under serialisering (som metadata eller anpassade objekt) så att den kan användas som ett bibliotek.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Initierar en ny instans av Scene-klassen. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload(entity) | Initierar en ny instans av Scene-klassen med en entity fäst vid en ny nod. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| entitet | Entitet | Den initiala entity som fästes vid scene |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload2(parentScene, name) | Initierar en ny instans av Scene-klassen som en delscen. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| parentScene | Scene | Den överordnade scenen. |
+| name | Sträng | Scenens namn. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload3{#constructor_overload3}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload3(fileName) | Initierar en ny instans av Scene-klassen och öppnar filen omedelbart. Detta är en föråldrad konstruktor, vänligen använd #Error Cref: M:Aspose.ThreeD.Scene.FromFile(System.String,System.Threading.CancellationToken). |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| fileName | Sträng | Filens namn att öppna. |
+
+ **Result:**
+
+
+
+---
+
+
+### getSubScenes{#getSubScenes}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getSubScenes() | Hämtar alla delscener |
+
+ **Result:**
+
+
+
+---
+
+
+### getLibrary{#getLibrary}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getLibrary() | Objekt som inte används direkt i scenhierarkin kan definieras i Library. Detta är användbart när du använder delscener och placerar återanvändbara komponenter under delscener. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAnimationClips{#getAnimationClips}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getAnimationClips() | Hämtar alla AnimationClip som definierats i scenen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getCurrentAnimationClip{#getCurrentAnimationClip}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getCurrentAnimationClip() | Hämtar eller anger den aktiva AnimationClip |
+
+ **Result:**
+
+
+
+---
+
+
+### setCurrentAnimationClip{#setCurrentAnimationClip}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setCurrentAnimationClip(value) | Hämtar eller anger den aktiva AnimationClip |
+
+ **Result:**
+
+
+
+---
+
+
+### getAssetInfo{#getAssetInfo}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getAssetInfo() | Hämtar eller anger top‑nivå tillgångsinformation. Dokumentinformationen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setAssetInfo{#setAssetInfo}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setAssetInfo(value) | Hämtar eller anger top‑nivå tillgångsinformation. Dokumentinformationen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getPoses{#getPoses}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getPoses() | Hämtar alla Pose som används i denna scen. Poseerna. |
+
+ **Result:**
+
+
+
+---
+
+
+### getRootNode{#getRootNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getRootNode() | Hämtar rot‑noden i scenen. Rot‑noden. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getScene() | Hämtar scenen som detta objekt tillhör |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAnimationClip{#getAnimationClip}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getAnimationClip(name) | Hämtar en namngiven AnimationClip |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| name | Sträng | Den |
+
+ **Result:**
+AnimationClip
+
+
+---
+
+
+### clear{#clear}
+
+| Namn | Beskrivning |
+| --- | --- |
+| clear() | Rensar scenens innehåll och återställer standardinställningarna. |
+
+ **Result:**
+AnimationClip
+
+
+---
+
+
+### createAnimationClip{#createAnimationClip}
+
+| Namn | Beskrivning |
+| --- | --- |
+| createAnimationClip(name) | En förkortad funktion för att skapa och registrera AnimationClip. Den första AnimationClip kommer att tilldelas CurrentAnimationClip. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| name | Sträng | Namnet på animation clip. |
+
+ **Result:**
+AnimationClip
+
+
+---
+
+
+### open{#open}
+
+| Namn | Beskrivning |
+| --- | --- |
+| open(fileName, options) | Öppnar scenen från angiven sökväg med angivet filformat. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| fileName | Sträng | Filnamn. |
+| alternativ | LoadOptions | Mer detaljerad konfiguration för att öppna strömmen. |
+
+ **Result:**
+AnimationClip
+
+
+---
+
+
+### open{#open}
+
+| Namn | Beskrivning |
+| --- | --- |
+| open(fileName) | Öppnar scenen från angiven sökväg |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| fileName | Sträng | Filnamn. |
+
+ **Result:**
+AnimationClip
+
+
+---
+
+
+### fromFile{#fromFile}
+
+| Namn | Beskrivning |
+| --- | --- |
+| fromFile(fileName) | Öppnar scenen från angiven sökväg |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| fileName | Sträng | Filnamn. |
+
+ **Result:**
+AnimationClip
+
+
+---
+
+
+### save{#save}
+
+| Namn | Beskrivning |
+| --- | --- |
+| save(fileName) | Sparar scenen till angiven sökväg med angivet filformat. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| fileName | Sträng | Filnamn. |
+
+ **Result:**
+AnimationClip
+
+
+---
+
+
+### save{#save}
+
+| Namn | Beskrivning |
+| --- | --- |
+| save(fileName, format) | Sparar scenen till angiven sökväg med angivet filformat. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| fileName | Sträng | Filnamn. |
+| format | Filformat | Format. |
+
+ **Result:**
+AnimationClip
+
+
+---
+
+
+### save{#save}
+
+| Namn | Beskrivning |
+| --- | --- |
+| save(fileName, options) | Sparar scenen till angiven sökväg med angivet filformat. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| fileName | Sträng | Filnamn. |
+| alternativ | SaveOptions | Mer detaljerad konfiguration för att spara strömmen. |
+
+ **Result:**
+AnimationClip
+
+
+---
+
+
+### render{#render}
+
+| Namn | Beskrivning |
+| --- | --- |
+| render(camera, fileName) | Rendera scenen till en extern fil från den angivna kamerans perspektiv. Standardutdata är 1024x768 och utdataformatet är png. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| kamera | Kamera | Från vilken kameras perspektiv scenen ska renderas |
+| fileName | Sträng | Filnamnet på utdatafilen |
+
+ **Result:**
+AnimationClip
+
+
+---
+
+
+### render{#render}
+
+| Namn | Beskrivning |
+| --- | --- |
+| render(camera, fileName, size, format) | Rendera scenen till en extern fil från den angivna kamerans perspektiv. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| kamera | Kamera | Från vilken kameras perspektiv scenen ska renderas |
+| fileName | Sträng | Filnamnet på utdatafilen |
+| storlek | Vector2 | Storleken på den slutliga renderade bilden |
+| format | Sträng | Bildformatet för utdatafilen |
+
+ **Result:**
+AnimationClip
+
+
+---
+
+
+### render{#render}
+
+| Namn | Beskrivning |
+| --- | --- |
+| render(camera, fileName, size, format, options) | Rendera scenen till en extern fil från den angivna kamerans perspektiv. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| kamera | Kamera | Från vilken kameras perspektiv scenen ska renderas |
+| fileName | Sträng | Filnamnet på utdatafilen |
+| storlek | Vector2 | Storleken på den slutliga renderade bilden |
+| format | Sträng | Bildformatet för utdatafilen |
+| alternativ | ImageRenderOptions | Alternativet för att anpassa vissa interna inställningar. |
+
+ **Result:**
+AnimationClip
+
+
+---
+
+
+### render{#render}
+
+| Namn | Beskrivning |
+| --- | --- |
+| render(camera, bitmap) | Rendera scenen till bitmap från den givna kamerans perspektiv. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| kamera | Kamera | Från vilken kameras perspektiv scenen ska renderas |
+| bitmap | TextureData | Mål för det renderade resultatet |
+
+ **Result:**
+AnimationClip
+
+
+---
+
+
+### render{#render}
+
+| Namn | Beskrivning |
+| --- | --- |
+| render(camera, bitmap, options) | Rendera scenen till bitmap från den givna kamerans perspektiv. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| kamera | Kamera | Från vilken kameras perspektiv scenen ska renderas |
+| bitmap | TextureData | Mål för det renderade resultatet |
+| alternativ | ImageRenderOptions | Alternativet för att anpassa vissa interna inställningar. |
+
+ **Result:**
+AnimationClip
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/sceneobject/_index.md
+++ b/swedish/nodejs-java/aspose.threed/sceneobject/_index.md
@@ -1,0 +1,196 @@
+---
+title: "SceneObject"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/sceneobject/
+---
+## SceneObject class
+
+Rotklassen för objekt som kommer att lagras i en scen.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor(name) | Initiera ett SceneObject med ett standardnamn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| name | Sträng | Namnet på den här instansen |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload() | Initiera ett SceneObject. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getScene() | Hämtar scenen som detta objekt tillhör |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/shaderexception/_index.md
+++ b/swedish/nodejs-java/aspose.threed/shaderexception/_index.md
@@ -1,0 +1,35 @@
+---
+title: "ShaderException"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/shaderexception/
+---
+## ShaderException class
+
+Shaderrelaterade undantag
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor(message) | Konstruktor för ShaderException |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| messag | Sträng | null |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/shadermaterial/_index.md
+++ b/swedish/nodejs-java/aspose.threed/shadermaterial/_index.md
@@ -1,0 +1,261 @@
+---
+title: "ShaderMaterial"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/shadermaterial/
+---
+## ShaderMaterial class
+
+Ett shader‑material tillåter att beskriva materialet med en extern renderingsmotor eller shader‑språk.  ShaderMaterial använder ShaderTechnique för att beskriva de konkreta renderingsdetaljerna,  och den mest lämpliga kommer att användas enligt den slutgiltiga renderingsplattformen.  Till exempel kan din ShaderMaterial‑instans ha två tekniker, en definierad av HLSL och en annan definierad av GLSL.  På icke‑Windows‑plattform bör GLSL användas istället för HLSL.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Initierar en ny instans av ShaderMaterial‑klassen. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload(name) | Initierar en ny instans av ShaderMaterial‑klassen. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| name | Sträng | Namn |
+
+ **Result:**
+
+
+
+---
+
+
+### getTechniques{#getTechniques}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getTechniques() | Hämtar alla tillgängliga tekniker som definieras i detta material. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTexture{#getTexture}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getTexture(slotName) | Hämtar texturen från den angivna sloten, den kan vara materialets egenskapsnamn eller shaderns parameternamn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| slotName | Sträng | Slotnamn. |
+
+ **Result:**
+TextureBase
+
+
+---
+
+
+### setTexture{#setTexture}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setTexture(slotName, texture) | Anger texturen till den angivna sloten |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| slotName | Sträng | Slotnamn. |
+| texture | TextureBase | Textur. |
+
+ **Result:**
+TextureBase
+
+
+---
+
+
+### toString{#toString}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toString() | Formaterar objekt till sträng. |
+
+ **Result:**
+Sträng
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+### iterator{#iterator}
+
+| Namn | Beskrivning |
+| --- | --- |
+| iterator() | Reserverad för internt bruk. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/shaderprogram/_index.md
+++ b/swedish/nodejs-java/aspose.threed/shaderprogram/_index.md
@@ -1,0 +1,13 @@
+---
+title: "ShaderProgram"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/shaderprogram/
+---
+## ShaderProgram class
+
+Shaderprogrammet  @hideconstructor
+
+

--- a/swedish/nodejs-java/aspose.threed/shaderset/_index.md
+++ b/swedish/nodejs-java/aspose.threed/shaderset/_index.md
@@ -1,0 +1,133 @@
+---
+title: "ShaderSet"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/shaderset/
+---
+## ShaderSet class
+
+Shaderprogram för varje typ av material
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Skapa en instans av ShaderSet |
+
+ **Result:**
+
+
+
+---
+
+
+### getLambert{#getLambert}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getLambert() | Hämtar eller anger shadern som används för att rendera lambert-materialet |
+
+ **Result:**
+
+
+
+---
+
+
+### setLambert{#setLambert}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setLambert(value) | Hämtar eller anger shadern som används för att rendera lambert-materialet |
+
+ **Result:**
+
+
+
+---
+
+
+### getPhong{#getPhong}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getPhong() | Hämtar eller anger shadern som används för att rendera phong-materialet |
+
+ **Result:**
+
+
+
+---
+
+
+### setPhong{#setPhong}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setPhong(value) | Hämtar eller anger shadern som används för att rendera phong-materialet |
+
+ **Result:**
+
+
+
+---
+
+
+### getPbr{#getPbr}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getPbr() | Hämtar eller anger shadern som används för att rendera PBR-materialet |
+
+ **Result:**
+
+
+
+---
+
+
+### setPbr{#setPbr}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setPbr(value) | Hämtar eller anger shadern som används för att rendera PBR-materialet |
+
+ **Result:**
+
+
+
+---
+
+
+### getFallback{#getFallback}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFallback() | Hämtar eller anger reservshadern när den erforderliga shadern är otillgänglig |
+
+ **Result:**
+
+
+
+---
+
+
+### setFallback{#setFallback}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFallback(value) | Hämtar eller anger reservshadern när den erforderliga shadern är otillgänglig |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/shadersource/_index.md
+++ b/swedish/nodejs-java/aspose.threed/shadersource/_index.md
@@ -1,0 +1,13 @@
+---
+title: "ShaderSource"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/shadersource/
+---
+## ShaderSource class
+
+Shaderns källkod  @hideconstructor
+
+

--- a/swedish/nodejs-java/aspose.threed/shadertechnique/_index.md
+++ b/swedish/nodejs-java/aspose.threed/shadertechnique/_index.md
@@ -1,0 +1,270 @@
+---
+title: "ShaderTechnique"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/shadertechnique/
+---
+## ShaderTechnique class
+
+En shader‑teknik representerar en konkret renderingsimplementation.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Initierar en ny instans av klassen ShaderTechnique. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDescription{#getDescription}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getDescription() | Hämtar eller anger beskrivningen av denna teknik |
+
+ **Result:**
+
+
+
+---
+
+
+### setDescription{#setDescription}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setDescription(value) | Hämtar eller anger beskrivningen av denna teknik |
+
+ **Result:**
+
+
+
+---
+
+
+### getShaderLanguage{#getShaderLanguage}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getShaderLanguage() | Hämtar eller anger shaderspråket som används av denna teknik. |
+
+ **Result:**
+
+
+
+---
+
+
+### setShaderLanguage{#setShaderLanguage}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setShaderLanguage(value) | Hämtar eller anger shaderspråket som används av denna teknik. |
+
+ **Result:**
+
+
+
+---
+
+
+### getShaderVersion{#getShaderVersion}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getShaderVersion() | Hämtar eller anger shaderversionen som används av denna teknik. |
+
+ **Result:**
+
+
+
+---
+
+
+### setShaderVersion{#setShaderVersion}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setShaderVersion(value) | Hämtar eller anger shaderversionen som används av denna teknik. |
+
+ **Result:**
+
+
+
+---
+
+
+### getShaderFile{#getShaderFile}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getShaderFile() | Hämtar eller anger filnamnet för den externa shaderfilen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setShaderFile{#setShaderFile}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setShaderFile(value) | Hämtar eller anger filnamnet för den externa shaderfilen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getShaderContent{#getShaderContent}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getShaderContent() | Hämtar eller anger innehållet i ett inbäddat shader-skript. Det kan vara en HLSL/GLSL shaderkällfil. |
+
+ **Result:**
+
+
+
+---
+
+
+### setShaderContent{#setShaderContent}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setShaderContent(value) | Hämtar eller anger innehållet i ett inbäddat shader-skript. Det kan vara en HLSL/GLSL shaderkällfil. |
+
+ **Result:**
+
+
+
+---
+
+
+### getShaderEntry{#getShaderEntry}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getShaderEntry() | Hämtar eller anger ingångspunkten för shadern, vissa shaders som HLSL kan ha anpassade shaderingångar. |
+
+ **Result:**
+
+
+
+---
+
+
+### setShaderEntry{#setShaderEntry}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setShaderEntry(value) | Hämtar eller anger ingångspunkten för shadern, vissa shaders som HLSL kan ha anpassade shaderingångar. |
+
+ **Result:**
+
+
+
+---
+
+
+### getRenderAPI{#getRenderAPI}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getRenderAPI() | Hämtar eller anger renderings-API:t som används av denna teknik |
+
+ **Result:**
+
+
+
+---
+
+
+### setRenderAPI{#setRenderAPI}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setRenderAPI(value) | Hämtar eller anger renderings-API:t som används av denna teknik |
+
+ **Result:**
+
+
+
+---
+
+
+### getRenderAPIVersion{#getRenderAPIVersion}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getRenderAPIVersion() | Hämtar eller anger versionen av renderings-API:et. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRenderAPIVersion{#setRenderAPIVersion}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setRenderAPIVersion(value) | Hämtar eller anger versionen av renderings-API:et. |
+
+ **Result:**
+
+
+
+---
+
+
+### getShaderParameters{#getShaderParameters}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getShaderParameters() | Hämtar definitionen av shader‑parametern. Nyckeln är namnet på den dynamiska egenskapen, och värdet är shader‑parameternamnet som egenskapen är kopplad till. |
+
+ **Result:**
+
+
+
+---
+
+
+### addBinding{#addBinding}
+
+| Namn | Beskrivning |
+| --- | --- |
+| addBinding(property, shaderParameter) | Kopplar den dynamiska egenskapen till shader‑parameter. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Namnet på den dynamiska egenskapen. |
+| shaderParameter | Sträng | Namnet på shader‑parametern. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/shadervariable/_index.md
+++ b/swedish/nodejs-java/aspose.threed/shadervariable/_index.md
@@ -1,0 +1,68 @@
+---
+title: "ShaderVariable"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/shadervariable/
+---
+## ShaderVariable class
+
+Shader‑variabel
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor(name) | Konstruktor för ShaderVariable |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| nam | Sträng | null |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload(name, shaderStage) | Konstruktor för ShaderVariable |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| nam | Sträng | null |
+| shaderStage | Nummer | ShaderStage |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar namnet på denna variabel |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/shape/_index.md
+++ b/swedish/nodejs-java/aspose.threed/shape/_index.md
@@ -1,0 +1,573 @@
+---
+title: "Form"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/shape/
+---
+## Shape class
+
+Formen beskriver deformationen på en uppsättning kontrollpunkter, vilket liknar cluster‑deformeraren i Maya.  Till exempel kan vi lägga till en form till en skapad geometri.  Och formen och geometrin har samma topologiska information men olika positioner för kontrollpunkterna.  Med varierande mängder av påverkan utför geometrin en deformationseffekt.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Initierar en ny instans av klassen Shape. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload(name) | Initierar en ny instans av klassen Shape. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| name | Sträng | Namn |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getIndices() | Hämtar indexen. Indexen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getVisible{#getVisible}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getVisible() | Hämtar eller anger om geometrin är synlig |
+
+ **Result:**
+
+
+
+---
+
+
+### setVisible{#setVisible}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setVisible(value) | Hämtar eller anger om geometrin är synlig |
+
+ **Result:**
+
+
+
+---
+
+
+### getDeformers{#getDeformers}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getDeformers() | Hämtar alla deformers som är associerade med denna geometri. Deformers. |
+
+ **Result:**
+
+
+
+---
+
+
+### getControlPoints{#getControlPoints}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getControlPoints() | Hämtar alla kontrollpunkter |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastShadows{#getCastShadows}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getCastShadows() | Hämtar eller anger om denna geometri kan kasta skugga |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastShadows{#setCastShadows}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setCastShadows(value) | Hämtar eller anger om denna geometri kan kasta skugga |
+
+ **Result:**
+
+
+
+---
+
+
+### getReceiveShadows{#getReceiveShadows}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getReceiveShadows() | Hämtar eller anger om denna geometri kan ta emot skugga. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReceiveShadows{#setReceiveShadows}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setReceiveShadows(value) | Hämtar eller anger om denna geometri kan ta emot skugga. |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElements{#getVertexElements}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getVertexElements() | Hämtar alla vertex elements |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNodes() | Hämtar alla föräldranoder, en entitet kan fästas vid flera föräldranoder för geometri‑instansering. Noderna. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExcluded() | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExcluded(value) | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNode() | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setParentNode(value) | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getScene() | Hämtar scenen som detta objekt tillhör |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### fromControlPoints{#fromControlPoints}
+
+| Namn | Beskrivning |
+| --- | --- |
+| fromControlPoints(controlPoints) | Skapa en form med specificerade kontrollpunkter med standardindex. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| kontrollpunkt | Vector3[] | null |
+
+ **Result:**
+Form
+
+
+---
+
+
+### getElement{#getElement}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getElement(type) | Hämtar ett vertex element med angiven typ |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| typ | VertexElementType | VertexElementType |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### getVertexElementOfUV{#getVertexElementOfUV}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getVertexElementOfUV(textureMapping) | Hämtar en VertexElementUV-instans med given texture mapping-typ |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| textureMapping | TextureMapping | TextureMapping |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### createElement{#createElement}
+
+| Namn | Beskrivning |
+| --- | --- |
+| createElement(type) | Skapar ett vertex element med angiven typ och lägger till det i geometrin. Om typen är VertexElementType.UV, skapas ett VertexElementUV med texture mapping-typ till TextureMapping.DIFFUSE. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| typ | VertexElementType | VertexElementType |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### addElement{#addElement}
+
+| Namn | Beskrivning |
+| --- | --- |
+| addElement(element) | Lägger till ett befintligt vertex element i den aktuella geometrin |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| element | VertexElement | Vertex elementet att lägga till |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### createElement{#createElement}
+
+| Namn | Beskrivning |
+| --- | --- |
+| createElement(type, mappingMode, referenceMode) | Skapar ett vertex element med angiven typ och lägger till det i geometrin. Om typen är VertexElementType.UV, skapas ett VertexElementUV med texture mapping-typ till TextureMapping.DIFFUSE. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| typ | VertexElementType | VertexElementType |
+| mappingMode | MappingMode | MappingMode |
+| referenceMode | ReferenceMode | ReferenceMode |
+
+ **Result:**
+VertexElement
+
+
+---
+
+
+### createElementUV{#createElementUV}
+
+| Namn | Beskrivning |
+| --- | --- |
+| createElementUV(uvMapping) | Skapar ett VertexElementUV med given texturkartläggningstyp. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| uvMapping | TextureMapping | TextureMapping |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### createElementUV{#createElementUV}
+
+| Namn | Beskrivning |
+| --- | --- |
+| createElementUV(uvMapping, mappingMode, referenceMode) | Skapar ett VertexElementUV med given texturkartläggningstyp. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| uvMapping | TextureMapping | TextureMapping |
+| mappingMode | MappingMode | MappingMode |
+| referenceMode | ReferenceMode | ReferenceMode |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBoundingBox() | Hämtar den omgivande lådan för den aktuella enheten i dess objektrums koordinatsystem. |
+
+ **Result:**
+VertexElementUV
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEntityRendererKey() | Hämtar nyckeln för enhetens renderare som är registrerad i renderaren |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/skeleton/_index.md
+++ b/swedish/nodejs-java/aspose.threed/skeleton/_index.md
@@ -1,0 +1,339 @@
+---
+title: "Skelett"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/skeleton/
+---
+## Skeleton class
+
+Skeleton används huvudsakligen av CAD‑program för att hjälpa designern att manipulera transformationen av skelettstrukturen, den är vanligtvis oanvändbar utanför CAD‑programmen. För att få skelettshierarkin att fungera som ett objekt i CAD‑programmet måste den översta Skeleton‑noden markeras som rot genom att sätta Type till SkeletonType.SKELETON, och alla barn sättas till SkeletonType.BONE
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Initierar en ny instans av Skeleton-klassen. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload(name) | Initierar en ny instans av Skeleton-klassen. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| name | Sträng | Namn. |
+
+ **Result:**
+
+
+
+---
+
+
+### getSize{#getSize}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getSize() | Hämtar eller anger storleken på lemnod som används i CAD-program för att representera benets storlek. |
+
+ **Result:**
+
+
+
+---
+
+
+### setSize{#setSize}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setSize(value) | Hämtar eller anger storleken på lemnod som används i CAD-program för att representera benets storlek. |
+
+ **Result:**
+
+
+
+---
+
+
+### getType{#getType}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getType() | Hämtar eller anger typen av skelettet. Värdet på egenskapen är heltalskonstanten SkeletonType. Typen av skelettet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setType{#setType}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setType(value) | Hämtar eller anger typen av skelettet. Värdet på egenskapen är heltalskonstanten SkeletonType. Typen av skelettet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNodes() | Hämtar alla föräldranoder, en entitet kan fästas vid flera föräldranoder för geometri‑instansering. Noderna. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExcluded() | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExcluded(value) | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNode() | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setParentNode(value) | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getScene() | Hämtar scenen som detta objekt tillhör |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBoundingBox() | Hämtar den omgivande lådan för den aktuella enheten i dess objektrums koordinatsystem. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEntityRendererKey() | Hämtar nyckeln för enhetens renderare som är registrerad i renderaren |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/skindeformer/_index.md
+++ b/swedish/nodejs-java/aspose.threed/skindeformer/_index.md
@@ -1,0 +1,209 @@
+---
+title: "SkinDeformer"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/skindeformer/
+---
+## SkinDeformer class
+
+En skin‑deformer innehåller flera ben för att arbeta, varje ben blandar en del av geometrin med kontrollpunktens vikter.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor(name) | Initierar en ny instans av klassen SkinDeformer. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| name | Sträng | Namn. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload() | Initierar en ny instans av klassen SkinDeformer. |
+
+ **Result:**
+
+
+
+---
+
+
+### getBones{#getBones}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBones() | Hämtar alla ben som skin-deformern innehåller |
+
+ **Result:**
+
+
+
+---
+
+
+### getOwner{#getOwner}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getOwner() | Hämtar geometrin som äger denna deformerare |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/sphere/_index.md
+++ b/swedish/nodejs-java/aspose.threed/sphere/_index.md
@@ -1,0 +1,581 @@
+---
+title: "Sphere"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/sphere/
+---
+## Sphere class
+
+Parametriserad sfär.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Initierar en ny instans av Sphere med standardradie 1. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload(radius) | Initierar en ny instans av Sphere-klassen med angiven radie. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| radius | Nummer | Radie. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload2(radius, widthSegments, heightSegments) | Initierar en ny instans av Sphere-klassen med angiven radie, breddsegment och höjsegment. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| radius | Nummer | Radie på sfären. |
+| widthSegments | Nummer | Breddsegment. |
+| heightSegments | Nummer | Höjsegment. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload3{#constructor_overload3}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload3(name, radius, widthSegments, heightSegments, phiStart, phiLength, thetaStart, thetaLength) | Initierar en ny instans av Sphere-klassen. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| name | Sträng | Namn. |
+| radius | Nummer | Radie på sfären. |
+| widthSegments | Nummer | Breddsegment. |
+| heightSegments | Nummer | Höjsegment. |
+| phiStart | Nummer | Phi start. |
+| phiLength | Nummer | Phi längd. |
+| thetaStart | Nummer | Theta start. |
+| thetaLength | Nummer | Theta längd. |
+
+ **Result:**
+
+
+
+---
+
+
+### getWidthSegments{#getWidthSegments}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getWidthSegments() | Hämtar eller anger breddsegmenten. Breddsegmenten. |
+
+ **Result:**
+
+
+
+---
+
+
+### setWidthSegments{#setWidthSegments}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setWidthSegments(value) | Hämtar eller anger breddsegmenten. Breddsegmenten. |
+
+ **Result:**
+
+
+
+---
+
+
+### getHeightSegments{#getHeightSegments}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getHeightSegments() | Hämtar eller anger höjsegmenten. Höjsegmenten. |
+
+ **Result:**
+
+
+
+---
+
+
+### setHeightSegments{#setHeightSegments}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setHeightSegments(value) | Hämtar eller anger höjsegmenten. Höjsegmenten. |
+
+ **Result:**
+
+
+
+---
+
+
+### getPhiStart{#getPhiStart}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getPhiStart() | Hämtar eller anger phi-starten. Phi-starten. |
+
+ **Result:**
+
+
+
+---
+
+
+### setPhiStart{#setPhiStart}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setPhiStart(value) | Hämtar eller anger phi-starten. Phi-starten. |
+
+ **Result:**
+
+
+
+---
+
+
+### getPhiLength{#getPhiLength}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getPhiLength() | Hämtar eller anger längden på phi. Längden på phi. |
+
+ **Result:**
+
+
+
+---
+
+
+### setPhiLength{#setPhiLength}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setPhiLength(value) | Hämtar eller anger längden på phi. Längden på phi. |
+
+ **Result:**
+
+
+
+---
+
+
+### getThetaStart{#getThetaStart}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getThetaStart() | Hämtar eller anger theta-starten. Theta-starten. |
+
+ **Result:**
+
+
+
+---
+
+
+### setThetaStart{#setThetaStart}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setThetaStart(value) | Hämtar eller anger theta-starten. Theta-starten. |
+
+ **Result:**
+
+
+
+---
+
+
+### getThetaLength{#getThetaLength}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getThetaLength() | Hämtar eller anger längden på theta. Längden på theta. |
+
+ **Result:**
+
+
+
+---
+
+
+### setThetaLength{#setThetaLength}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setThetaLength(value) | Hämtar eller anger längden på theta. Längden på theta. |
+
+ **Result:**
+
+
+
+---
+
+
+### getRadius{#getRadius}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getRadius() | Hämtar eller anger radien på sfären. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRadius{#setRadius}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setRadius(value) | Hämtar eller anger radien på sfären. |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastShadows{#getCastShadows}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getCastShadows() | Hämtar eller anger om denna geometri kan kasta skugga |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastShadows{#setCastShadows}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setCastShadows(value) | Hämtar eller anger om denna geometri kan kasta skugga |
+
+ **Result:**
+
+
+
+---
+
+
+### getReceiveShadows{#getReceiveShadows}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getReceiveShadows() | Hämtar eller anger om denna geometri kan ta emot skugga. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReceiveShadows{#setReceiveShadows}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setReceiveShadows(value) | Hämtar eller anger om denna geometri kan ta emot skugga. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNodes() | Hämtar alla föräldranoder, en entitet kan fästas vid flera föräldranoder för geometri‑instansering. Noderna. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExcluded() | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExcluded(value) | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNode() | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setParentNode(value) | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getScene() | Hämtar scenen som detta objekt tillhör |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### toMesh{#toMesh}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toMesh() | Konvertera aktuellt objekt till mesh |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBoundingBox() | Hämtar den omgivande lådan för den aktuella enheten i dess objektrums koordinatsystem. |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEntityRendererKey() | Hämtar nyckeln för enhetens renderare som är registrerad i renderaren |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/spirvsource/_index.md
+++ b/swedish/nodejs-java/aspose.threed/spirvsource/_index.md
@@ -1,0 +1,159 @@
+---
+title: "SPIRVSource"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/spirvsource/
+---
+## SPIRVSource class
+
+Den kompilerade shadern i SPIR‑V‑format.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Konstruktor för SPIR-V-baserade shaderkällor. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMaximumDescriptorSets{#getMaximumDescriptorSets}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getMaximumDescriptorSets() | Maximalt antal descriptor-sets, standardvärdet är 10 |
+
+ **Result:**
+
+
+
+---
+
+
+### setMaximumDescriptorSets{#setMaximumDescriptorSets}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setMaximumDescriptorSets(value) | Maximalt antal descriptor-sets, standardvärdet är 10 |
+
+ **Result:**
+
+
+
+---
+
+
+### getComputeShader{#getComputeShader}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getComputeShader() | Hämtar eller anger källkoden för compute-shadern. |
+
+ **Result:**
+
+
+
+---
+
+
+### setComputeShader{#setComputeShader}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setComputeShader(value) | Hämtar eller anger källkoden för compute-shadern. |
+
+ **Result:**
+
+
+
+---
+
+
+### getGeometryShader{#getGeometryShader}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getGeometryShader() | Hämtar eller anger källkoden för geometry-shadern. |
+
+ **Result:**
+
+
+
+---
+
+
+### setGeometryShader{#setGeometryShader}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setGeometryShader(value) | Hämtar eller anger källkoden för geometry-shadern. |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexShader{#getVertexShader}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getVertexShader() | Hämtar eller anger källkoden för vertex-shadern |
+
+ **Result:**
+
+
+
+---
+
+
+### setVertexShader{#setVertexShader}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setVertexShader(value) | Hämtar eller anger källkoden för vertex-shadern |
+
+ **Result:**
+
+
+
+---
+
+
+### getFragmentShader{#getFragmentShader}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFragmentShader() | Hämtar eller anger källkoden för fragmentshadern. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFragmentShader{#setFragmentShader}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFragmentShader(value) | Hämtar eller anger källkoden för fragmentshadern. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/stencilstate/_index.md
+++ b/swedish/nodejs-java/aspose.threed/stencilstate/_index.md
@@ -1,0 +1,152 @@
+---
+title: "StencilState"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/stencilstate/
+---
+## StencilState class
+
+Stencil‑tillstånd per yta.  @hideconstructor
+
+
+## Metoder
+
+### getCompare{#getCompare}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getCompare() | Hämtar eller anger jämförelsefunktionen som används i stenciltest. Värdet på egenskapen är heltalskonstanten CompareFunction. |
+
+ **Result:**
+
+
+
+---
+
+
+### setCompare{#setCompare}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setCompare(value) | Hämtar eller anger jämförelsefunktionen som används i stenciltest. Värdet på egenskapen är heltalskonstanten CompareFunction. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFailAction{#getFailAction}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFailAction() | Hämtar eller anger stencil-åtgärden när stenciltestet misslyckas. Värdet på egenskapen är heltalskonstanten StencilAction. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFailAction{#setFailAction}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFailAction(value) | Hämtar eller anger stencil-åtgärden när stenciltestet misslyckas. Värdet på egenskapen är heltalskonstanten StencilAction. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDepthFailAction{#getDepthFailAction}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getDepthFailAction() | Hämtar eller anger stencil-åtgärden när stenciltestet passerar men djup-testet misslyckas. Värdet på egenskapen är heltalskonstanten StencilAction. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDepthFailAction{#setDepthFailAction}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setDepthFailAction(value) | Hämtar eller anger stencil-åtgärden när stenciltestet passerar men djup-testet misslyckas. Värdet på egenskapen är heltalskonstanten StencilAction. |
+
+ **Result:**
+
+
+
+---
+
+
+### getPassAction{#getPassAction}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getPassAction() | Hämtar eller anger stencil-åtgärden när både stenciltestet och djup-testet passerar. Värdet på egenskapen är heltalskonstanten StencilAction. |
+
+ **Result:**
+
+
+
+---
+
+
+### setPassAction{#setPassAction}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setPassAction(value) | Hämtar eller anger stencil-åtgärden när både stenciltestet och djup-testet passerar. Värdet på egenskapen är heltalskonstanten StencilAction. |
+
+ **Result:**
+
+
+
+---
+
+
+### equals{#equals}
+
+| Namn | Beskrivning |
+| --- | --- |
+| equals(obj) | Returnerar ett värde som indikerar om den här instansen är lika med ett angivet objekt. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| ob | Objekt | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### hashCode{#hashCode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| hashCode() | Returnerar hash‑koden för den här instansen. |
+
+ **Result:**
+boolean
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/stlloadoptions/_index.md
+++ b/swedish/nodejs-java/aspose.threed/stlloadoptions/_index.md
@@ -1,0 +1,191 @@
+---
+title: "StlLoadOptions"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/stlloadoptions/
+---
+## StlLoadOptions class
+
+Läsalternativ för STL
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Initierar en ny StlLoadOptions-instans. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload(contentType) | Initierar en ny StlLoadOptions-instans. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| contentType | FileContentType | FileContentType |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlipCoordinateSystem{#getFlipCoordinateSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFlipCoordinateSystem() | Hämtar eller anger om koordinatsystemet för kontrollpunkter/normaler ska vändas vid import. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlipCoordinateSystem{#setFlipCoordinateSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFlipCoordinateSystem(value) | Hämtar eller anger om koordinatsystemet för kontrollpunkter/normaler ska vändas vid import. |
+
+ **Result:**
+
+
+
+---
+
+
+### getRecalculateNormal{#getRecalculateNormal}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getRecalculateNormal() | Ignorera normaldata som lagras i STL-filen och beräkna om normaldata baserat på vertexpositionen. Standardvärdet är falskt. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRecalculateNormal{#setRecalculateNormal}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setRecalculateNormal(value) | Ignorera normaldata som lagras i STL-filen och beräkna om normaldata baserat på vertexpositionen. Standardvärdet är falskt. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileFormat() | Hämtar filformatet som anges i aktuellt Spara/Ladda-alternativ. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEncoding() | Hämtar eller anger standardkodning för textbaserade filer. Standardvärdet är null, vilket betyder att importören/exportören bestämmer vilken kodning som ska användas. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileSystem() | Tillåter användaren att hantera hur externa beroenden ska hanteras under laddning/sparning. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFileSystem(value) | Tillåter användaren att hantera hur externa beroenden ska hanteras under laddning/sparning. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getLookupPaths() | Vissa filer, som OBJ, är beroende av externa filer; sökvägarna gör det möjligt för Aspose.3D att leta efter externa filer att ladda. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileName() | Filnamnet för den exporterade/importerade scenen. Detta är valfritt, men användbart när externa resurser som OBJ:s material serialiseras. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFileName(value) | Filnamnet för den exporterade/importerade scenen. Detta är valfritt, men användbart när externa resurser som OBJ:s material serialiseras. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/stlsaveoptions/_index.md
+++ b/swedish/nodejs-java/aspose.threed/stlsaveoptions/_index.md
@@ -1,0 +1,191 @@
+---
+title: "StlSaveOptions"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/stlsaveoptions/
+---
+## StlSaveOptions class
+
+Sparaalternativ för STL
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Initierar en ny instans av StlSaveOptions. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload(contentType) | Initierar en ny instans av StlSaveOptions. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| contentType | FileContentType | FileContentType |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlipCoordinateSystem{#getFlipCoordinateSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFlipCoordinateSystem() | Hämtar eller anger om koordinatsystemet för kontrollpunkter/normaler ska vändas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlipCoordinateSystem{#setFlipCoordinateSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFlipCoordinateSystem(value) | Hämtar eller anger om koordinatsystemet för kontrollpunkter/normaler ska vändas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportTextures{#getExportTextures}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExportTextures() | Försök att kopiera texturer som används i scenen till utdatamappen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextures{#setExportTextures}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExportTextures(value) | Försök att kopiera texturer som används i scenen till utdatamappen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileFormat() | Hämtar filformatet som anges i aktuellt Spara/Ladda-alternativ. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEncoding() | Hämtar eller anger standardkodning för textbaserade filer. Standardvärdet är null, vilket betyder att importören/exportören bestämmer vilken kodning som ska användas. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileSystem() | Tillåter användaren att hantera hur externa beroenden ska hanteras under laddning/sparning. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFileSystem(value) | Tillåter användaren att hantera hur externa beroenden ska hanteras under laddning/sparning. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getLookupPaths() | Vissa filer, som OBJ, är beroende av externa filer; sökvägarna gör det möjligt för Aspose.3D att leta efter externa filer att ladda. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileName() | Filnamnet för den exporterade/importerade scenen. Detta är valfritt, men användbart när externa resurser som OBJ:s material serialiseras. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFileName(value) | Filnamnet för den exporterade/importerade scenen. Detta är valfritt, men användbart när externa resurser som OBJ:s material serialiseras. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/sweptareasolid/_index.md
+++ b/swedish/nodejs-java/aspose.threed/sweptareasolid/_index.md
@@ -1,0 +1,385 @@
+---
+title: "SweptAreaSolid"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/sweptareasolid/
+---
+## SweptAreaSolid class
+
+En SweptAreaSolid konstruerar en geometri genom att svepa en profil längs en direktrix.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getShape{#getShape}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getShape() | Basprofilen för att konstruera geometrin. |
+
+ **Result:**
+
+
+
+---
+
+
+### setShape{#setShape}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setShape(value) | Basprofilen för att konstruera geometrin. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDirectrix{#getDirectrix}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getDirectrix() | Direktrisen som det svepta området sveper längs med. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDirectrix{#setDirectrix}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setDirectrix(value) | Direktrisen som det svepta området sveper längs med. |
+
+ **Result:**
+
+
+
+---
+
+
+### getStartPoint{#getStartPoint}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getStartPoint() | Startpunkten för direktrixen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setStartPoint{#setStartPoint}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setStartPoint(value) | Startpunkten för direktrixen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEndPoint{#getEndPoint}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEndPoint() | Slutpunkten för direktrixen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setEndPoint{#setEndPoint}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setEndPoint(value) | Slutpunkten för direktrixen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNodes() | Hämtar alla föräldranoder, en entitet kan fästas vid flera föräldranoder för geometri‑instansering. Noderna. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExcluded() | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExcluded(value) | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNode() | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setParentNode(value) | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getScene() | Hämtar scenen som detta objekt tillhör |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### toMesh{#toMesh}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toMesh() | Konvertera aktuellt objekt till mesh |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBoundingBox() | Hämtar den omgivande lådan för den aktuella enheten i dess objektrums koordinatsystem. |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEntityRendererKey() | Hämtar nyckeln för enhetens renderare som är registrerad i renderaren |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/text/_index.md
+++ b/swedish/nodejs-java/aspose.threed/text/_index.md
@@ -1,0 +1,346 @@
+---
+title: "Text"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/text/
+---
+## Text class
+
+Textprofil, denna profil beskriver konturer med hjälp av typsnitt och text.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getContent{#getContent}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getContent() | Textens innehåll |
+
+ **Result:**
+
+
+
+---
+
+
+### setContent{#setContent}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setContent(value) | Textens innehåll |
+
+ **Result:**
+
+
+
+---
+
+
+### getFont{#getFont}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFont() | Typsnittet för texten. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFont{#setFont}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFont(value) | Typsnittet för texten. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFontSize{#getFontSize}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFontSize() | Skala för typsnittsstorlek. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFontSize{#setFontSize}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFontSize(value) | Skala för typsnittsstorlek. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNodes() | Hämtar alla föräldranoder, en entitet kan fästas vid flera föräldranoder för geometri‑instansering. Noderna. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExcluded() | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExcluded(value) | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNode() | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setParentNode(value) | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getScene() | Hämtar scenen som detta objekt tillhör |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEntityRendererKey() | Hämtar nyckeln för enhetens renderare som är registrerad i renderaren |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBoundingBox() | Hämtar den omgivande lådan för den aktuella enheten i dess objektrums koordinatsystem. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/texture/_index.md
+++ b/swedish/nodejs-java/aspose.threed/texture/_index.md
@@ -1,0 +1,607 @@
+---
+title: "Texture"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/texture/
+---
+## Texture class
+
+Denna klass definierar texturen från en extern fil.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Initierar en ny instans av klassen Texture. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload(name) | Initierar en ny instans av klassen Texture. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| name | Sträng | Namn |
+
+ **Result:**
+
+
+
+---
+
+
+### getEnableMipMap{#getEnableMipMap}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEnableMipMap() | Hämtar eller anger om mipmap är aktiverad för denna textur |
+
+ **Result:**
+
+
+
+---
+
+
+### setEnableMipMap{#setEnableMipMap}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setEnableMipMap(value) | Hämtar eller anger om mipmap är aktiverad för denna textur |
+
+ **Result:**
+
+
+
+---
+
+
+### getContent{#getContent}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getContent() | Hämtar eller anger det binära innehållet i texturen. Det inbäddade texturinnehållet är valfritt, användaren bör ladda texturen från en extern fil om detta saknas. |
+
+ **Result:**
+
+
+
+---
+
+
+### setContent{#setContent}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setContent(value) | Hämtar eller anger det binära innehållet i texturen. Det inbäddade texturinnehållet är valfritt, användaren bör ladda texturen från en extern fil om detta saknas. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileName() | Hämtar eller anger den associerade texturfilen. Filens namn. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFileName(value) | Hämtar eller anger den associerade texturfilen. Filens namn. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAlpha{#getAlpha}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getAlpha() | Hämtar eller anger standard alfa‑värdet för texturen. Detta är giltigt när AlphaSource är AlphaSource.PIXEL_ALPHA. Standardvärdet är 1.0, giltigt värdeintervall är mellan 0 och 1. |
+
+ **Result:**
+
+
+
+---
+
+
+### setAlpha{#setAlpha}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setAlpha(value) | Hämtar eller anger standard alfa‑värdet för texturen. Detta är giltigt när AlphaSource är AlphaSource.PIXEL_ALPHA. Standardvärdet är 1.0, giltigt värdeintervall är mellan 0 och 1. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAlphaSource{#getAlphaSource}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getAlphaSource() | Hämtar eller anger om texturen definierar alfa‑kanalen. Standardvärdet är AlphaSource.NONE. Värdet på egenskapen är en heltalskonstant för AlphaSource. |
+
+ **Result:**
+
+
+
+---
+
+
+### setAlphaSource{#setAlphaSource}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setAlphaSource(value) | Hämtar eller anger om texturen definierar alfa‑kanalen. Standardvärdet är AlphaSource.NONE. Värdet på egenskapen är en heltalskonstant för AlphaSource. |
+
+ **Result:**
+
+
+
+---
+
+
+### getWrapModeU{#getWrapModeU}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getWrapModeU() | Hämtar eller anger texturens omslagslägen i U. Värdet på egenskapen är en heltalskonstant för WrapMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setWrapModeU{#setWrapModeU}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setWrapModeU(value) | Hämtar eller anger texturens omslagslägen i U. Värdet på egenskapen är en heltalskonstant för WrapMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getWrapModeV{#getWrapModeV}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getWrapModeV() | Hämtar eller anger texturens omslagslägen i V. Värdet på egenskapen är en heltalskonstant för WrapMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setWrapModeV{#setWrapModeV}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setWrapModeV(value) | Hämtar eller anger texturens omslagslägen i V. Värdet på egenskapen är en heltalskonstant för WrapMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getWrapModeW{#getWrapModeW}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getWrapModeW() | Hämtar eller anger texturens omslagslägen i W. Värdet på egenskapen är en heltalskonstant för WrapMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setWrapModeW{#setWrapModeW}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setWrapModeW(value) | Hämtar eller anger texturens omslagslägen i W. Värdet på egenskapen är en heltalskonstant för WrapMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMinFilter{#getMinFilter}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getMinFilter() | Hämtar eller anger filtret för minifiering. Värdet på egenskapen är en heltalskonstant för TextureFilter. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMinFilter{#setMinFilter}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setMinFilter(value) | Hämtar eller anger filtret för minifiering. Värdet på egenskapen är en heltalskonstant för TextureFilter. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMagFilter{#getMagFilter}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getMagFilter() | Hämtar eller anger filtret för förstoring. Värdet på egenskapen är ett heltalskonstant av typen TextureFilter. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMagFilter{#setMagFilter}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setMagFilter(value) | Hämtar eller anger filtret för förstoring. Värdet på egenskapen är ett heltalskonstant av typen TextureFilter. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMipFilter{#getMipFilter}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getMipFilter() | Hämtar eller anger filtret för mip-nivåprovning. Värdet på egenskapen är ett heltalskonstant av typen TextureFilter. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMipFilter{#setMipFilter}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setMipFilter(value) | Hämtar eller anger filtret för mip-nivåprovning. Värdet på egenskapen är ett heltalskonstant av typen TextureFilter. |
+
+ **Result:**
+
+
+
+---
+
+
+### getUVRotation{#getUVRotation}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getUVRotation() | Hämtar eller anger rotationen för texturen |
+
+ **Result:**
+
+
+
+---
+
+
+### setUVRotation{#setUVRotation}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setUVRotation(value) | Hämtar eller anger rotationen för texturen |
+
+ **Result:**
+
+
+
+---
+
+
+### getUVScale{#getUVScale}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getUVScale() | Hämtar eller anger UV-skalan. UV-skalan. |
+
+ **Result:**
+
+
+
+---
+
+
+### setUVScale{#setUVScale}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setUVScale(value) | Hämtar eller anger UV-skalan. UV-skalan. |
+
+ **Result:**
+
+
+
+---
+
+
+### getUVTranslation{#getUVTranslation}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getUVTranslation() | Hämtar eller anger UV-översättningen. UV-översättningen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setUVTranslation{#setUVTranslation}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setUVTranslation(value) | Hämtar eller anger UV-översättningen. UV-översättningen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTranslation{#setTranslation}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setTranslation(u, v) | Anger UV-översättningen. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| u | Nummer | U. |
+| v | Nummer | V. |
+
+ **Result:**
+
+
+
+---
+
+
+### setScale{#setScale}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setScale(u, v) | Anger UV-skalan. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| u | Nummer | U. |
+| v | Nummer | V. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRotation{#setRotation}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setRotation(u, v) | Anger UV-rotationen. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| u | Nummer | U. |
+| v | Nummer | V. |
+
+ **Result:**
+
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/texturebase/_index.md
+++ b/swedish/nodejs-java/aspose.threed/texturebase/_index.md
@@ -1,0 +1,516 @@
+---
+title: "TextureBase"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/texturebase/
+---
+## TextureBase class
+
+Basklass för alla konkreta texturer.  Texture definierar utseendet och känslan av en geometrisk yta.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor(name) | Initierar en ny instans av klassen TextureBase. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| name | Sträng | Namn. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAlpha{#getAlpha}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getAlpha() | Hämtar eller anger standard alfa‑värdet för texturen. Detta är giltigt när AlphaSource är AlphaSource.PIXEL_ALPHA. Standardvärdet är 1.0, giltigt värdeintervall är mellan 0 och 1. |
+
+ **Result:**
+
+
+
+---
+
+
+### setAlpha{#setAlpha}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setAlpha(value) | Hämtar eller anger standard alfa‑värdet för texturen. Detta är giltigt när AlphaSource är AlphaSource.PIXEL_ALPHA. Standardvärdet är 1.0, giltigt värdeintervall är mellan 0 och 1. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAlphaSource{#getAlphaSource}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getAlphaSource() | Hämtar eller anger om texturen definierar alfa‑kanalen. Standardvärdet är AlphaSource.NONE. Värdet på egenskapen är en heltalskonstant för AlphaSource. |
+
+ **Result:**
+
+
+
+---
+
+
+### setAlphaSource{#setAlphaSource}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setAlphaSource(value) | Hämtar eller anger om texturen definierar alfa‑kanalen. Standardvärdet är AlphaSource.NONE. Värdet på egenskapen är en heltalskonstant för AlphaSource. |
+
+ **Result:**
+
+
+
+---
+
+
+### getWrapModeU{#getWrapModeU}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getWrapModeU() | Hämtar eller anger texturens omslagslägen i U. Värdet på egenskapen är en heltalskonstant för WrapMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setWrapModeU{#setWrapModeU}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setWrapModeU(value) | Hämtar eller anger texturens omslagslägen i U. Värdet på egenskapen är en heltalskonstant för WrapMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getWrapModeV{#getWrapModeV}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getWrapModeV() | Hämtar eller anger texturens omslagslägen i V. Värdet på egenskapen är en heltalskonstant för WrapMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setWrapModeV{#setWrapModeV}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setWrapModeV(value) | Hämtar eller anger texturens omslagslägen i V. Värdet på egenskapen är en heltalskonstant för WrapMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getWrapModeW{#getWrapModeW}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getWrapModeW() | Hämtar eller anger texturens omslagslägen i W. Värdet på egenskapen är en heltalskonstant för WrapMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setWrapModeW{#setWrapModeW}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setWrapModeW(value) | Hämtar eller anger texturens omslagslägen i W. Värdet på egenskapen är en heltalskonstant för WrapMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMinFilter{#getMinFilter}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getMinFilter() | Hämtar eller anger filtret för minifiering. Värdet på egenskapen är en heltalskonstant för TextureFilter. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMinFilter{#setMinFilter}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setMinFilter(value) | Hämtar eller anger filtret för minifiering. Värdet på egenskapen är en heltalskonstant för TextureFilter. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMagFilter{#getMagFilter}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getMagFilter() | Hämtar eller anger filtret för förstoring. Värdet på egenskapen är ett heltalskonstant av typen TextureFilter. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMagFilter{#setMagFilter}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setMagFilter(value) | Hämtar eller anger filtret för förstoring. Värdet på egenskapen är ett heltalskonstant av typen TextureFilter. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMipFilter{#getMipFilter}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getMipFilter() | Hämtar eller anger filtret för mip-nivåprovning. Värdet på egenskapen är ett heltalskonstant av typen TextureFilter. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMipFilter{#setMipFilter}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setMipFilter(value) | Hämtar eller anger filtret för mip-nivåprovning. Värdet på egenskapen är ett heltalskonstant av typen TextureFilter. |
+
+ **Result:**
+
+
+
+---
+
+
+### getUVRotation{#getUVRotation}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getUVRotation() | Hämtar eller anger rotationen för texturen |
+
+ **Result:**
+
+
+
+---
+
+
+### setUVRotation{#setUVRotation}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setUVRotation(value) | Hämtar eller anger rotationen för texturen |
+
+ **Result:**
+
+
+
+---
+
+
+### getUVScale{#getUVScale}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getUVScale() | Hämtar eller anger UV-skalan. UV-skalan. |
+
+ **Result:**
+
+
+
+---
+
+
+### setUVScale{#setUVScale}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setUVScale(value) | Hämtar eller anger UV-skalan. UV-skalan. |
+
+ **Result:**
+
+
+
+---
+
+
+### getUVTranslation{#getUVTranslation}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getUVTranslation() | Hämtar eller anger UV-översättningen. UV-översättningen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setUVTranslation{#setUVTranslation}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setUVTranslation(value) | Hämtar eller anger UV-översättningen. UV-översättningen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTranslation{#setTranslation}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setTranslation(u, v) | Anger UV-översättningen. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| u | Nummer | U. |
+| v | Nummer | V. |
+
+ **Result:**
+
+
+
+---
+
+
+### setScale{#setScale}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setScale(u, v) | Anger UV-skalan. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| u | Nummer | U. |
+| v | Nummer | V. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRotation{#setRotation}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setRotation(u, v) | Anger UV-rotationen. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| u | Nummer | U. |
+| v | Nummer | V. |
+
+ **Result:**
+
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/texturecodec/_index.md
+++ b/swedish/nodejs-java/aspose.threed/texturecodec/_index.md
@@ -1,0 +1,61 @@
+---
+title: "TextureCodec"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/texturecodec/
+---
+## TextureCodec class
+
+Klass för att hantera kodare och avkodare för texturer.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getSupportedEncoderFormats{#getSupportedEncoderFormats}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getSupportedEncoderFormats() | Hämtar alla stödda kodarformat |
+
+ **Result:**
+String[]
+
+
+---
+
+
+### registerCodec{#registerCodec}
+
+| Namn | Beskrivning |
+| --- | --- |
+| registerCodec(codec) | Registrera en uppsättning texturkodare och avkodare |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| kod | ITextureCodec | null |
+
+ **Result:**
+String[]
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/texturedata/_index.md
+++ b/swedish/nodejs-java/aspose.threed/texturedata/_index.md
@@ -1,0 +1,289 @@
+---
+title: "TextureData"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/texturedata/
+---
+## TextureData class
+
+Denna klass innehåller rådata och formatdefinitionen för en textur.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor(width, height, stride, bytesPerPixel, pixelFormat, data) | Konstruktor för TextureData |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| bredd | Nummer | null |
+| höjd | Nummer | null |
+| strid | Nummer | null |
+| bytesPerPixe | Nummer | null |
+| pixelFormat | PixelFormat | PixelFormat |
+| data | byte[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload(width, height, pixelFormat) | Skapar en ny TextureData och allokerar pixeldata. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| bredd | Nummer | null |
+| höjd | Nummer | null |
+| pixelFormat | PixelFormat | PixelFormat |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload2() | Konstruktor för TextureData |
+
+ **Result:**
+
+
+
+---
+
+
+### getData{#getData}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getData() | Rå byte för pixeldata |
+
+ **Result:**
+
+
+
+---
+
+
+### getWidth{#getWidth}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getWidth() | Antal horisontella pixlar |
+
+ **Result:**
+
+
+
+---
+
+
+### getHeight{#getHeight}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getHeight() | Antal vertikala pixlar |
+
+ **Result:**
+
+
+
+---
+
+
+### getStride{#getStride}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getStride() | Antal byte i en rad. |
+
+ **Result:**
+
+
+
+---
+
+
+### getBytesPerPixel{#getBytesPerPixel}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBytesPerPixel() | Antal byte per pixel |
+
+ **Result:**
+
+
+
+---
+
+
+### getPixelFormat{#getPixelFormat}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getPixelFormat() | Pixelens format Värdet på egenskapen är PixelFormat heltalskonstant. |
+
+ **Result:**
+
+
+
+---
+
+
+### fromFile{#fromFile}
+
+| Namn | Beskrivning |
+| --- | --- |
+| fromFile(fileName) | Ladda en textur från fil |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| fileNam | Sträng | null |
+
+ **Result:**
+TextureData
+
+
+---
+
+
+### save{#save}
+
+| Namn | Beskrivning |
+| --- | --- |
+| save(fileName) | Spara texturdata i bildfil |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| fileName | Sträng | Filnamnet där bilden kommer att sparas. |
+
+ **Result:**
+TextureData
+
+
+---
+
+
+### save{#save}
+
+| Namn | Beskrivning |
+| --- | --- |
+| save(fileName, format) | Spara texturdata i bildfil |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| fileName | Sträng | Filnamnet där bilden kommer att sparas. |
+| format | Sträng | Bildformat för utdatafilen. |
+
+ **Result:**
+TextureData
+
+
+---
+
+
+### mapPixels{#mapPixels}
+
+| Namn | Beskrivning |
+| --- | --- |
+| mapPixels(mapMode) | Mappa alla pixlar för läs/skriv |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| mapMode | PixelMapMode | PixelMapMode |
+
+ **Result:**
+PixelMapping
+
+
+---
+
+
+### mapPixels{#mapPixels}
+
+| Namn | Beskrivning |
+| --- | --- |
+| mapPixels(mapMode, format) | Mappa alla pixlar för läs/skriv i angivet pixelformat |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| mapMode | PixelMapMode | PixelMapMode |
+| format | PixelFormat | PixelFormat |
+
+ **Result:**
+PixelMapping
+
+
+---
+
+
+### mapPixels{#mapPixels}
+
+| Namn | Beskrivning |
+| --- | --- |
+| mapPixels(rect, mapMode, format) | Mappa pixlar adresserade av rect för läsning/skrivning i angivet pixelformat |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| rect | Rect | Området av pixlar som ska nås |
+| mapMode | PixelMapMode | PixelMapMode |
+| format | PixelFormat | PixelFormat |
+
+ **Result:**
+PixelMapping
+
+
+---
+
+
+### transformPixelFormat{#transformPixelFormat}
+
+| Namn | Beskrivning |
+| --- | --- |
+| transformPixelFormat(pixelFormat) | Transformera pixelns layout till ett nytt pixelformat. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| pixelFormat | PixelFormat | PixelFormat |
+
+ **Result:**
+PixelMapping
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/textureslot/_index.md
+++ b/swedish/nodejs-java/aspose.threed/textureslot/_index.md
@@ -1,0 +1,42 @@
+---
+title: "TextureSlot"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/textureslot/
+---
+## TextureSlot class
+
+Texturplats i Material, kan enumereras genom materialinstansen.  @hideconstructor
+
+
+## Metoder
+
+### getSlotName{#getSlotName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getSlotName() | Slotnamnet som indikerar var denna textur kommer att bindas till. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTexture{#getTexture}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getTexture() | Texturen som kommer att bindas till materialet. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/torus/_index.md
+++ b/swedish/nodejs-java/aspose.threed/torus/_index.md
@@ -1,0 +1,528 @@
+---
+title: "Torus"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/torus/
+---
+## Torus class
+
+Parametriserad torus.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Initierar en ny instans av Torus-klassen. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload(radius, tube) | Initierar en ny instans av Torus-klassen. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| radius | Nummer | Radien på torusen. |
+| tube | Nummer | Radien på torusens tube. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload2(radius, tube, arc) | Initierar en ny instans av Torus-klassen. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| radius | Nummer | Radien på torusen. |
+| tube | Nummer | Radien på torusens tube. |
+| arc | Nummer | Båge. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload3{#constructor_overload3}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload3(name, radius, tube, radialSegments, tubularSegments, arc) | Initierar en ny instans av Torus-klassen. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| name | Sträng | Namn. |
+| radius | Nummer | Radien på torusen. |
+| tube | Nummer | Radien på torusens tube. |
+| radialSegments | Nummer | Radiala segment. |
+| tubularSegments | Nummer | Tubulära segment. |
+| arc | Nummer | Båge. |
+
+ **Result:**
+
+
+
+---
+
+
+### getRadius{#getRadius}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getRadius() | Hämtar eller anger radien för torusen. Radien. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRadius{#setRadius}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setRadius(value) | Hämtar eller anger radien för torusen. Radien. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTube{#getTube}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getTube() | Hämtar eller anger radien för röret. Röret. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTube{#setTube}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setTube(value) | Hämtar eller anger radien för röret. Röret. |
+
+ **Result:**
+
+
+
+---
+
+
+### getRadialSegments{#getRadialSegments}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getRadialSegments() | Hämtar eller anger de radiella segmenten. De radiella segmenten. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRadialSegments{#setRadialSegments}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setRadialSegments(value) | Hämtar eller anger de radiella segmenten. De radiella segmenten. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTubularSegments{#getTubularSegments}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getTubularSegments() | Hämtar eller anger de tubulära segmenten. De tubulära segmenten. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTubularSegments{#setTubularSegments}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setTubularSegments(value) | Hämtar eller anger de tubulära segmenten. De tubulära segmenten. |
+
+ **Result:**
+
+
+
+---
+
+
+### getArc{#getArc}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getArc() | Hämtar eller anger bågen. Bågen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setArc{#setArc}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setArc(value) | Hämtar eller anger bågen. Bågen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getCastShadows{#getCastShadows}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getCastShadows() | Hämtar eller anger om denna geometri kan kasta skugga |
+
+ **Result:**
+
+
+
+---
+
+
+### setCastShadows{#setCastShadows}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setCastShadows(value) | Hämtar eller anger om denna geometri kan kasta skugga |
+
+ **Result:**
+
+
+
+---
+
+
+### getReceiveShadows{#getReceiveShadows}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getReceiveShadows() | Hämtar eller anger om denna geometri kan ta emot skugga. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReceiveShadows{#setReceiveShadows}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setReceiveShadows(value) | Hämtar eller anger om denna geometri kan ta emot skugga. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNodes() | Hämtar alla föräldranoder, en entitet kan fästas vid flera föräldranoder för geometri‑instansering. Noderna. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExcluded() | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExcluded(value) | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNode() | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setParentNode(value) | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getScene() | Hämtar scenen som detta objekt tillhör |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### toMesh{#toMesh}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toMesh() | Konvertera aktuellt objekt till mesh |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBoundingBox() | Hämtar den omgivande lådan för den aktuella enheten i dess objektrums koordinatsystem. |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEntityRendererKey() | Hämtar nyckeln för enhetens renderare som är registrerad i renderaren |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/transform/_index.md
+++ b/swedish/nodejs-java/aspose.threed/transform/_index.md
@@ -1,0 +1,561 @@
+---
+title: "Transform"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/transform/
+---
+## Transform class
+
+En transform innehåller information som möjliggör åtkomst till objektets förflyttning/skala/rotation eller transformmatris med minimal kostnad. Detta används av lokal transform.  @hideconstructor
+
+
+## Metoder
+
+### getGeometricTranslation{#getGeometricTranslation}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getGeometricTranslation() | Hämtar eller anger den geometriska translationen. Geometrisk transformation påverkar endast de bifogade enheterna och lämnar underordnade noder opåverkade. Den kommer att slås ihop som lokal transformation när du exporterar den geometriska transformationen till filtyper som inte stödjer den. |
+
+ **Result:**
+
+
+
+---
+
+
+### setGeometricTranslation{#setGeometricTranslation}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setGeometricTranslation(value) | Hämtar eller anger den geometriska translationen. Geometrisk transformation påverkar endast de bifogade enheterna och lämnar underordnade noder opåverkade. Den kommer att slås ihop som lokal transformation när du exporterar den geometriska transformationen till filtyper som inte stödjer den. |
+
+ **Result:**
+
+
+
+---
+
+
+### getGeometricScaling{#getGeometricScaling}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getGeometricScaling() | Hämtar eller anger den geometriska skalningen. Geometrisk transformation påverkar endast de bifogade enheterna och lämnar underordnade noder opåverkade. Den kommer att slås ihop som lokal transformation när du exporterar den geometriska transformationen till filtyper som inte stödjer den. |
+
+ **Result:**
+
+
+
+---
+
+
+### setGeometricScaling{#setGeometricScaling}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setGeometricScaling(value) | Hämtar eller anger den geometriska skalningen. Geometrisk transformation påverkar endast de bifogade enheterna och lämnar underordnade noder opåverkade. Den kommer att slås ihop som lokal transformation när du exporterar den geometriska transformationen till filtyper som inte stödjer den. |
+
+ **Result:**
+
+
+
+---
+
+
+### getGeometricRotation{#getGeometricRotation}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getGeometricRotation() | Hämtar eller anger den geometriska Euler-rotationen (mätt i grader). Geometrisk transformation påverkar endast de bifogade enheterna och lämnar underordnade noder opåverkade. Den kommer att slås ihop som lokal transformation när du exporterar den geometriska transformationen till filtyper som inte stödjer den. |
+
+ **Result:**
+
+
+
+---
+
+
+### setGeometricRotation{#setGeometricRotation}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setGeometricRotation(value) | Hämtar eller anger den geometriska Euler-rotationen (mätt i grader). Geometrisk transformation påverkar endast de bifogade enheterna och lämnar underordnade noder opåverkade. Den kommer att slås ihop som lokal transformation när du exporterar den geometriska transformationen till filtyper som inte stödjer den. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTranslation{#getTranslation}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getTranslation() | Hämtar eller anger översättningen |
+
+ **Result:**
+
+
+
+---
+
+
+### setTranslation{#setTranslation}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setTranslation(value) | Hämtar eller anger översättningen |
+
+ **Result:**
+
+
+
+---
+
+
+### getScale{#getScale}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getScale() | Hämtar eller anger skalan |
+
+ **Result:**
+
+
+
+---
+
+
+### setScale{#setScale}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setScale(value) | Hämtar eller anger skalan |
+
+ **Result:**
+
+
+
+---
+
+
+### getPreRotation{#getPreRotation}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getPreRotation() | Hämtar eller anger förrotationen representerad i grader |
+
+ **Result:**
+
+
+
+---
+
+
+### setPreRotation{#setPreRotation}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setPreRotation(value) | Hämtar eller anger förrotationen representerad i grader |
+
+ **Result:**
+
+
+
+---
+
+
+### getPostRotation{#getPostRotation}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getPostRotation() | Hämtar eller anger efterrotationen representerad i grader |
+
+ **Result:**
+
+
+
+---
+
+
+### setPostRotation{#setPostRotation}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setPostRotation(value) | Hämtar eller anger efterrotationen representerad i grader |
+
+ **Result:**
+
+
+
+---
+
+
+### getEulerAngles{#getEulerAngles}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEulerAngles() | Hämtar eller anger rotationen representerad i Euler-vinklar, mätt i grader |
+
+ **Result:**
+
+
+
+---
+
+
+### setEulerAngles{#setEulerAngles}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setEulerAngles(value) | Hämtar eller anger rotationen representerad i Euler-vinklar, mätt i grader |
+
+ **Result:**
+
+
+
+---
+
+
+### getRotation{#getRotation}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getRotation() | Hämtar eller anger rotationen representerad i en kvaternion. |
+
+ **Result:**
+
+
+
+---
+
+
+### setRotation{#setRotation}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setRotation(value) | Hämtar eller anger rotationen representerad i en kvaternion. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTransformMatrix{#getTransformMatrix}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getTransformMatrix() | Hämtar eller anger transformmatrisen. En tilldelning här kommer att återställa Översättningen, Skalan och Rotation, medan GeometricRotation, GeometricScaling och GeometricTranslation inte påverkas. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTransformMatrix{#setTransformMatrix}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setTransformMatrix(value) | Hämtar eller anger transformmatrisen. En tilldelning här kommer att återställa Översättningen, Skalan och Rotation, medan GeometricRotation, GeometricScaling och GeometricTranslation inte påverkas. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### setGeometricTranslation{#setGeometricTranslation}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setGeometricTranslation(x, y, z) | Anger den geometriska översättningen. Geometrisk transformation påverkar endast de bifogade enheterna och lämnar barnnoderna opåverkade. Den kommer att slås samman som lokal transformation när du exporterar den geometriska transformationen till filtyper som inte stöder den. |
+
+ **Result:**
+
+
+
+---
+
+
+### setGeometricScaling{#setGeometricScaling}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setGeometricScaling(sx, sy, sz) | Anger den geometriska skalningen. Geometrisk transformation påverkar endast de bifogade enheterna och lämnar barnnoderna opåverkade. Den kommer att slås samman som lokal transformation när du exporterar den geometriska transformationen till filtyper som inte stöder den. |
+
+ **Result:**
+
+
+
+---
+
+
+### setGeometricRotation{#setGeometricRotation}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setGeometricRotation(rx, ry, rz) | Anger den geometriska Euler-rotationen (mätt i grader). Geometrisk transformation påverkar endast de bifogade enheterna och lämnar barnnoderna opåverkade. Den kommer att slås samman som lokal transformation när du exporterar den geometriska transformationen till filtyper som inte stöder den. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTranslation{#setTranslation}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setTranslation(tx, ty, tz) | Anger översättningen för den aktuella transformen. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| t | Nummer | null |
+| t | Nummer | null |
+| t | Nummer | null |
+
+ **Result:**
+Transform
+
+
+---
+
+
+### setScale{#setScale}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setScale(sx, sy, sz) | Anger skalan för den aktuella transformen. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| s | Nummer | null |
+| s | Nummer | null |
+| s | Nummer | null |
+
+ **Result:**
+Transform
+
+
+---
+
+
+### setEulerAngles{#setEulerAngles}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setEulerAngles(rx, ry, rz) | Ställer in Euler-vinklarna i grader för den aktuella transformationen. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| r | Nummer | null |
+| r | Nummer | null |
+| r | Nummer | null |
+
+ **Result:**
+Transform
+
+
+---
+
+
+### setRotation{#setRotation}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setRotation(rw, rx, ry, rz) | Ställer in rotationen (som kvaternionkomponenter) för den aktuella transformationen. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| r | Nummer | null |
+| r | Nummer | null |
+| r | Nummer | null |
+| r | Nummer | null |
+
+ **Result:**
+Transform
+
+
+---
+
+
+### setPreRotation{#setPreRotation}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setPreRotation(rx, ry, rz) | Ställer in förrotationen representerad i grader |
+
+ **Result:**
+Transform
+
+
+---
+
+
+### setPostRotation{#setPostRotation}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setPostRotation(rx, ry, rz) | Ställer in efterrotationen representerad i grader |
+
+ **Result:**
+Transform
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/transformbuilder/_index.md
+++ b/swedish/nodejs-java/aspose.threed/transformbuilder/_index.md
@@ -1,0 +1,457 @@
+---
+title: "TransformBuilder"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/transformbuilder/
+---
+## TransformBuilder class
+
+TransformBuilder används för att bygga en transformmatris genom en kedja av transformationer.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor(initial, order) | Skapa en TransformBuilder med initial transformmatris och angiven sammansättningsordning |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| initia | Matrix4 | null |
+| ordning | ComposeOrder | ComposeOrder |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload(order) | Skapa en TransformBuilder med initial identitets‑transformmatris och angiven sammansättningsordning |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| ordning | ComposeOrder | ComposeOrder |
+
+ **Result:**
+
+
+
+---
+
+
+### getMatrix{#getMatrix}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getMatrix() | Hämtar eller anger det aktuella matrisvärdet |
+
+ **Result:**
+
+
+
+---
+
+
+### setMatrix{#setMatrix}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setMatrix(value) | Hämtar eller anger det aktuella matrisvärdet |
+
+ **Result:**
+
+
+
+---
+
+
+### getComposeOrder{#getComposeOrder}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getComposeOrder() | Hämtar eller anger kedjans sammansättningsordning. Värdet på egenskapen är heltalskonstanten ComposeOrder. |
+
+ **Result:**
+
+
+
+---
+
+
+### setComposeOrder{#setComposeOrder}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setComposeOrder(value) | Hämtar eller anger kedjans sammansättningsordning. Värdet på egenskapen är heltalskonstanten ComposeOrder. |
+
+ **Result:**
+
+
+
+---
+
+
+### compose{#compose}
+
+| Namn | Beskrivning |
+| --- | --- |
+| compose(m) | Lägg till eller sätt in argumentet i den interna matrisen. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+|  | Matrix4 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### append{#append}
+
+| Namn | Beskrivning |
+| --- | --- |
+| append(m) | Lägg till den nya transformmatrisen till transformkedjan. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+|  | Matrix4 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### prepend{#prepend}
+
+| Namn | Beskrivning |
+| --- | --- |
+| prepend(m) | Lägg till i början den nya transformationsmatrisen i transformationskedjan. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+|  | Matrix4 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### rearrange{#rearrange}
+
+| Namn | Beskrivning |
+| --- | --- |
+| rearrange(newX, newY, newZ) | Ordna om layouten för axeln. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| newX | Axel | Axel |
+| newY | Axel | Axel |
+| newZ | Axel | Axel |
+
+ **Result:**
+
+
+
+---
+
+
+### scale{#scale}
+
+| Namn | Beskrivning |
+| --- | --- |
+| skala(r) | Kedja en skalningstransformationsmatris med en komponent skalad med s |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+|  | Nummer | null |
+
+ **Result:**
+
+
+
+---
+
+
+### scale{#scale}
+
+| Namn | Beskrivning |
+| --- | --- |
+| scale(x, y, z) | Kedja en skalningstransformationsmatris |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+|  | Nummer | null |
+|  | Nummer | null |
+|  | Nummer | null |
+
+ **Result:**
+
+
+
+---
+
+
+### scale{#scale}
+
+| Namn | Beskrivning |
+| --- | --- |
+| skala(r) | Kedja en skalningstransform |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+|  | Vector3 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### rotateDegree{#rotateDegree}
+
+| Namn | Beskrivning |
+| --- | --- |
+| rotateDegree(angle, axis) | Kedja en rotationstransform i grader |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| vinkel | Nummer | Vinkeln att rotera i grader |
+| axel | Vector3 | Axeln att rotera kring |
+
+ **Result:**
+
+
+
+---
+
+
+### rotateRadian{#rotateRadian}
+
+| Namn | Beskrivning |
+| --- | --- |
+| rotateRadian(angle, axis) | Kedja en rotationstransform i radianer |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| vinkel | Nummer | Vinkeln att rotera i radianer |
+| axel | Vector3 | Axeln att rotera kring |
+
+ **Result:**
+
+
+
+---
+
+
+### rotate{#rotate}
+
+| Namn | Beskrivning |
+| --- | --- |
+| rotate(q) | Kedja en rotation med en kvaternion |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+|  | Kvaternion | null |
+
+ **Result:**
+
+
+
+---
+
+
+### rotateEulerDegree{#rotateEulerDegree}
+
+| Namn | Beskrivning |
+| --- | --- |
+| rotateEulerDegree(degX, degY, degZ) | Kedja en rotation med Euler-vinklar i grader |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| grad | Nummer | null |
+| grad | Nummer | null |
+| grad | Nummer | null |
+
+ **Result:**
+
+
+
+---
+
+
+### rotateEulerRadian{#rotateEulerRadian}
+
+| Namn | Beskrivning |
+| --- | --- |
+| rotateEulerRadian(x, y, z) | Kedja en rotation med Euler-vinklar i radianer |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+|  | Nummer | null |
+|  | Nummer | null |
+|  | Nummer | null |
+
+ **Result:**
+
+
+
+---
+
+
+### rotateEulerRadian{#rotateEulerRadian}
+
+| Namn | Beskrivning |
+| --- | --- |
+| rotateEulerRadian(r) | Kedja en rotation med Euler-vinklar i radianer |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+|  | Vector3 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### translate{#translate}
+
+| Namn | Beskrivning |
+| --- | --- |
+| translate(tx, ty, tz) | Kedja en translationstransform |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| t | Nummer | null |
+| t | Nummer | null |
+| t | Nummer | null |
+
+ **Result:**
+
+
+
+---
+
+
+### translate{#translate}
+
+| Namn | Beskrivning |
+| --- | --- |
+| translate(v) | Kedja en translationstransform |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+|  | Vector3 | null |
+
+ **Result:**
+
+
+
+---
+
+
+### reset{#reset}
+
+| Namn | Beskrivning |
+| --- | --- |
+| reset() | Återställ transformen till identitetsmatrisen |
+
+ **Result:**
+
+
+
+---
+
+
+### rotateDegree{#rotateDegree}
+
+| Namn | Beskrivning |
+| --- | --- |
+| rotateDegree(rot, order) | Lägg till rotation med angiven ordning |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| rot | Vector3 | Rotation i grader |
+| ordning | RotationOrder | RotationOrder |
+
+ **Result:**
+
+
+
+---
+
+
+### rotateRadian{#rotateRadian}
+
+| Namn | Beskrivning |
+| --- | --- |
+| rotateRadian(rot, order) | Lägg till rotation med angiven ordning |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| rot | Vector3 | Rotation i radian |
+| ordning | RotationOrder | RotationOrder |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/transformedcurve/_index.md
+++ b/swedish/nodejs-java/aspose.threed/transformedcurve/_index.md
@@ -1,0 +1,359 @@
+---
+title: "TransformedCurve"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/transformedcurve/
+---
+## TransformedCurve class
+
+En TransformedCurve ger en kurva en placering genom att använda en transformationsmatris. Detta möjliggör att utföra en transformation inom en TrimmedCurve eller CompositeCurve.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Konstruktorn för TransformedCurve |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload(basisCurve, transformation) | Konstruktorn för TransformedCurve |
+
+ **Result:**
+
+
+
+---
+
+
+### getTransformMatrix{#getTransformMatrix}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getTransformMatrix() | Transformationsmatrisen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTransformMatrix{#setTransformMatrix}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setTransformMatrix(value) | Transformationsmatrisen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getBasisCurve{#getBasisCurve}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBasisCurve() | Basiskurvan. |
+
+ **Result:**
+
+
+
+---
+
+
+### setBasisCurve{#setBasisCurve}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setBasisCurve(value) | Basiskurvan. |
+
+ **Result:**
+
+
+
+---
+
+
+### getColor{#getColor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getColor() | Hämtar eller anger färgen på linjen, standardvärdet är vit(1, 1, 1) |
+
+ **Result:**
+
+
+
+---
+
+
+### setColor{#setColor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setColor(value) | Hämtar eller anger färgen på linjen, standardvärdet är vit(1, 1, 1) |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNodes() | Hämtar alla föräldranoder, en entitet kan fästas vid flera föräldranoder för geometri‑instansering. Noderna. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExcluded() | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExcluded(value) | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNode() | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setParentNode(value) | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getScene() | Hämtar scenen som detta objekt tillhör |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEntityRendererKey() | Hämtar nyckeln för enhetens renderare som är registrerad i renderaren |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBoundingBox() | Hämtar den omgivande lådan för den aktuella enheten i dess objektrums koordinatsystem. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/trapeziumshape/_index.md
+++ b/swedish/nodejs-java/aspose.threed/trapeziumshape/_index.md
@@ -1,0 +1,385 @@
+---
+title: "TrapeziumShape"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/trapeziumshape/
+---
+## TrapeziumShape class
+
+IFC‑kompatibel trapetsform definierad av parametrar.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Konstruktor för TrapeziumShape |
+
+ **Result:**
+
+
+
+---
+
+
+### getBottomXDim{#getBottomXDim}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBottomXDim() | Hämtar eller anger omfattningen av den nedre linjen mätt längs x-axeln. |
+
+ **Result:**
+
+
+
+---
+
+
+### setBottomXDim{#setBottomXDim}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setBottomXDim(value) | Hämtar eller anger omfattningen av den nedre linjen mätt längs x-axeln. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTopXDim{#getTopXDim}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getTopXDim() | Hämtar eller anger omfattningen av den övre linjen mätt längs x-axeln. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTopXDim{#setTopXDim}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setTopXDim(value) | Hämtar eller anger omfattningen av den övre linjen mätt längs x-axeln. |
+
+ **Result:**
+
+
+
+---
+
+
+### getYDim{#getYDim}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getYDim() | Hämtar eller anger avståndet mellan den övre och nedre linjen mätt längs y-axeln. |
+
+ **Result:**
+
+
+
+---
+
+
+### setYDim{#setYDim}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setYDim(value) | Hämtar eller anger avståndet mellan den övre och nedre linjen mätt längs y-axeln. |
+
+ **Result:**
+
+
+
+---
+
+
+### getTopXOffset{#getTopXOffset}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getTopXOffset() | Hämtar eller anger förskjutningen från början av den övre linjen till den nedre linjen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setTopXOffset{#setTopXOffset}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setTopXOffset(value) | Hämtar eller anger förskjutningen från början av den övre linjen till den nedre linjen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNodes() | Hämtar alla föräldranoder, en entitet kan fästas vid flera föräldranoder för geometri‑instansering. Noderna. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExcluded() | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExcluded(value) | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNode() | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setParentNode(value) | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getScene() | Hämtar scenen som detta objekt tillhör |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtent{#getExtent}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExtent() | Hämtar omfattningen i x- och y-dimension. |
+
+ **Result:**
+Vector2
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEntityRendererKey() | Hämtar nyckeln för enhetens renderare som är registrerad i renderaren |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBoundingBox() | Hämtar den omgivande lådan för den aktuella enheten i dess objektrums koordinatsystem. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/trialexception/_index.md
+++ b/swedish/nodejs-java/aspose.threed/trialexception/_index.md
@@ -1,0 +1,61 @@
+---
+title: "TrialException"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/trialexception/
+---
+## TrialException class
+
+Detta kastas i Scene.Open/Scene.Save när inga licenser har tillämpats. Du kan inaktivera detta undantag genom att sätta SuppressTrialException till true.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor(msg) | Konstruktor för TrialException |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| ms | Sträng | null |
+
+ **Result:**
+
+
+
+---
+
+
+### getSuppressTrialException{#getSuppressTrialException}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getSuppressTrialException() | Sätter detta till true för att undertrycka provundantag för olicensierad användning, men begränsningarna kommer inte att tas bort. För att ta bort begränsningarna, vänligen använd en korrekt licens. Och att sätta detta till true betyder också att du är medveten om de olicensierade begränsningarna. |
+
+ **Result:**
+
+
+
+---
+
+
+### setSuppressTrialException{#setSuppressTrialException}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setSuppressTrialException(value) | Sätter detta till true för att undertrycka provundantag för olicensierad användning, men begränsningarna kommer inte att tas bort. För att ta bort begränsningarna, vänligen använd en korrekt licens. Och att sätta detta till true betyder också att du är medveten om de olicensierade begränsningarna. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/trimesh/_index.md
+++ b/swedish/nodejs-java/aspose.threed/trimesh/_index.md
@@ -1,0 +1,679 @@
+---
+title: "TriMesh"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/trimesh/
+---
+## TriMesh class
+
+En TriMesh innehåller rådata som kan användas direkt av GPU. Denna klass är ett verktyg för att hjälpa till att konstruera ett mesh som endast innehåller per-vertex‑data.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor(name, declaration) | Initiera en instans av TriMesh |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| name | Sträng | Namnet på detta TriMesh |
+| deklaration | VertexDeclaration | Vertexens deklaration |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexDeclaration{#getVertexDeclaration}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getVertexDeclaration() | Vertexlayouten för TriMesh. |
+
+ **Result:**
+
+
+
+---
+
+
+### getVerticesCount{#getVerticesCount}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getVerticesCount() | Antalet vertexar i detta TriMesh |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndicesCount{#getIndicesCount}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getIndicesCount() | Antalet index i detta TriMesh |
+
+ **Result:**
+
+
+
+---
+
+
+### getUnmergedVerticesCount{#getUnmergedVerticesCount}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getUnmergedVerticesCount() | Antalet icke-sammanfogade vertexar som passerade in via beginVertex() och endVertex(). |
+
+ **Result:**
+
+
+
+---
+
+
+### getCapacity{#getCapacity}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getCapacity() | Kapaciteten för förallokerade vertexar. |
+
+ **Result:**
+
+
+
+---
+
+
+### getVerticesSizeInBytes{#getVerticesSizeInBytes}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getVerticesSizeInBytes() | Den totala storleken på alla vertexar i byte |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNodes() | Hämtar alla föräldranoder, en entitet kan fästas vid flera föräldranoder för geometri‑instansering. Noderna. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExcluded() | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExcluded(value) | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNode() | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setParentNode(value) | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getScene() | Hämtar scenen som detta objekt tillhör |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### fromMesh{#fromMesh}
+
+| Namn | Beskrivning |
+| --- | --- |
+| fromMesh(declaration, mesh) | Skapa ett TriMesh från ett givet mesh-objekt med given vertex-layout. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| declaratio | VertexDeclaration | null |
+| mes | Mesh | null |
+
+ **Result:**
+TriMesh
+
+
+---
+
+
+### copyFrom{#copyFrom}
+
+| Namn | Beskrivning |
+| --- | --- |
+| copyFrom(input, vd) | Kopiera TriMesh från input med ny vertex-layout |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| input | TriMesh | Inmatnings-TriMesh för kopiering |
+| vd | VertexDeclaration | Den nya vertex-deklarationen för utdata-TriMesh |
+
+ **Result:**
+TriMesh
+
+
+---
+
+
+### fromMesh{#fromMesh}
+
+| Namn | Beskrivning |
+| --- | --- |
+| fromMesh(mesh, useFloat) | Skapa ett TriMesh från ett givet mesh-objekt, vertex-deklarationen baseras på input-meshens struktur. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| mes | Mesh | null |
+| useFloat | boolean | Använd float-typ istället för double-typ för varje vertex-elementkomponent. |
+
+ **Result:**
+TriMesh
+
+
+---
+
+
+### beginVertex{#beginVertex}
+
+| Namn | Beskrivning |
+| --- | --- |
+| beginVertex() | Börja lägga till vertex |
+
+ **Result:**
+Vertex
+
+
+---
+
+
+### endVertex{#endVertex}
+
+| Namn | Beskrivning |
+| --- | --- |
+| endVertex() | Avsluta att lägga till vertex |
+
+ **Result:**
+Vertex
+
+
+---
+
+
+### verticesToArray{#verticesToArray}
+
+| Namn | Beskrivning |
+| --- | --- |
+| verticesToArray() | Konvertera vertexdata till bytearray |
+
+ **Result:**
+byte[]
+
+
+---
+
+
+### toString{#toString}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toString() |  |
+
+ **Result:**
+Sträng
+
+
+---
+
+
+### fromRawData{#fromRawData}
+
+| Namn | Beskrivning |
+| --- | --- |
+| fromRawData(vd, vertices, indices, generateVertexMapping) | Skapa TriMesh från rådata. Den returnerade TriMesh kommer inte att kopiera den inmatade bytearrayen för prestanda, externa förändringar av arrayen kommer att återspeglas i detta objekt. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| vd | VertexDeclaration | Vertexdeklaration, måste innehålla minst ett fält. |
+| vertices | byte[] | Den inmatade vertexdata, den minsta längden på vertexerna måste vara större än eller lika med storleken på vertexdeklarationen. |
+| indices | Number[] | Triangelindexen |
+| generateVertexMapping | boolean | Generera |
+
+ **Result:**
+TriMesh
+
+
+---
+
+
+### loadVerticesFromBytes{#loadVerticesFromBytes}
+
+| Namn | Beskrivning |
+| --- | --- |
+| loadVerticesFromBytes(verticesInBytes) | Läs in vertexar från byte, längden på byte måste vara ett heltalsmultipel av vertexstorleken. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| verticesInByte | byte[] | null |
+
+ **Result:**
+TriMesh
+
+
+---
+
+
+### readVector4{#readVector4}
+
+| Namn | Beskrivning |
+| --- | --- |
+| readVector4(idx, field) | Läs vector4-fältet |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| idx | Nummer | Indexet för vertex att läsa |
+| field | VertexField | Fältet med datatypen Vector4/FVector4 |
+
+ **Result:**
+Vector4
+
+
+---
+
+
+### readFVector4{#readFVector4}
+
+| Namn | Beskrivning |
+| --- | --- |
+| readFVector4(idx, field) | Läs vector4-fältet |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| idx | Nummer | Indexet för vertex att läsa |
+| field | VertexField | Fältet med datatypen Vector4/FVector4 |
+
+ **Result:**
+FVector4
+
+
+---
+
+
+### readVector3{#readVector3}
+
+| Namn | Beskrivning |
+| --- | --- |
+| readVector3(idx, field) | Läs vector3-fältet |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| idx | Nummer | Indexet för vertex att läsa |
+| field | VertexField | Fältet med en Vector3/FVector3-datatyp |
+
+ **Result:**
+Vector3
+
+
+---
+
+
+### readFVector3{#readFVector3}
+
+| Namn | Beskrivning |
+| --- | --- |
+| readFVector3(idx, field) | Läs vector3-fältet |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| idx | Nummer | Indexet för vertex att läsa |
+| field | VertexField | Fältet med en Vector3/FVector3-datatyp |
+
+ **Result:**
+FVector3
+
+
+---
+
+
+### readVector2{#readVector2}
+
+| Namn | Beskrivning |
+| --- | --- |
+| readVector2(idx, field) | Läs vector2-fältet |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| idx | Nummer | Indexet för vertex att läsa |
+| field | VertexField | Fältet med en Vector2/FVector2-datatyp |
+
+ **Result:**
+Vector2
+
+
+---
+
+
+### readFVector2{#readFVector2}
+
+| Namn | Beskrivning |
+| --- | --- |
+| readFVector2(idx, field) | Läs vector2-fältet |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| idx | Nummer | Indexet för vertex att läsa |
+| field | VertexField | Fältet med en Vector2/FVector2-datatyp |
+
+ **Result:**
+FVector2
+
+
+---
+
+
+### readDouble{#readDouble}
+
+| Namn | Beskrivning |
+| --- | --- |
+| readDouble(idx, field) | Läs double-fältet |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| idx | Nummer | Indexet för vertex att läsa |
+| field | VertexField | Fältet med en float/double-kompatibel datatyp |
+
+ **Result:**
+Nummer
+
+
+---
+
+
+### readFloat{#readFloat}
+
+| Namn | Beskrivning |
+| --- | --- |
+| readFloat(idx, field) | Läs float-fältet |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| idx | Nummer | Indexet för vertex att läsa |
+| field | VertexField | Fältet med en float/double-kompatibel datatyp |
+
+ **Result:**
+Nummer
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBoundingBox() | Hämtar den omgivande lådan för den aktuella enheten i dess objektrums koordinatsystem. |
+
+ **Result:**
+Nummer
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEntityRendererKey() | Hämtar nyckeln för enhetens renderare som är registrerad i renderaren |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+### iterator{#iterator}
+
+| Namn | Beskrivning |
+| --- | --- |
+| iterator() | Reserverad för internt bruk. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/trimmedcurve/_index.md
+++ b/swedish/nodejs-java/aspose.threed/trimmedcurve/_index.md
@@ -1,0 +1,398 @@
+---
+title: "TrimmedCurve"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/trimmedcurve/
+---
+## TrimmedCurve class
+
+En begränsad kurva som beskär den grundläggande kurvan i båda ändar.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Konstruktor för TrimmedCurve |
+
+ **Result:**
+
+
+
+---
+
+
+### getBasisCurve{#getBasisCurve}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBasisCurve() | Basiskurvan som ska trimmas. |
+
+ **Result:**
+
+
+
+---
+
+
+### setBasisCurve{#setBasisCurve}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setBasisCurve(value) | Basiskurvan som ska trimmas. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFirst{#getFirst}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFirst() | Den första ändpunkten att trimma, kan vara en kartesisk punkt eller en reell parameter. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFirst{#setFirst}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFirst(value) | Den första ändpunkten att trimma, kan vara en kartesisk punkt eller en reell parameter. |
+
+ **Result:**
+
+
+
+---
+
+
+### getSecond{#getSecond}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getSecond() | Den andra ändpunkten att trimma, kan vara en kartesisk punkt eller en reell parameter. |
+
+ **Result:**
+
+
+
+---
+
+
+### setSecond{#setSecond}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setSecond(value) | Den andra ändpunkten att trimma, kan vara en kartesisk punkt eller en reell parameter. |
+
+ **Result:**
+
+
+
+---
+
+
+### getSameDirection{#getSameDirection}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getSameDirection() | Hämtar eller anger om det trimmade resultatet använder samma riktning som baskurvan. |
+
+ **Result:**
+
+
+
+---
+
+
+### setSameDirection{#setSameDirection}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setSameDirection(value) | Hämtar eller anger om det trimmade resultatet använder samma riktning som baskurvan. |
+
+ **Result:**
+
+
+
+---
+
+
+### getColor{#getColor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getColor() | Hämtar eller anger färgen på linjen, standardvärdet är vit(1, 1, 1) |
+
+ **Result:**
+
+
+
+---
+
+
+### setColor{#setColor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setColor(value) | Hämtar eller anger färgen på linjen, standardvärdet är vit(1, 1, 1) |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNodes() | Hämtar alla föräldranoder, en entitet kan fästas vid flera föräldranoder för geometri‑instansering. Noderna. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExcluded() | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExcluded(value) | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNode() | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setParentNode(value) | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getScene() | Hämtar scenen som detta objekt tillhör |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEntityRendererKey() | Hämtar nyckeln för enhetens renderare som är registrerad i renderaren |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBoundingBox() | Hämtar den omgivande lådan för den aktuella enheten i dess objektrums koordinatsystem. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/tshape/_index.md
+++ b/swedish/nodejs-java/aspose.threed/tshape/_index.md
@@ -1,0 +1,463 @@
+---
+title: "TShape"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/tshape/
+---
+## TShape class
+
+IFC‑kompatibel T‑form definierad av parametrar.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Konstruktor för TShape |
+
+ **Result:**
+
+
+
+---
+
+
+### getDepth{#getDepth}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getDepth() | Hämtar eller anger längden på webben. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDepth{#setDepth}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setDepth(value) | Hämtar eller anger längden på webben. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlangeWidth{#getFlangeWidth}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFlangeWidth() | Hämtar eller anger längden på flänsen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlangeWidth{#setFlangeWidth}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFlangeWidth(value) | Hämtar eller anger längden på flänsen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getWebThickness{#getWebThickness}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getWebThickness() | Hämtar eller anger väggtjockleken på webben. |
+
+ **Result:**
+
+
+
+---
+
+
+### setWebThickness{#setWebThickness}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setWebThickness(value) | Hämtar eller anger väggtjockleken på webben. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlangeThickness{#getFlangeThickness}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFlangeThickness() | Hämtar eller anger väggtjockleken på flänsen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlangeThickness{#setFlangeThickness}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFlangeThickness(value) | Hämtar eller anger väggtjockleken på flänsen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFilletRadius{#getFilletRadius}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFilletRadius() | Hämtar eller anger radien för fillet mellan webben och flänsen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFilletRadius{#setFilletRadius}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFilletRadius(value) | Hämtar eller anger radien för fillet mellan webben och flänsen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlangeEdgeRadius{#getFlangeEdgeRadius}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFlangeEdgeRadius() | Hämtar eller anger radien för flänskanten. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlangeEdgeRadius{#setFlangeEdgeRadius}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFlangeEdgeRadius(value) | Hämtar eller anger radien för flänskanten. |
+
+ **Result:**
+
+
+
+---
+
+
+### getWebEdgeRadius{#getWebEdgeRadius}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getWebEdgeRadius() | Hämtar eller anger radien för webbkanten. |
+
+ **Result:**
+
+
+
+---
+
+
+### setWebEdgeRadius{#setWebEdgeRadius}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setWebEdgeRadius(value) | Hämtar eller anger radien för webbkanten. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNodes() | Hämtar alla föräldranoder, en entitet kan fästas vid flera föräldranoder för geometri‑instansering. Noderna. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExcluded() | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExcluded(value) | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNode() | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setParentNode(value) | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getScene() | Hämtar scenen som detta objekt tillhör |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtent{#getExtent}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExtent() | Hämtar omfattningen i x- och y-dimension. |
+
+ **Result:**
+Vector2
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEntityRendererKey() | Hämtar nyckeln för enhetens renderare som är registrerad i renderaren |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBoundingBox() | Hämtar den omgivande lådan för den aktuella enheten i dess objektrums koordinatsystem. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/u3dloadoptions/_index.md
+++ b/swedish/nodejs-java/aspose.threed/u3dloadoptions/_index.md
@@ -1,0 +1,146 @@
+---
+title: "U3dLoadOptions"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/u3dloadoptions/
+---
+## U3dLoadOptions class
+
+Läsalternativ för universal 3d
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Konstruktor för U3dLoadOptions |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlipCoordinateSystem{#getFlipCoordinateSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFlipCoordinateSystem() | Hämtar eller anger om koordinatsystemet för kontrollpunkter/normaler ska vändas vid import/export. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlipCoordinateSystem{#setFlipCoordinateSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFlipCoordinateSystem(value) | Hämtar eller anger om koordinatsystemet för kontrollpunkter/normaler ska vändas vid import/export. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileFormat() | Hämtar filformatet som anges i aktuellt Spara/Ladda-alternativ. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEncoding() | Hämtar eller anger standardkodning för textbaserade filer. Standardvärdet är null, vilket betyder att importören/exportören bestämmer vilken kodning som ska användas. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileSystem() | Tillåter användaren att hantera hur externa beroenden ska hanteras under laddning/sparning. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFileSystem(value) | Tillåter användaren att hantera hur externa beroenden ska hanteras under laddning/sparning. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getLookupPaths() | Vissa filer, som OBJ, är beroende av externa filer; sökvägarna gör det möjligt för Aspose.3D att leta efter externa filer att ladda. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileName() | Filnamnet för den exporterade/importerade scenen. Detta är valfritt, men användbart när externa resurser som OBJ:s material serialiseras. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFileName(value) | Filnamnet för den exporterade/importerade scenen. Detta är valfritt, men användbart när externa resurser som OBJ:s material serialiseras. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/u3dsaveoptions/_index.md
+++ b/swedish/nodejs-java/aspose.threed/u3dsaveoptions/_index.md
@@ -1,0 +1,328 @@
+---
+title: "U3dSaveOptions"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/u3dsaveoptions/
+---
+## U3dSaveOptions class
+
+Sparaalternativ för universal 3d
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Konstruktor för U3dSaveOptions |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlipCoordinateSystem{#getFlipCoordinateSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFlipCoordinateSystem() | Hämtar eller anger om koordinatsystemet för kontrollpunkter/normaler ska vändas vid import/export. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlipCoordinateSystem{#setFlipCoordinateSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFlipCoordinateSystem(value) | Hämtar eller anger om koordinatsystemet för kontrollpunkter/normaler ska vändas vid import/export. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMeshCompression{#getMeshCompression}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getMeshCompression() | Hämtar eller anger huruvida mesh-datakomprimering ska aktiveras. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMeshCompression{#setMeshCompression}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setMeshCompression(value) | Hämtar eller anger huruvida mesh-datakomprimering ska aktiveras. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportNormals{#getExportNormals}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExportNormals() | Hämtar eller anger huruvida normaldata ska exporteras. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportNormals{#setExportNormals}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExportNormals(value) | Hämtar eller anger huruvida normaldata ska exporteras. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportTextureCoordinates{#getExportTextureCoordinates}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExportTextureCoordinates() | Hämtar eller anger huruvida texturkoordinater ska exporteras. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextureCoordinates{#setExportTextureCoordinates}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExportTextureCoordinates(value) | Hämtar eller anger huruvida texturkoordinater ska exporteras. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportVertexDiffuse{#getExportVertexDiffuse}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExportVertexDiffuse() | Hämtar eller anger om vertexens diffusa färg ska exporteras. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportVertexDiffuse{#setExportVertexDiffuse}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExportVertexDiffuse(value) | Hämtar eller anger om vertexens diffusa färg ska exporteras. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportVertexSpecular{#getExportVertexSpecular}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExportVertexSpecular() | Hämtar eller anger om vertexens spekulära färg ska exporteras. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportVertexSpecular{#setExportVertexSpecular}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExportVertexSpecular(value) | Hämtar eller anger om vertexens spekulära färg ska exporteras. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEmbedTextures{#getEmbedTextures}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEmbedTextures() | Bädda in de externa texturerna i U3D-filen, standardvärdet är falskt. |
+
+ **Result:**
+
+
+
+---
+
+
+### setEmbedTextures{#setEmbedTextures}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setEmbedTextures(value) | Bädda in de externa texturerna i U3D-filen, standardvärdet är falskt. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportTextures{#getExportTextures}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExportTextures() | Försök att kopiera texturer som används i scenen till utdatamappen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextures{#setExportTextures}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExportTextures(value) | Försök att kopiera texturer som används i scenen till utdatamappen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileFormat() | Hämtar filformatet som anges i aktuellt Spara/Ladda-alternativ. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEncoding() | Hämtar eller anger standardkodning för textbaserade filer. Standardvärdet är null, vilket betyder att importören/exportören bestämmer vilken kodning som ska användas. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileSystem() | Tillåter användaren att hantera hur externa beroenden ska hanteras under laddning/sparning. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFileSystem(value) | Tillåter användaren att hantera hur externa beroenden ska hanteras under laddning/sparning. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getLookupPaths() | Vissa filer, som OBJ, är beroende av externa filer; sökvägarna gör det möjligt för Aspose.3D att leta efter externa filer att ladda. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileName() | Filnamnet för den exporterade/importerade scenen. Detta är valfritt, men användbart när externa resurser som OBJ:s material serialiseras. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFileName(value) | Filnamnet för den exporterade/importerade scenen. Detta är valfritt, men användbart när externa resurser som OBJ:s material serialiseras. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/usdsaveoptions/_index.md
+++ b/swedish/nodejs-java/aspose.threed/usdsaveoptions/_index.md
@@ -1,0 +1,237 @@
+---
+title: "UsdSaveOptions"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/usdsaveoptions/
+---
+## UsdSaveOptions class
+
+Spara alternativ för USD/USDZ-format.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Initierar en ny UsdSaveOptions med formatet FileFormat.USD |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload(fileFormat) | Initierar en ny UsdSaveOptions med angivet USD/USDZ-format. |
+
+ **Result:**
+
+
+
+---
+
+
+### getPrimitiveToMesh{#getPrimitiveToMesh}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getPrimitiveToMesh() | Konvertera de primitiva enheterna till mesh under exporten. Eller koda direkt primitiva till utdatafilen (kommer att använda Aspose's extensionsdefinition för inofficiella primitiva som Dish, Torus). Standardvärdet är true. |
+
+ **Result:**
+
+
+
+---
+
+
+### setPrimitiveToMesh{#setPrimitiveToMesh}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setPrimitiveToMesh(value) | Konvertera de primitiva enheterna till mesh under exporten. Eller koda direkt primitiva till utdatafilen (kommer att använda Aspose's extensionsdefinition för inofficiella primitiva som Dish, Torus). Standardvärdet är true. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportMetaData{#getExportMetaData}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExportMetaData() | Exportera nodens egenskaper via USD:s customData-fält. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportMetaData{#setExportMetaData}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExportMetaData(value) | Exportera nodens egenskaper via USD:s customData-fält. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMaterialConverter{#getMaterialConverter}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getMaterialConverter() | Anpassad konverterare för att konvertera geometrins material till PBR-material. Om detta är odefinierat kommer USD-exportören automatiskt att konvertera standardmaterialet till PBR-material. Standardvärdet är null. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMaterialConverter{#setMaterialConverter}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setMaterialConverter(value) | Anpassad konverterare för att konvertera geometrins material till PBR-material. Om detta är odefinierat kommer USD-exportören automatiskt att konvertera standardmaterialet till PBR-material. Standardvärdet är null. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExportTextures{#getExportTextures}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExportTextures() | Försök att kopiera texturer som används i scenen till utdatamappen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExportTextures{#setExportTextures}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExportTextures(value) | Försök att kopiera texturer som används i scenen till utdatamappen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileFormat() | Hämtar filformatet som anges i aktuellt Spara/Ladda-alternativ. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEncoding() | Hämtar eller anger standardkodning för textbaserade filer. Standardvärdet är null, vilket betyder att importören/exportören bestämmer vilken kodning som ska användas. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileSystem() | Tillåter användaren att hantera hur externa beroenden ska hanteras under laddning/sparning. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFileSystem(value) | Tillåter användaren att hantera hur externa beroenden ska hanteras under laddning/sparning. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getLookupPaths() | Vissa filer, som OBJ, är beroende av externa filer; sökvägarna gör det möjligt för Aspose.3D att leta efter externa filer att ladda. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileName() | Filnamnet för den exporterade/importerade scenen. Detta är valfritt, men användbart när externa resurser som OBJ:s material serialiseras. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFileName(value) | Filnamnet för den exporterade/importerade scenen. Detta är valfritt, men användbart när externa resurser som OBJ:s material serialiseras. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/ushape/_index.md
+++ b/swedish/nodejs-java/aspose.threed/ushape/_index.md
@@ -1,0 +1,437 @@
+---
+title: "UShape"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/ushape/
+---
+## UShape class
+
+IFC-kompatibel U-form definierad av parametrar.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Konstruktor för UShape |
+
+ **Result:**
+
+
+
+---
+
+
+### getDepth{#getDepth}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getDepth() | Hämtar eller anger längden på webben. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDepth{#setDepth}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setDepth(value) | Hämtar eller anger längden på webben. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlangeWidth{#getFlangeWidth}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFlangeWidth() | Hämtar eller anger längden på flänsen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlangeWidth{#setFlangeWidth}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFlangeWidth(value) | Hämtar eller anger längden på flänsen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getWebThickness{#getWebThickness}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getWebThickness() | Hämtar eller anger tjockleken på nätet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setWebThickness{#setWebThickness}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setWebThickness(value) | Hämtar eller anger tjockleken på nätet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlangeThickness{#getFlangeThickness}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFlangeThickness() | Hämtar eller anger tjockleken på flänsen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlangeThickness{#setFlangeThickness}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFlangeThickness(value) | Hämtar eller anger tjockleken på flänsen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFilletRadius{#getFilletRadius}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFilletRadius() | Hämtar eller anger radien på avrundningen mellan fläns och web. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFilletRadius{#setFilletRadius}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFilletRadius(value) | Hämtar eller anger radien på avrundningen mellan fläns och web. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEdgeRadius{#getEdgeRadius}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEdgeRadius() | Hämtar eller anger radien på kanten i flänsens kant. |
+
+ **Result:**
+
+
+
+---
+
+
+### setEdgeRadius{#setEdgeRadius}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setEdgeRadius(value) | Hämtar eller anger radien på kanten i flänsens kant. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNodes() | Hämtar alla föräldranoder, en entitet kan fästas vid flera föräldranoder för geometri‑instansering. Noderna. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExcluded() | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExcluded(value) | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNode() | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setParentNode(value) | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getScene() | Hämtar scenen som detta objekt tillhör |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtent{#getExtent}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExtent() | Hämtar omfattningen i x- och y-dimension. |
+
+ **Result:**
+Vector2
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEntityRendererKey() | Hämtar nyckeln för enhetens renderare som är registrerad i renderaren |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBoundingBox() | Hämtar den omgivande lådan för den aktuella enheten i dess objektrums koordinatsystem. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/vector2/_index.md
+++ b/swedish/nodejs-java/aspose.threed/vector2/_index.md
@@ -1,0 +1,293 @@
+---
+title: "Vector2"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/vector2/
+---
+## Vector2 class
+
+En vektor med två komponenter.
+
+
+## Egenskaper
+
+| Namn | Beskrivning |
+| --- | --- |
+| x | x-komponenten. |
+| y | y-komponenten. |
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload(s) | Initierar en ny instans av strukturen Vector2. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| s | Nummer | S. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload2(vec) | Initierar en ny instans av strukturen Vector2. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| vec | FVector2 | Vektor i float. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload3{#constructor_overload3}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload3(x, y) | Initierar en ny instans av strukturen Vector2. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| x | Nummer | x-koordinaten. |
+| y | Nummer | y-koordinaten. |
+
+ **Result:**
+
+
+
+---
+
+
+### getU{#getU}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getU() | Hämtar eller anger U-komponenten om Vector2 används som en kartläggningskoordinat. Det är ett alias för x-komponenten. |
+
+ **Result:**
+
+
+
+---
+
+
+### setU{#setU}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setU(value) | Hämtar eller anger U-komponenten om Vector2 används som en kartläggningskoordinat. Det är ett alias för x-komponenten. |
+
+ **Result:**
+
+
+
+---
+
+
+### getV{#getV}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getV() | Hämtar eller anger V-komponenten om Vector2 används som en kartläggningskoordinat. Det är ett alias för y-komponenten. |
+
+ **Result:**
+
+
+
+---
+
+
+### setV{#setV}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setV(value) | Hämtar eller anger V-komponenten om Vector2 används som en kartläggningskoordinat. Det är ett alias för y-komponenten. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLength{#getLength}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getLength() | Hämtar längden. Längden. |
+
+ **Result:**
+
+
+
+---
+
+
+### dot{#dot}
+
+| Namn | Beskrivning |
+| --- | --- |
+| dot(rhs) | Hämtar skalärprodukten av två vektorer |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| rhs | Vector2 | Värde för högra sidan. |
+
+ **Result:**
+Nummer
+
+
+---
+
+
+### equals{#equals}
+
+| Namn | Beskrivning |
+| --- | --- |
+| equals(rhs) | Kontrollera om två vector2 är lika |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| rhs | Vector2 | Värdet på högra sidan. |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### hashCode{#hashCode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| hashCode() | Hämtar hashkoden för Vector2 |
+
+ **Result:**
+Nummer
+
+
+---
+
+
+### equals{#equals}
+
+| Namn | Beskrivning |
+| --- | --- |
+| equals(obj) | Kontrollera om två vector2 är lika |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| obj | Objekt | Objektet att jämföra. |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### toString{#toString}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toString() | Returnerar en java.lang.String som representerar den aktuella Vector2. |
+
+ **Result:**
+Sträng
+
+
+---
+
+
+### cross{#cross}
+
+| Namn | Beskrivning |
+| --- | --- |
+| cross(v) | Korsprodukt av två vektorer |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+|  | Vector2 | null |
+
+ **Result:**
+Nummer
+
+
+---
+
+
+### normalize{#normalize}
+
+| Namn | Beskrivning |
+| --- | --- |
+| normalize() | Normaliserar detta objekt. |
+
+ **Result:**
+Vector2
+
+
+---
+
+
+### compareTo{#compareTo}
+
+| Namn | Beskrivning |
+| --- | --- |
+| compareTo(other) | Jämför den aktuella vektorn med en annan instans. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| othe | Vector2 | null |
+
+ **Result:**
+Nummer
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/vector3/_index.md
+++ b/swedish/nodejs-java/aspose.threed/vector3/_index.md
@@ -1,0 +1,347 @@
+---
+title: "Vector3"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/vector3/
+---
+## Vector3 class
+
+En vektor med tre komponenter.
+
+
+## Egenskaper
+
+| Namn | Beskrivning |
+| --- | --- |
+| x | x-komponenten. |
+| y | y-komponenten. |
+| z | z-komponenten. |
+| ORIGIN | Hämtar ursprungspositionen. Ursprung. |
+| UNIT_SCALE | Hämtar enhetsskalningsvektorn. |
+| X_AXIS | Hämtar X-axeln. X-axeln. |
+| Y_AXIS | Hämtar Y-axeln. Y-axeln. |
+| Z_AXIS | Hämtar Z-axeln. Z-axeln. |
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload(x, y, z) | Initierar en ny instans av strukturen Vector3. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| x | Nummer | x-koordinaten. |
+| y | Nummer | y-koordinaten. |
+| z | Nummer | z-koordinaten. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload2(vec) | Initierar en ny instans av strukturen Vector3. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| vec | FVector3 | x-koordinaten. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload3{#constructor_overload3}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload3(v) | Initierar en ny instans av strukturen Vector3. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| v | Nummer | V. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload4{#constructor_overload4}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload4(vec4) | Initierar en ny instans av strukturen Vector3. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| vec4 | Vector4 | Vec4. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLength2{#getLength2}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getLength2() | Hämtar kvadraten av längden. length2. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLength{#getLength}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getLength() | Hämtar längden på denna vektor. Längden. |
+
+ **Result:**
+
+
+
+---
+
+
+### equals{#equals}
+
+| Namn | Beskrivning |
+| --- | --- |
+| equals(obj) | Kontrollera om två vector3 är lika |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| obj | Objekt | Objektet för att kontrollera likhet. |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### hashCode{#hashCode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| hashCode() | Hämtar hashkoden för Vector3 |
+
+ **Result:**
+Nummer
+
+
+---
+
+
+### dot{#dot}
+
+| Namn | Beskrivning |
+| --- | --- |
+| dot(rhs) | Hämtar skalärprodukten av två vektorer |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| rhs | Vector3 | Värde för högra sidan. |
+
+ **Result:**
+Nummer
+
+
+---
+
+
+### normalize{#normalize}
+
+| Namn | Beskrivning |
+| --- | --- |
+| normalize() | Normaliserar detta objekt. |
+
+ **Result:**
+Vector3
+
+
+---
+
+
+### sin{#sin}
+
+| Namn | Beskrivning |
+| --- | --- |
+| sin() | Beräknar sinus för varje komponent |
+
+ **Result:**
+Vector3
+
+
+---
+
+
+### cos{#cos}
+
+| Namn | Beskrivning |
+| --- | --- |
+| cos() | Beräknar cosinus för varje komponent |
+
+ **Result:**
+Vector3
+
+
+---
+
+
+### cross{#cross}
+
+| Namn | Beskrivning |
+| --- | --- |
+| cross(rhs) | Korsprodukt av två vektorer |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| rhs | Vector3 | Värde för högra sidan. |
+
+ **Result:**
+Vector3
+
+
+---
+
+
+### set{#set}
+
+| Namn | Beskrivning |
+| --- | --- |
+| set(newX, newY, newZ) | Sätter x/y/z-komponenten i ett anrop. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| newX | Nummer | x-komponenten. |
+| newY | Nummer | y-komponenten. |
+| newZ | Nummer | z-komponenten. |
+
+ **Result:**
+Vector3
+
+
+---
+
+
+### toString{#toString}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toString() | Returnerar en java.lang.String som representerar den aktuella Vector3. |
+
+ **Result:**
+Sträng
+
+
+---
+
+
+### angleBetween{#angleBetween}
+
+| Namn | Beskrivning |
+| --- | --- |
+| angleBetween(dir, up) | Beräkna den inre vinkeln mellan två riktningar. Två riktningar kan vara icke-normaliserade vektorer. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| dir | Vector3 | Riktningsvektorn att jämföra med |
+| up | Vector3 | Uppvektorn för de två riktningarnas gemensamma plan |
+
+ **Result:**
+Nummer
+
+
+---
+
+
+### angleBetween{#angleBetween}
+
+| Namn | Beskrivning |
+| --- | --- |
+| angleBetween(dir) | Beräkna den inre vinkeln mellan två riktningar. Två riktningar kan vara icke-normaliserade vektorer. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| dir | Vector3 | Riktningsvektorn att jämföra med |
+
+ **Result:**
+Nummer
+
+
+---
+
+
+### compareTo{#compareTo}
+
+| Namn | Beskrivning |
+| --- | --- |
+| compareTo(other) | Jämför den aktuella vektorn med en annan instans. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| othe | Vector3 | null |
+
+ **Result:**
+Nummer
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/vector4/_index.md
+++ b/swedish/nodejs-java/aspose.threed/vector4/_index.md
@@ -1,0 +1,246 @@
+---
+title: "Vector4"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/vector4/
+---
+## Vector4 class
+
+En vektor med fyra komponenter.
+
+
+## Egenskaper
+
+| Namn | Beskrivning |
+| --- | --- |
+| x | x-komponenten. |
+| y | y-komponenten. |
+| z | z-komponenten. |
+| w | w-komponenten. |
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload(vec, w) | Initierar en ny instans av strukturen Vector4. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| vec | Vector3 | Vec. |
+| w | Nummer | Bredden. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload2{#constructor_overload2}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload2(vec) | Initierar en ny instans av strukturen Vector4. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| vec | Vector3 | Vec. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload3{#constructor_overload3}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload3(vec) | Initierar en ny instans av strukturen Vector4. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| vec | FVector4 | Vec. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload4{#constructor_overload4}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload4(x, y, z) | Initierar en ny instans av strukturen Vector4. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| x | Nummer | x-koordinaten. |
+| y | Nummer | y-koordinaten. |
+| z | Nummer | z-koordinaten. |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload5{#constructor_overload5}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload5(x, y, z, w) | Initierar en ny instans av strukturen Vector4. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| x | Nummer | x-koordinaten. |
+| y | Nummer | y-koordinaten. |
+| z | Nummer | z-koordinaten. |
+| w | Nummer | Bredden. |
+
+ **Result:**
+
+
+
+---
+
+
+### set{#set}
+
+| Namn | Beskrivning |
+| --- | --- |
+| set(newX, newY, newZ) | Sätter vektorns xyz-komponenter på en gång, w kommer att sättas till 1 |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| newX | Nummer | Ny X-komponent. |
+| newY | Nummer | Ny Y-komponent. |
+| newZ | Nummer | Ny Z-komponent. |
+
+ **Result:**
+
+
+
+---
+
+
+### equals{#equals}
+
+| Namn | Beskrivning |
+| --- | --- |
+| equals(obj) | Kontrollera om två vektorer är lika |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| ob | Objekt | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### hashCode{#hashCode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| hashCode() | Hämtar hashkoden för denna vektor |
+
+ **Result:**
+Nummer
+
+
+---
+
+
+### set{#set}
+
+| Namn | Beskrivning |
+| --- | --- |
+| set(newX, newY, newZ, newW) | Sätter alla vektorkomponenter på en gång |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| newX | Nummer | Ny X-komponent. |
+| newY | Nummer | Ny Y-komponent. |
+| newZ | Nummer | Ny Z-komponent. |
+| newW | Nummer | Ny W-komponent. |
+
+ **Result:**
+Nummer
+
+
+---
+
+
+### toString{#toString}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toString() | Returnerar en java.lang.String som representerar den aktuella Vector4. |
+
+ **Result:**
+Sträng
+
+
+---
+
+
+### compareTo{#compareTo}
+
+| Namn | Beskrivning |
+| --- | --- |
+| compareTo(other) | Jämför den aktuella vektorn med en annan instans. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| othe | Vector4 | null |
+
+ **Result:**
+Nummer
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/vertex/_index.md
+++ b/swedish/nodejs-java/aspose.threed/vertex/_index.md
@@ -1,0 +1,187 @@
+---
+title: "Vertex"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/vertex/
+---
+## Vertex class
+
+Vertexreferens, används för att komma åt den råa vertexen i TriMesh.  @hideconstructor
+
+
+## Metoder
+
+### compareTo{#compareTo}
+
+| Namn | Beskrivning |
+| --- | --- |
+| compareTo(other) | Jämför vertexen med en annan vertex-instans |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| othe | Vertex | null |
+
+ **Result:**
+Nummer
+
+
+---
+
+
+### readVector4{#readVector4}
+
+| Namn | Beskrivning |
+| --- | --- |
+| readVector4(field) | Läs vector4-fältet |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| field | VertexField | Fältet med datatypen Vector4/FVector4 |
+
+ **Result:**
+Vector4
+
+
+---
+
+
+### readFVector4{#readFVector4}
+
+| Namn | Beskrivning |
+| --- | --- |
+| readFVector4(field) | Läs vector4-fältet |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| field | VertexField | Fältet med datatypen Vector4/FVector4 |
+
+ **Result:**
+FVector4
+
+
+---
+
+
+### readVector3{#readVector3}
+
+| Namn | Beskrivning |
+| --- | --- |
+| readVector3(field) | Läs vector3-fältet |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| field | VertexField | Fältet med en Vector3/FVector3-datatyp |
+
+ **Result:**
+Vector3
+
+
+---
+
+
+### readFVector3{#readFVector3}
+
+| Namn | Beskrivning |
+| --- | --- |
+| readFVector3(field) | Läs vector3-fältet |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| field | VertexField | Fältet med en Vector3/FVector3-datatyp |
+
+ **Result:**
+FVector3
+
+
+---
+
+
+### readVector2{#readVector2}
+
+| Namn | Beskrivning |
+| --- | --- |
+| readVector2(field) | Läs vector2-fältet |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| field | VertexField | Fältet med en Vector2/FVector2-datatyp |
+
+ **Result:**
+Vector2
+
+
+---
+
+
+### readFVector2{#readFVector2}
+
+| Namn | Beskrivning |
+| --- | --- |
+| readFVector2(field) | Läs vector2-fältet |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| field | VertexField | Fältet med en Vector2/FVector2-datatyp |
+
+ **Result:**
+FVector2
+
+
+---
+
+
+### readDouble{#readDouble}
+
+| Namn | Beskrivning |
+| --- | --- |
+| readDouble(field) | Läs double-fältet |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| field | VertexField | Fältet med en float/double-kompatibel datatyp |
+
+ **Result:**
+Nummer
+
+
+---
+
+
+### readFloat{#readFloat}
+
+| Namn | Beskrivning |
+| --- | --- |
+| readFloat(field) | Läs float-fältet |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| field | VertexField | Fältet med en float/double-kompatibel datatyp |
+
+ **Result:**
+Nummer
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/vertexdeclaration/_index.md
+++ b/swedish/nodejs-java/aspose.threed/vertexdeclaration/_index.md
@@ -1,0 +1,201 @@
+---
+title: "VertexDeclaration"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/vertexdeclaration/
+---
+## VertexDeclaration class
+
+Deklarationen av en anpassad definierad vertexstruktur
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getSealed{#getSealed}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getSealed() | En VertexDeclaration kommer att förseglas när den har använts av com.aspose.threed.TriMesh`1 eller TriMesh, inga fler ändringar är tillåtna. |
+
+ **Result:**
+
+
+
+---
+
+
+### getCount{#getCount}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getCount() | Hämtar antalet alla fält som definierats i denna VertexDeclaration |
+
+ **Result:**
+
+
+
+---
+
+
+### getSize{#getSize}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getSize() | Storleken i byte för vertex-strukturen. |
+
+ **Result:**
+
+
+
+---
+
+
+### get{#get}
+
+| Namn | Beskrivning |
+| --- | --- |
+| get(index) |  |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| Namn | Beskrivning |
+| --- | --- |
+| clear() | Rensa alla fält. |
+
+ **Result:**
+
+
+
+---
+
+
+### addField{#addField}
+
+| Namn | Beskrivning |
+| --- | --- |
+| addField(dataType, semantic, index, alias) | Lägg till ett nytt vertex-fält |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| dataType | Nummer | VertexFieldDataType |
+| semantic | VertexFieldSemantic | VertexFieldSemantic |
+| index | Nummer | Indexet för samma fältsemantik, -1 för automatisk generering |
+| alias | Sträng | Aliasnamnet för fältet |
+
+ **Result:**
+
+
+
+---
+
+
+### fromGeometry{#fromGeometry}
+
+| Namn | Beskrivning |
+| --- | --- |
+| fromGeometry(geometry, useFloat) | Skapa en VertexDeclaration baserad på en Geometrys layout. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| geometr | Geometry | null |
+| useFloat | boolean | Använd float istället för dubbeltyp |
+
+ **Result:**
+VertexDeclaration
+
+
+---
+
+
+### compareTo{#compareTo}
+
+| Namn | Beskrivning |
+| --- | --- |
+| compareTo(other) | Jämför detta objekt med ett angivet objekt och returnerar en indikation på deras relativa värden. |
+
+ **Result:**
+VertexDeclaration
+
+
+---
+
+
+### toString{#toString}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toString() |  |
+
+ **Result:**
+Sträng
+
+
+---
+
+
+### hashCode{#hashCode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| hashCode() |  |
+
+ **Result:**
+Nummer
+
+
+---
+
+
+### equals{#equals}
+
+| Namn | Beskrivning |
+| --- | --- |
+| equals(obj) | Bestämmer om detta objekt och ett specificerat objekt, som också måste vara ett VertexDeclaration-objekt, har samma värde. |
+
+ **Result:**
+Nummer
+
+
+---
+
+
+### iterator{#iterator}
+
+| Namn | Beskrivning |
+| --- | --- |
+| iterator() | Reserverad för internt bruk. |
+
+ **Result:**
+Nummer
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/vertexelement/_index.md
+++ b/swedish/nodejs-java/aspose.threed/vertexelement/_index.md
@@ -1,0 +1,165 @@
+---
+title: "VertexElement"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/vertexelement/
+---
+## VertexElement class
+
+Basklass för vertexelement.  En vertexelementtyp identifieras av VertexElementType.  Ett VertexElement beskriver hur vertexelementet mappas till en geometrisk yta och hur mappningsinformationen är ordnad i minnet.  Ett VertexElement innehåller Normals, UVs eller annan typ av information.  @hideconstructor
+
+
+## Metoder
+
+### getVertexElementType{#getVertexElementType}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getVertexElementType() | Hämtar typen av VertexElement. Värdet på egenskapen är heltalskonstanten VertexElementType. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getMappingMode() | Hämtar eller anger hur elementet är mappat. Värdet på egenskapen är heltalskonstanten MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setMappingMode(value) | Hämtar eller anger hur elementet är mappat. Värdet på egenskapen är heltalskonstanten MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getReferenceMode() | Hämtar eller anger hur elementet refereras. Värdet på egenskapen är heltalskonstanten ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setReferenceMode(value) | Hämtar eller anger hur elementet refereras. Värdet på egenskapen är heltalskonstanten ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getIndices() | Hämtar indexdata. Indexarrayen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setIndices(data) | Läs in index |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| data | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| Namn | Beskrivning |
+| --- | --- |
+| clear() | Rensar all data från detta vertex‑element. |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toString() | Strängrepresentation av vertex-elementet. |
+
+ **Result:**
+Sträng
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/vertexelementbinormal/_index.md
+++ b/swedish/nodejs-java/aspose.threed/vertexelementbinormal/_index.md
@@ -1,0 +1,229 @@
+---
+title: "VertexElementBinormal"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/vertexelementbinormal/
+---
+## VertexElementBinormal class
+
+Definierar binormala vektorer för angivna komponenter.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Initierar en ny instans av klassen VertexElementBinormal. |
+
+ **Result:**
+
+
+
+---
+
+
+### getData{#getData}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getData() | Hämtar vertexdata |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getVertexElementType() | Hämtar typen av VertexElement. Värdet på egenskapen är heltalskonstanten VertexElementType. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getMappingMode() | Hämtar eller anger hur elementet är mappat. Värdet på egenskapen är heltalskonstanten MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setMappingMode(value) | Hämtar eller anger hur elementet är mappat. Värdet på egenskapen är heltalskonstanten MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getReferenceMode() | Hämtar eller anger hur elementet refereras. Värdet på egenskapen är heltalskonstanten ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setReferenceMode(value) | Hämtar eller anger hur elementet refereras. Värdet på egenskapen är heltalskonstanten ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getIndices() | Hämtar indexdata. Indexarrayen. |
+
+ **Result:**
+
+
+
+---
+
+
+### copyTo{#copyTo}
+
+| Namn | Beskrivning |
+| --- | --- |
+| copyTo(target) | Kopierar data till specificerat element |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| mål | VertexElementVector4 | Mål. |
+
+ **Result:**
+
+
+
+---
+
+
+### setData{#setData}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setData(data) | Läs in data |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| data | Vector4[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| Namn | Beskrivning |
+| --- | --- |
+| clear() | Tar bort alla element från de direkta och indexarrayerna. |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setIndices(data) | Läs in index |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| data | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toString() | Strängrepresentation av vertex-elementet. |
+
+ **Result:**
+Sträng
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/vertexelementdoublestemplate/_index.md
+++ b/swedish/nodejs-java/aspose.threed/vertexelementdoublestemplate/_index.md
@@ -1,0 +1,216 @@
+---
+title: "VertexElementDoublesTemplate"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/vertexelementdoublestemplate/
+---
+## VertexElementDoublesTemplate class
+
+En hjälparklass för att definiera konkreta VertexElement-implementationer.  @hideconstructor
+
+
+## Metoder
+
+### getData{#getData}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getData() | Hämtar vertexdata |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getVertexElementType() | Hämtar typen av VertexElement. Värdet på egenskapen är heltalskonstanten VertexElementType. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getMappingMode() | Hämtar eller anger hur elementet är mappat. Värdet på egenskapen är heltalskonstanten MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setMappingMode(value) | Hämtar eller anger hur elementet är mappat. Värdet på egenskapen är heltalskonstanten MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getReferenceMode() | Hämtar eller anger hur elementet refereras. Värdet på egenskapen är heltalskonstanten ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setReferenceMode(value) | Hämtar eller anger hur elementet refereras. Värdet på egenskapen är heltalskonstanten ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getIndices() | Hämtar indexdata. Indexarrayen. |
+
+ **Result:**
+
+
+
+---
+
+
+### copyTo{#copyTo}
+
+| Namn | Beskrivning |
+| --- | --- |
+| copyTo(target) | Kopierar data till specificerat element |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| mål | VertexElementDoublesTemplate | Mål. |
+
+ **Result:**
+
+
+
+---
+
+
+### setData{#setData}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setData(data) | Läs in data |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| data | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| Namn | Beskrivning |
+| --- | --- |
+| clear() | Tar bort alla element från de direkta och indexarrayerna. |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setIndices(data) | Läs in index |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| data | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toString() | Strängrepresentation av vertex-elementet. |
+
+ **Result:**
+Sträng
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/vertexelementedgecrease/_index.md
+++ b/swedish/nodejs-java/aspose.threed/vertexelementedgecrease/_index.md
@@ -1,0 +1,229 @@
+---
+title: "VertexElementEdgeCrease"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/vertexelementedgecrease/
+---
+## VertexElementEdgeCrease class
+
+Definierar kantveck för angivna komponenter
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Initierar en ny instans av klassen VertexElementEdgeCrease. |
+
+ **Result:**
+
+
+
+---
+
+
+### getData{#getData}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getData() | Hämtar vertexdata |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getVertexElementType() | Hämtar typen av VertexElement. Värdet på egenskapen är heltalskonstanten VertexElementType. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getMappingMode() | Hämtar eller anger hur elementet är mappat. Värdet på egenskapen är heltalskonstanten MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setMappingMode(value) | Hämtar eller anger hur elementet är mappat. Värdet på egenskapen är heltalskonstanten MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getReferenceMode() | Hämtar eller anger hur elementet refereras. Värdet på egenskapen är heltalskonstanten ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setReferenceMode(value) | Hämtar eller anger hur elementet refereras. Värdet på egenskapen är heltalskonstanten ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getIndices() | Hämtar indexdata. Indexarrayen. |
+
+ **Result:**
+
+
+
+---
+
+
+### copyTo{#copyTo}
+
+| Namn | Beskrivning |
+| --- | --- |
+| copyTo(target) | Kopierar data till specificerat element |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| mål | VertexElementDoublesTemplate | Mål. |
+
+ **Result:**
+
+
+
+---
+
+
+### setData{#setData}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setData(data) | Läs in data |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| data | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| Namn | Beskrivning |
+| --- | --- |
+| clear() | Tar bort alla element från de direkta och indexarrayerna. |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setIndices(data) | Läs in index |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| data | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toString() | Strängrepresentation av vertex-elementet. |
+
+ **Result:**
+Sträng
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/vertexelementhole/_index.md
+++ b/swedish/nodejs-java/aspose.threed/vertexelementhole/_index.md
@@ -1,0 +1,191 @@
+---
+title: "VertexElementHole"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/vertexelementhole/
+---
+## VertexElementHole class
+
+Definierar om angiven polygon är ett hål
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Initierar en ny instans av klassen VertexElementHole. |
+
+ **Result:**
+
+
+
+---
+
+
+### getData{#getData}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getData() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getVertexElementType() | Hämtar typen av VertexElement. Värdet på egenskapen är heltalskonstanten VertexElementType. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getMappingMode() | Hämtar eller anger hur elementet är mappat. Värdet på egenskapen är heltalskonstanten MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setMappingMode(value) | Hämtar eller anger hur elementet är mappat. Värdet på egenskapen är heltalskonstanten MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getReferenceMode() | Hämtar eller anger hur elementet refereras. Värdet på egenskapen är heltalskonstanten ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setReferenceMode(value) | Hämtar eller anger hur elementet refereras. Värdet på egenskapen är heltalskonstanten ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getIndices() | Hämtar indexdata. Indexarrayen. |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| Namn | Beskrivning |
+| --- | --- |
+| clear() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setIndices(data) | Läs in index |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| data | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toString() | Strängrepresentation av vertex-elementet. |
+
+ **Result:**
+Sträng
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/vertexelementintstemplate/_index.md
+++ b/swedish/nodejs-java/aspose.threed/vertexelementintstemplate/_index.md
@@ -1,0 +1,216 @@
+---
+title: "VertexElementIntsTemplate"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/vertexelementintstemplate/
+---
+## VertexElementIntsTemplate class
+
+En hjälparklass för att definiera konkreta VertexElement-implementationer.  @hideconstructor
+
+
+## Metoder
+
+### getData{#getData}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getData() | Hämtar vertexdata |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getVertexElementType() | Hämtar typen av VertexElement. Värdet på egenskapen är heltalskonstanten VertexElementType. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getMappingMode() | Hämtar eller anger hur elementet är mappat. Värdet på egenskapen är heltalskonstanten MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setMappingMode(value) | Hämtar eller anger hur elementet är mappat. Värdet på egenskapen är heltalskonstanten MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getReferenceMode() | Hämtar eller anger hur elementet refereras. Värdet på egenskapen är heltalskonstanten ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setReferenceMode(value) | Hämtar eller anger hur elementet refereras. Värdet på egenskapen är heltalskonstanten ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getIndices() | Hämtar indexdata. Indexarrayen. |
+
+ **Result:**
+
+
+
+---
+
+
+### copyTo{#copyTo}
+
+| Namn | Beskrivning |
+| --- | --- |
+| copyTo(target) | Kopierar data till specificerat element |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| mål | VertexElementIntsTemplate | Mål. |
+
+ **Result:**
+
+
+
+---
+
+
+### setData{#setData}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setData(data) | Läs in data |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| data | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| Namn | Beskrivning |
+| --- | --- |
+| clear() | Tar bort alla element från de direkta och indexarrayerna. |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setIndices(data) | Läs in index |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| data | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toString() | Strängrepresentation av vertex-elementet. |
+
+ **Result:**
+Sträng
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/vertexelementmaterial/_index.md
+++ b/swedish/nodejs-java/aspose.threed/vertexelementmaterial/_index.md
@@ -1,0 +1,178 @@
+---
+title: "VertexElementMaterial"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/vertexelementmaterial/
+---
+## VertexElementMaterial class
+
+Definierar materialindex för angivna komponenter.  En nod kan ha flera material, VertexElementMaterial används för att rendera olika delar av geometrin i olika material.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Initierar en ny instans av klassen VertexElementMaterial. |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getVertexElementType() | Hämtar typen av VertexElement. Värdet på egenskapen är heltalskonstanten VertexElementType. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getMappingMode() | Hämtar eller anger hur elementet är mappat. Värdet på egenskapen är heltalskonstanten MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setMappingMode(value) | Hämtar eller anger hur elementet är mappat. Värdet på egenskapen är heltalskonstanten MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getReferenceMode() | Hämtar eller anger hur elementet refereras. Värdet på egenskapen är heltalskonstanten ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setReferenceMode(value) | Hämtar eller anger hur elementet refereras. Värdet på egenskapen är heltalskonstanten ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getIndices() | Hämtar indexdata. Indexarrayen. |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| Namn | Beskrivning |
+| --- | --- |
+| clear() | Tar bort alla element från de direkta och indexarrayerna. |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setIndices(data) | Läs in index |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| data | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toString() | Strängrepresentation av vertex-elementet. |
+
+ **Result:**
+Sträng
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/vertexelementnormal/_index.md
+++ b/swedish/nodejs-java/aspose.threed/vertexelementnormal/_index.md
@@ -1,0 +1,229 @@
+---
+title: "VertexElementNormal"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/vertexelementnormal/
+---
+## VertexElementNormal class
+
+Definierar normala vektorer för angivna komponenter.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Initierar en ny instans av klassen VertexElementNormal. |
+
+ **Result:**
+
+
+
+---
+
+
+### getData{#getData}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getData() | Hämtar vertexdata |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getVertexElementType() | Hämtar typen av VertexElement. Värdet på egenskapen är heltalskonstanten VertexElementType. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getMappingMode() | Hämtar eller anger hur elementet är mappat. Värdet på egenskapen är heltalskonstanten MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setMappingMode(value) | Hämtar eller anger hur elementet är mappat. Värdet på egenskapen är heltalskonstanten MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getReferenceMode() | Hämtar eller anger hur elementet refereras. Värdet på egenskapen är heltalskonstanten ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setReferenceMode(value) | Hämtar eller anger hur elementet refereras. Värdet på egenskapen är heltalskonstanten ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getIndices() | Hämtar indexdata. Indexarrayen. |
+
+ **Result:**
+
+
+
+---
+
+
+### copyTo{#copyTo}
+
+| Namn | Beskrivning |
+| --- | --- |
+| copyTo(target) | Kopierar data till specificerat element |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| mål | VertexElementVector4 | Mål. |
+
+ **Result:**
+
+
+
+---
+
+
+### setData{#setData}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setData(data) | Läs in data |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| data | Vector4[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| Namn | Beskrivning |
+| --- | --- |
+| clear() | Tar bort alla element från de direkta och indexarrayerna. |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setIndices(data) | Läs in index |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| data | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toString() | Strängrepresentation av vertex-elementet. |
+
+ **Result:**
+Sträng
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/vertexelementpolygongroup/_index.md
+++ b/swedish/nodejs-java/aspose.threed/vertexelementpolygongroup/_index.md
@@ -1,0 +1,229 @@
+---
+title: "VertexElementPolygonGroup"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/vertexelementpolygongroup/
+---
+## VertexElementPolygonGroup class
+
+Definierar polygongrupp för angivna komponenter för att gruppera relaterade polygoner tillsammans.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Initierar en ny instans av klassen VertexElementPolygonGroup. |
+
+ **Result:**
+
+
+
+---
+
+
+### getData{#getData}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getData() | Hämtar vertexdata |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getVertexElementType() | Hämtar typen av VertexElement. Värdet på egenskapen är heltalskonstanten VertexElementType. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getMappingMode() | Hämtar eller anger hur elementet är mappat. Värdet på egenskapen är heltalskonstanten MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setMappingMode(value) | Hämtar eller anger hur elementet är mappat. Värdet på egenskapen är heltalskonstanten MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getReferenceMode() | Hämtar eller anger hur elementet refereras. Värdet på egenskapen är heltalskonstanten ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setReferenceMode(value) | Hämtar eller anger hur elementet refereras. Värdet på egenskapen är heltalskonstanten ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getIndices() | Hämtar indexdata. Indexarrayen. |
+
+ **Result:**
+
+
+
+---
+
+
+### copyTo{#copyTo}
+
+| Namn | Beskrivning |
+| --- | --- |
+| copyTo(target) | Kopierar data till specificerat element |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| mål | VertexElementIntsTemplate | Mål. |
+
+ **Result:**
+
+
+
+---
+
+
+### setData{#setData}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setData(data) | Läs in data |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| data | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| Namn | Beskrivning |
+| --- | --- |
+| clear() | Tar bort alla element från de direkta och indexarrayerna. |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setIndices(data) | Läs in index |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| data | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toString() | Strängrepresentation av vertex-elementet. |
+
+ **Result:**
+Sträng
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/vertexelementsmoothinggroup/_index.md
+++ b/swedish/nodejs-java/aspose.threed/vertexelementsmoothinggroup/_index.md
@@ -1,0 +1,229 @@
+---
+title: "VertexElementSmoothingGroup"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/vertexelementsmoothinggroup/
+---
+## VertexElementSmoothingGroup class
+
+En slätningsgrupp är en grupp av polygoner i ett polygonnät som ska framstå som en slät yta.  Viss tidig 3D-modelleringsprogramvara som 3D Studio Max för DOS använde slätningsgrupp för att undvika lagring av normala vektorer för varje mesh-vertex.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Initierar en ny instans av klassen VertexElementSmoothingGroup. |
+
+ **Result:**
+
+
+
+---
+
+
+### getData{#getData}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getData() | Hämtar vertexdata |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getVertexElementType() | Hämtar typen av VertexElement. Värdet på egenskapen är heltalskonstanten VertexElementType. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getMappingMode() | Hämtar eller anger hur elementet är mappat. Värdet på egenskapen är heltalskonstanten MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setMappingMode(value) | Hämtar eller anger hur elementet är mappat. Värdet på egenskapen är heltalskonstanten MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getReferenceMode() | Hämtar eller anger hur elementet refereras. Värdet på egenskapen är heltalskonstanten ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setReferenceMode(value) | Hämtar eller anger hur elementet refereras. Värdet på egenskapen är heltalskonstanten ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getIndices() | Hämtar indexdata. Indexarrayen. |
+
+ **Result:**
+
+
+
+---
+
+
+### copyTo{#copyTo}
+
+| Namn | Beskrivning |
+| --- | --- |
+| copyTo(target) | Kopierar data till specificerat element |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| mål | VertexElementIntsTemplate | Mål. |
+
+ **Result:**
+
+
+
+---
+
+
+### setData{#setData}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setData(data) | Läs in data |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| data | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| Namn | Beskrivning |
+| --- | --- |
+| clear() | Tar bort alla element från de direkta och indexarrayerna. |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setIndices(data) | Läs in index |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| data | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toString() | Strängrepresentation av vertex-elementet. |
+
+ **Result:**
+Sträng
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/vertexelementspecular/_index.md
+++ b/swedish/nodejs-java/aspose.threed/vertexelementspecular/_index.md
@@ -1,0 +1,229 @@
+---
+title: "VertexElementSpecular"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/vertexelementspecular/
+---
+## VertexElementSpecular class
+
+Definierar spekulär färg för angivna komponenter.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Initierar en ny instans av klassen VertexElementSpecular. |
+
+ **Result:**
+
+
+
+---
+
+
+### getData{#getData}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getData() | Hämtar vertexdata |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getVertexElementType() | Hämtar typen av VertexElement. Värdet på egenskapen är heltalskonstanten VertexElementType. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getMappingMode() | Hämtar eller anger hur elementet är mappat. Värdet på egenskapen är heltalskonstanten MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setMappingMode(value) | Hämtar eller anger hur elementet är mappat. Värdet på egenskapen är heltalskonstanten MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getReferenceMode() | Hämtar eller anger hur elementet refereras. Värdet på egenskapen är heltalskonstanten ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setReferenceMode(value) | Hämtar eller anger hur elementet refereras. Värdet på egenskapen är heltalskonstanten ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getIndices() | Hämtar indexdata. Indexarrayen. |
+
+ **Result:**
+
+
+
+---
+
+
+### copyTo{#copyTo}
+
+| Namn | Beskrivning |
+| --- | --- |
+| copyTo(target) | Kopierar data till specificerat element |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| mål | VertexElementVector4 | Mål. |
+
+ **Result:**
+
+
+
+---
+
+
+### setData{#setData}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setData(data) | Läs in data |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| data | Vector4[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| Namn | Beskrivning |
+| --- | --- |
+| clear() | Tar bort alla element från de direkta och indexarrayerna. |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setIndices(data) | Läs in index |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| data | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toString() | Strängrepresentation av vertex-elementet. |
+
+ **Result:**
+Sträng
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/vertexelementtangent/_index.md
+++ b/swedish/nodejs-java/aspose.threed/vertexelementtangent/_index.md
@@ -1,0 +1,229 @@
+---
+title: "VertexElementTangent"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/vertexelementtangent/
+---
+## VertexElementTangent class
+
+Definierar tangentiala vektorer för angivna komponenter.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Initierar en ny instans av klassen VertexElementTangent. |
+
+ **Result:**
+
+
+
+---
+
+
+### getData{#getData}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getData() | Hämtar vertexdata |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getVertexElementType() | Hämtar typen av VertexElement. Värdet på egenskapen är heltalskonstanten VertexElementType. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getMappingMode() | Hämtar eller anger hur elementet är mappat. Värdet på egenskapen är heltalskonstanten MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setMappingMode(value) | Hämtar eller anger hur elementet är mappat. Värdet på egenskapen är heltalskonstanten MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getReferenceMode() | Hämtar eller anger hur elementet refereras. Värdet på egenskapen är heltalskonstanten ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setReferenceMode(value) | Hämtar eller anger hur elementet refereras. Värdet på egenskapen är heltalskonstanten ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getIndices() | Hämtar indexdata. Indexarrayen. |
+
+ **Result:**
+
+
+
+---
+
+
+### copyTo{#copyTo}
+
+| Namn | Beskrivning |
+| --- | --- |
+| copyTo(target) | Kopierar data till specificerat element |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| mål | VertexElementVector4 | Mål. |
+
+ **Result:**
+
+
+
+---
+
+
+### setData{#setData}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setData(data) | Läs in data |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| data | Vector4[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| Namn | Beskrivning |
+| --- | --- |
+| clear() | Tar bort alla element från de direkta och indexarrayerna. |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setIndices(data) | Läs in index |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| data | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toString() | Strängrepresentation av vertex-elementet. |
+
+ **Result:**
+Sträng
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/vertexelementuserdata/_index.md
+++ b/swedish/nodejs-java/aspose.threed/vertexelementuserdata/_index.md
@@ -1,0 +1,204 @@
+---
+title: "VertexElementUserData"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/vertexelementuserdata/
+---
+## VertexElementUserData class
+
+Definierar anpassad användardata för angivna komponenter.  Vanligtvis är det applikationsspecifik data för speciellt ändamål.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Initierar en ny instans av klassen VertexElementUserData. |
+
+ **Result:**
+
+
+
+---
+
+
+### getData{#getData}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getData() | Den användardata som är bifogad i detta element |
+
+ **Result:**
+
+
+
+---
+
+
+### setData{#setData}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setData(value) | Den användardata som är bifogad i detta element |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getVertexElementType() | Hämtar typen av VertexElement. Värdet på egenskapen är heltalskonstanten VertexElementType. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getMappingMode() | Hämtar eller anger hur elementet är mappat. Värdet på egenskapen är heltalskonstanten MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setMappingMode(value) | Hämtar eller anger hur elementet är mappat. Värdet på egenskapen är heltalskonstanten MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getReferenceMode() | Hämtar eller anger hur elementet refereras. Värdet på egenskapen är heltalskonstanten ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setReferenceMode(value) | Hämtar eller anger hur elementet refereras. Värdet på egenskapen är heltalskonstanten ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getIndices() | Hämtar indexdata. Indexarrayen. |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| Namn | Beskrivning |
+| --- | --- |
+| clear() | Rensar all data från detta vertex‑element. |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setIndices(data) | Läs in index |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| data | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toString() | Strängrepresentation av vertex-elementet. |
+
+ **Result:**
+Sträng
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/vertexelementuv/_index.md
+++ b/swedish/nodejs-java/aspose.threed/vertexelementuv/_index.md
@@ -1,0 +1,248 @@
+---
+title: "VertexElementUV"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/vertexelementuv/
+---
+## VertexElementUV class
+
+Definierar UV-koordinaterna för angivna komponenter.  En geometri kan ha flera VertexElementUV-element, och var och en har olika TextureMappings.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Initierar en ny instans av klassen VertexElementUV. Standardtyp för texturavbildning är TextureMapping.DIFFUSE |
+
+ **Result:**
+
+
+
+---
+
+
+### constructor_overload{#constructor_overload}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor_overload(textureMapping) | Initierar en ny instans av klassen VertexElementUV. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| textureMapping | TextureMapping | TextureMapping |
+
+ **Result:**
+
+
+
+---
+
+
+### getData{#getData}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getData() | Hämtar vertexdata |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getVertexElementType() | Hämtar typen av VertexElement. Värdet på egenskapen är heltalskonstanten VertexElementType. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getMappingMode() | Hämtar eller anger hur elementet är mappat. Värdet på egenskapen är heltalskonstanten MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setMappingMode(value) | Hämtar eller anger hur elementet är mappat. Värdet på egenskapen är heltalskonstanten MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getReferenceMode() | Hämtar eller anger hur elementet refereras. Värdet på egenskapen är heltalskonstanten ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setReferenceMode(value) | Hämtar eller anger hur elementet refereras. Värdet på egenskapen är heltalskonstanten ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getIndices() | Hämtar indexdata. Indexarrayen. |
+
+ **Result:**
+
+
+
+---
+
+
+### copyTo{#copyTo}
+
+| Namn | Beskrivning |
+| --- | --- |
+| copyTo(target) | Kopierar data till specificerat element |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| mål | VertexElementVector4 | Mål. |
+
+ **Result:**
+
+
+
+---
+
+
+### setData{#setData}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setData(data) | Läs in data |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| data | Vector4[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| Namn | Beskrivning |
+| --- | --- |
+| clear() | Tar bort alla element från de direkta och indexarrayerna. |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setIndices(data) | Läs in index |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| data | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toString() | Strängrepresentation av vertex-elementet. |
+
+ **Result:**
+Sträng
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/vertexelementvector4/_index.md
+++ b/swedish/nodejs-java/aspose.threed/vertexelementvector4/_index.md
@@ -1,0 +1,216 @@
+---
+title: "VertexElementVector4"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/vertexelementvector4/
+---
+## VertexElementVector4 class
+
+En hjälparklass för att definiera konkreta VertexElement-implementationer.  @hideconstructor
+
+
+## Metoder
+
+### getData{#getData}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getData() | Hämtar vertexdata |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getVertexElementType() | Hämtar typen av VertexElement. Värdet på egenskapen är heltalskonstanten VertexElementType. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getMappingMode() | Hämtar eller anger hur elementet är mappat. Värdet på egenskapen är heltalskonstanten MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setMappingMode(value) | Hämtar eller anger hur elementet är mappat. Värdet på egenskapen är heltalskonstanten MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getReferenceMode() | Hämtar eller anger hur elementet refereras. Värdet på egenskapen är heltalskonstanten ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setReferenceMode(value) | Hämtar eller anger hur elementet refereras. Värdet på egenskapen är heltalskonstanten ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getIndices() | Hämtar indexdata. Indexarrayen. |
+
+ **Result:**
+
+
+
+---
+
+
+### copyTo{#copyTo}
+
+| Namn | Beskrivning |
+| --- | --- |
+| copyTo(target) | Kopierar data till specificerat element |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| mål | VertexElementVector4 | Mål. |
+
+ **Result:**
+
+
+
+---
+
+
+### setData{#setData}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setData(data) | Läs in data |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| data | Vector4[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| Namn | Beskrivning |
+| --- | --- |
+| clear() | Tar bort alla element från de direkta och indexarrayerna. |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setIndices(data) | Läs in index |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| data | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toString() | Strängrepresentation av vertex-elementet. |
+
+ **Result:**
+Sträng
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/vertexelementvertexcolor/_index.md
+++ b/swedish/nodejs-java/aspose.threed/vertexelementvertexcolor/_index.md
@@ -1,0 +1,229 @@
+---
+title: "VertexElementVertexColor"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/vertexelementvertexcolor/
+---
+## VertexElementVertexColor class
+
+Definierar vertexfärgen för angivna komponenter
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Initierar en ny instans av klassen VertexElementVertexColor. |
+
+ **Result:**
+
+
+
+---
+
+
+### getData{#getData}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getData() | Hämtar vertexdata |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getVertexElementType() | Hämtar typen av VertexElement. Värdet på egenskapen är heltalskonstanten VertexElementType. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getMappingMode() | Hämtar eller anger hur elementet är mappat. Värdet på egenskapen är heltalskonstanten MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setMappingMode(value) | Hämtar eller anger hur elementet är mappat. Värdet på egenskapen är heltalskonstanten MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getReferenceMode() | Hämtar eller anger hur elementet refereras. Värdet på egenskapen är heltalskonstanten ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setReferenceMode(value) | Hämtar eller anger hur elementet refereras. Värdet på egenskapen är heltalskonstanten ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getIndices() | Hämtar indexdata. Indexarrayen. |
+
+ **Result:**
+
+
+
+---
+
+
+### copyTo{#copyTo}
+
+| Namn | Beskrivning |
+| --- | --- |
+| copyTo(target) | Kopierar data till specificerat element |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| mål | VertexElementVector4 | Mål. |
+
+ **Result:**
+
+
+
+---
+
+
+### setData{#setData}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setData(data) | Läs in data |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| data | Vector4[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| Namn | Beskrivning |
+| --- | --- |
+| clear() | Tar bort alla element från de direkta och indexarrayerna. |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setIndices(data) | Läs in index |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| data | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toString() | Strängrepresentation av vertex-elementet. |
+
+ **Result:**
+Sträng
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/vertexelementvertexcrease/_index.md
+++ b/swedish/nodejs-java/aspose.threed/vertexelementvertexcrease/_index.md
@@ -1,0 +1,229 @@
+---
+title: "VertexElementVertexCrease"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/vertexelementvertexcrease/
+---
+## VertexElementVertexCrease class
+
+Definierar vertexveck för angivna komponenter
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Initierar en ny instans av klassen VertexElementVertexCrease. |
+
+ **Result:**
+
+
+
+---
+
+
+### getData{#getData}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getData() | Hämtar vertexdata |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getVertexElementType() | Hämtar typen av VertexElement. Värdet på egenskapen är heltalskonstanten VertexElementType. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getMappingMode() | Hämtar eller anger hur elementet är mappat. Värdet på egenskapen är heltalskonstanten MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setMappingMode(value) | Hämtar eller anger hur elementet är mappat. Värdet på egenskapen är heltalskonstanten MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getReferenceMode() | Hämtar eller anger hur elementet refereras. Värdet på egenskapen är heltalskonstanten ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setReferenceMode(value) | Hämtar eller anger hur elementet refereras. Värdet på egenskapen är heltalskonstanten ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getIndices() | Hämtar indexdata. Indexarrayen. |
+
+ **Result:**
+
+
+
+---
+
+
+### copyTo{#copyTo}
+
+| Namn | Beskrivning |
+| --- | --- |
+| copyTo(target) | Kopierar data till specificerat element |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| mål | VertexElementDoublesTemplate | Mål. |
+
+ **Result:**
+
+
+
+---
+
+
+### setData{#setData}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setData(data) | Läs in data |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| data | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| Namn | Beskrivning |
+| --- | --- |
+| clear() | Tar bort alla element från de direkta och indexarrayerna. |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setIndices(data) | Läs in index |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| data | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toString() | Strängrepresentation av vertex-elementet. |
+
+ **Result:**
+Sträng
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/vertexelementvisibility/_index.md
+++ b/swedish/nodejs-java/aspose.threed/vertexelementvisibility/_index.md
@@ -1,0 +1,191 @@
+---
+title: "VertexElementVisibility"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/vertexelementvisibility/
+---
+## VertexElementVisibility class
+
+Definierar om angivna komponenter är synliga
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Initierar en ny instans av klassen VertexElementVisibility. |
+
+ **Result:**
+
+
+
+---
+
+
+### getData{#getData}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getData() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getVertexElementType() | Hämtar typen av VertexElement. Värdet på egenskapen är heltalskonstanten VertexElementType. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getMappingMode() | Hämtar eller anger hur elementet är mappat. Värdet på egenskapen är heltalskonstanten MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setMappingMode(value) | Hämtar eller anger hur elementet är mappat. Värdet på egenskapen är heltalskonstanten MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getReferenceMode() | Hämtar eller anger hur elementet refereras. Värdet på egenskapen är heltalskonstanten ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setReferenceMode(value) | Hämtar eller anger hur elementet refereras. Värdet på egenskapen är heltalskonstanten ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getIndices() | Hämtar indexdata. Indexarrayen. |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| Namn | Beskrivning |
+| --- | --- |
+| clear() |  |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setIndices(data) | Läs in index |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| data | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toString() | Strängrepresentation av vertex-elementet. |
+
+ **Result:**
+Sträng
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/vertexelementweight/_index.md
+++ b/swedish/nodejs-java/aspose.threed/vertexelementweight/_index.md
@@ -1,0 +1,229 @@
+---
+title: "VertexElementWeight"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/vertexelementweight/
+---
+## VertexElementWeight class
+
+Definierar blandningsvikt för angivna komponenter.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Initierar en ny instans av klassen VertexElementWeight. |
+
+ **Result:**
+
+
+
+---
+
+
+### getData{#getData}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getData() | Hämtar vertexdata |
+
+ **Result:**
+
+
+
+---
+
+
+### getVertexElementType{#getVertexElementType}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getVertexElementType() | Hämtar typen av VertexElement. Värdet på egenskapen är heltalskonstanten VertexElementType. |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getMappingMode{#getMappingMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getMappingMode() | Hämtar eller anger hur elementet är mappat. Värdet på egenskapen är heltalskonstanten MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setMappingMode{#setMappingMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setMappingMode(value) | Hämtar eller anger hur elementet är mappat. Värdet på egenskapen är heltalskonstanten MappingMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getReferenceMode{#getReferenceMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getReferenceMode() | Hämtar eller anger hur elementet refereras. Värdet på egenskapen är heltalskonstanten ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### setReferenceMode{#setReferenceMode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setReferenceMode(value) | Hämtar eller anger hur elementet refereras. Värdet på egenskapen är heltalskonstanten ReferenceMode. |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndices{#getIndices}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getIndices() | Hämtar indexdata. Indexarrayen. |
+
+ **Result:**
+
+
+
+---
+
+
+### copyTo{#copyTo}
+
+| Namn | Beskrivning |
+| --- | --- |
+| copyTo(target) | Kopierar data till specificerat element |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| mål | VertexElementDoublesTemplate | Mål. |
+
+ **Result:**
+
+
+
+---
+
+
+### setData{#setData}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setData(data) | Läs in data |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| data | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### clear{#clear}
+
+| Namn | Beskrivning |
+| --- | --- |
+| clear() | Tar bort alla element från de direkta och indexarrayerna. |
+
+ **Result:**
+
+
+
+---
+
+
+### setIndices{#setIndices}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setIndices(data) | Läs in index |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| data | Number[] | null |
+
+ **Result:**
+
+
+
+---
+
+
+### toString{#toString}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toString() | Strängrepresentation av vertex-elementet. |
+
+ **Result:**
+Sträng
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/vertexfield/_index.md
+++ b/swedish/nodejs-java/aspose.threed/vertexfield/_index.md
@@ -1,0 +1,146 @@
+---
+title: "VertexField"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/vertexfield/
+---
+## VertexField class
+
+Vertexens fältminneslayoutbeskrivning.  @hideconstructor
+
+
+## Metoder
+
+### getDataType{#getDataType}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getDataType() | Datatyp för detta fält. Värdet på egenskapen är heltalskonstanten VertexFieldDataType. |
+
+ **Result:**
+
+
+
+---
+
+
+### getSemantic{#getSemantic}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getSemantic() | Användningssemantiken för detta fält. Värdet på egenskapen är heltalskonstanten VertexFieldSemantic. |
+
+ **Result:**
+
+
+
+---
+
+
+### getAlias{#getAlias}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getAlias() | Alias annoterat med attributet com.aspose.threed.SemanticAttribute |
+
+ **Result:**
+
+
+
+---
+
+
+### getIndex{#getIndex}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getIndex() | Index för detta fält i vertexens layout med samma semantik. |
+
+ **Result:**
+
+
+
+---
+
+
+### getOffset{#getOffset}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getOffset() | Offset i byte för detta fält. |
+
+ **Result:**
+
+
+
+---
+
+
+### getSize{#getSize}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getSize() | Storleken i byte för detta fält |
+
+ **Result:**
+
+
+
+---
+
+
+### hashCode{#hashCode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| hashCode() |  |
+
+ **Result:**
+Nummer
+
+
+---
+
+
+### equals{#equals}
+
+| Namn | Beskrivning |
+| --- | --- |
+| equals(obj) | Bestämmer om detta objekt och ett angivet objekt, som också måste vara ett VertexField-objekt, har samma värde. |
+
+ **Result:**
+Nummer
+
+
+---
+
+
+### compareTo{#compareTo}
+
+| Namn | Beskrivning |
+| --- | --- |
+| compareTo(other) | Jämför detta objekt med ett angivet objekt och returnerar en indikation på deras relativa värden. |
+
+ **Result:**
+Nummer
+
+
+---
+
+
+### toString{#toString}
+
+| Namn | Beskrivning |
+| --- | --- |
+| toString() |  |
+
+ **Result:**
+Sträng
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/viewport/_index.md
+++ b/swedish/nodejs-java/aspose.threed/viewport/_index.md
@@ -1,0 +1,185 @@
+---
+title: "Viewport"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/viewport/
+---
+## Viewport class
+
+En com.aspose.threed.IRenderTarget innehåller minst en viewport för att rendera scenen.  @hideconstructor
+
+
+## Metoder
+
+### getFrustum{#getFrustum}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFrustum() | Hämtar eller anger kameran för detta Viewport |
+
+ **Result:**
+
+
+
+---
+
+
+### setFrustum{#setFrustum}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFrustum(value) | Hämtar eller anger kameran för detta Viewport |
+
+ **Result:**
+
+
+
+---
+
+
+### getEnabled{#getEnabled}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEnabled() | Aktivera eller inaktivera detta viewport. |
+
+ **Result:**
+
+
+
+---
+
+
+### setEnabled{#setEnabled}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setEnabled(value) | Aktivera eller inaktivera detta viewport. |
+
+ **Result:**
+
+
+
+---
+
+
+### getRenderTarget{#getRenderTarget}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getRenderTarget() | Hämtar render-målet som skapade denna viewport. |
+
+ **Result:**
+
+
+
+---
+
+
+### getArea{#getArea}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getArea() | Hämtar eller anger området för viewporten i render-målet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setArea{#setArea}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setArea(value) | Hämtar eller anger området för viewporten i render-målet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getZOrder{#getZOrder}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getZOrder() | Hämtar eller anger Z-ordningen för viewporten. |
+
+ **Result:**
+
+
+
+---
+
+
+### setZOrder{#setZOrder}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setZOrder(value) | Hämtar eller anger Z-ordningen för viewporten. |
+
+ **Result:**
+
+
+
+---
+
+
+### getBackgroundColor{#getBackgroundColor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBackgroundColor() | Hämtar eller anger bakgrundsfärgen för viewporten. |
+
+ **Result:**
+
+
+
+---
+
+
+### setBackgroundColor{#setBackgroundColor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setBackgroundColor(value) | Hämtar eller anger bakgrundsfärgen för viewporten. |
+
+ **Result:**
+
+
+
+---
+
+
+### getDepthClear{#getDepthClear}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getDepthClear() | Hämtar eller anger djupvärdet som används när viewporten rensas med depth‑buffer‑biten satt. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDepthClear{#setDepthClear}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setDepthClear(value) | Hämtar eller anger djupvärdet som används när viewporten rensas med depth‑buffer‑biten satt. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/watermark/_index.md
+++ b/swedish/nodejs-java/aspose.threed/watermark/_index.md
@@ -1,0 +1,96 @@
+---
+title: "Vattenstämpel"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/watermark/
+---
+## Watermark class
+
+Verktyg för att koda/avkoda blind vattenstämpel till/från ett mesh.  @hideconstructor
+
+
+## Metoder
+
+### encodeWatermark{#encodeWatermark}
+
+| Namn | Beskrivning |
+| --- | --- |
+| encodeWatermark(input, text) | Koda en text till meshens blinda vattenstämpel. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| input | Mesh | Mesh för att koda en blind vattenstämpel |
+| text | Sträng | Text att koda till meshen |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### encodeWatermark{#encodeWatermark}
+
+| Namn | Beskrivning |
+| --- | --- |
+| encodeWatermark(input, text, password) | Koda en text till meshens blinda vattenstämpel. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| input | Mesh | Mesh för att koda en blind vattenstämpel |
+| text | Sträng | Text att koda till meshen |
+| password | Sträng | Lösenord för att skydda vattenstämpeln, det är valfritt |
+
+ **Result:**
+Mesh
+
+
+---
+
+
+### decodeWatermark{#decodeWatermark}
+
+| Namn | Beskrivning |
+| --- | --- |
+| decodeWatermark(input) | Dekoda vattenstämpeln från en mesh |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| input | Mesh | Meshen för att extrahera vattenstämpeln |
+
+ **Result:**
+Sträng
+
+
+---
+
+
+### decodeWatermark{#decodeWatermark}
+
+| Namn | Beskrivning |
+| --- | --- |
+| decodeWatermark(input, password) | Dekoda vattenstämpeln från en mesh |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| input | Mesh | Meshen för att extrahera vattenstämpeln |
+| password | Sträng | Lösenordet för att dekryptera vattenstämpeln |
+
+ **Result:**
+Sträng
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/windowhandle/_index.md
+++ b/swedish/nodejs-java/aspose.threed/windowhandle/_index.md
@@ -1,0 +1,13 @@
+---
+title: "WindowHandle"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/windowhandle/
+---
+## WindowHandle class
+
+Inkapslad fönsterhandtag för olika plattformar.  @hideconstructor
+
+

--- a/swedish/nodejs-java/aspose.threed/xloadoptions/_index.md
+++ b/swedish/nodejs-java/aspose.threed/xloadoptions/_index.md
@@ -1,0 +1,152 @@
+---
+title: "XLoadOptions"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/xloadoptions/
+---
+## XLoadOptions class
+
+Laddningsalternativen för DirectX X-filer.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor(contentType) | Konstruktor för XLoadOptions |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| contentType | FileContentType | FileContentType |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlipCoordinateSystem{#getFlipCoordinateSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFlipCoordinateSystem() | Vänd koordinatsystemet, detta är sant som standard |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlipCoordinateSystem{#setFlipCoordinateSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFlipCoordinateSystem(value) | Vänd koordinatsystemet, detta är sant som standard |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileFormat{#getFileFormat}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileFormat() | Hämtar filformatet som anges i aktuellt Spara/Ladda-alternativ. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEncoding{#getEncoding}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEncoding() | Hämtar eller anger standardkodning för textbaserade filer. Standardvärdet är null, vilket betyder att importören/exportören bestämmer vilken kodning som ska användas. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileSystem{#getFileSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileSystem() | Tillåter användaren att hantera hur externa beroenden ska hanteras under laddning/sparning. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileSystem{#setFileSystem}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFileSystem(value) | Tillåter användaren att hantera hur externa beroenden ska hanteras under laddning/sparning. |
+
+ **Result:**
+
+
+
+---
+
+
+### getLookupPaths{#getLookupPaths}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getLookupPaths() | Vissa filer, som OBJ, är beroende av externa filer; sökvägarna gör det möjligt för Aspose.3D att leta efter externa filer att ladda. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFileName{#getFileName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFileName() | Filnamnet för den exporterade/importerade scenen. Detta är valfritt, men användbart när externa resurser som OBJ:s material serialiseras. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFileName{#setFileName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFileName(value) | Filnamnet för den exporterade/importerade scenen. Detta är valfritt, men användbart när externa resurser som OBJ:s material serialiseras. |
+
+ **Result:**
+
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/ziparchivefilesystem/_index.md
+++ b/swedish/nodejs-java/aspose.threed/ziparchivefilesystem/_index.md
@@ -1,0 +1,75 @@
+---
+title: "ZipArchiveFileSystem"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/ziparchivefilesystem/
+---
+## ZipArchiveFileSystem class
+
+Filsystem för att ge skrivskyddad åtkomst till angiven zip-fil eller zip-ström.  Filsystemet kommer att tas bort efter öppna/spara‑operationen.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor(fileName) | Skapa ett ZipArchiveFileSystem med ett filnamn. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| fileNam | Sträng | null |
+
+ **Result:**
+
+
+
+---
+
+
+### readFile{#readFile}
+
+| Namn | Beskrivning |
+| --- | --- |
+| readFile(fileName, options) | Öppna fil för läsning |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| fileNam | Sträng | null |
+| alternativ | IOConfig | null |
+
+ **Result:**
+Stream
+
+
+---
+
+
+### writeFile{#writeFile}
+
+| Namn | Beskrivning |
+| --- | --- |
+| writeFile(fileName, options) | Öppna fil för skrivning, inte implementerat i denna klass. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| fileNam | Sträng | null |
+| alternativ | IOConfig | null |
+
+ **Result:**
+Stream
+
+
+---
+
+
+

--- a/swedish/nodejs-java/aspose.threed/zshape/_index.md
+++ b/swedish/nodejs-java/aspose.threed/zshape/_index.md
@@ -1,0 +1,437 @@
+---
+title: "ZShape"
+second_title: "Aspose.3D för Node.js via Java API-referens"
+description: 
+type: docs
+
+url: /sv/nodejs-java/aspose.threed/zshape/
+---
+## ZShape class
+
+IFC‑kompatibel Z‑formad profil definierad av parametrar.
+
+
+## Metoder
+
+### constructor{#constructor}
+
+| Namn | Beskrivning |
+| --- | --- |
+| constructor() | Konstruktor för ZShape |
+
+ **Result:**
+
+
+
+---
+
+
+### getDepth{#getDepth}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getDepth() | Hämtar eller anger längden på webben. |
+
+ **Result:**
+
+
+
+---
+
+
+### setDepth{#setDepth}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setDepth(value) | Hämtar eller anger längden på webben. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlangeWidth{#getFlangeWidth}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFlangeWidth() | Hämtar eller anger längden på flänsen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlangeWidth{#setFlangeWidth}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFlangeWidth(value) | Hämtar eller anger längden på flänsen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getWebThickness{#getWebThickness}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getWebThickness() | Hämtar eller anger tjockleken på väggen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setWebThickness{#setWebThickness}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setWebThickness(value) | Hämtar eller anger tjockleken på väggen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFlangeThickness{#getFlangeThickness}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFlangeThickness() | Hämtar eller anger tjockleken på flänsen. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFlangeThickness{#setFlangeThickness}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFlangeThickness(value) | Hämtar eller anger tjockleken på flänsen. |
+
+ **Result:**
+
+
+
+---
+
+
+### getFilletRadius{#getFilletRadius}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getFilletRadius() | Hämtar eller anger radien på avrundningen mellan fläns och web. |
+
+ **Result:**
+
+
+
+---
+
+
+### setFilletRadius{#setFilletRadius}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setFilletRadius(value) | Hämtar eller anger radien på avrundningen mellan fläns och web. |
+
+ **Result:**
+
+
+
+---
+
+
+### getEdgeRadius{#getEdgeRadius}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEdgeRadius() | Hämtar eller anger radien på flänskanten. |
+
+ **Result:**
+
+
+
+---
+
+
+### setEdgeRadius{#setEdgeRadius}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setEdgeRadius(value) | Hämtar eller anger radien på flänskanten. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNodes{#getParentNodes}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNodes() | Hämtar alla föräldranoder, en entitet kan fästas vid flera föräldranoder för geometri‑instansering. Noderna. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExcluded{#getExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExcluded() | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### setExcluded{#setExcluded}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setExcluded(value) | Hämtar eller anger om denna enhet ska exkluderas vid export. |
+
+ **Result:**
+
+
+
+---
+
+
+### getParentNode{#getParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getParentNode() | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### setParentNode{#setParentNode}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setParentNode(value) | Hämtar eller anger den första föräldranoden, om den första föräldranoden anges kommer denna enhet att frikopplas från andra föräldranoder. Föräldranoden. |
+
+ **Result:**
+
+
+
+---
+
+
+### getScene{#getScene}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getScene() | Hämtar scenen som detta objekt tillhör |
+
+ **Result:**
+
+
+
+---
+
+
+### getName{#getName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getName() | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### setName{#setName}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setName(value) | Hämtar eller anger namnet. Namnet. |
+
+ **Result:**
+
+
+
+---
+
+
+### getProperties{#getProperties}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperties() | Hämtar samlingen av alla egenskaper. |
+
+ **Result:**
+
+
+
+---
+
+
+### getExtent{#getExtent}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getExtent() | Hämtar omfattningen i x- och y-dimension. |
+
+ **Result:**
+Vector2
+
+
+---
+
+
+### getEntityRendererKey{#getEntityRendererKey}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getEntityRendererKey() | Hämtar nyckeln för enhetens renderare som är registrerad i renderaren |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### getBoundingBox{#getBoundingBox}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getBoundingBox() | Hämtar den omgivande lådan för den aktuella enheten i dess objektrums koordinatsystem. |
+
+ **Result:**
+EntityRendererKey
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Tar bort en dynamisk egenskap. |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Property | Vilken egenskap som ska tas bort |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### removeProperty{#removeProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| removeProperty(property) | Ta bort den angivna egenskapen som identifieras med namn |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propert | Sträng | null |
+
+ **Result:**
+boolean
+
+
+---
+
+
+### getProperty{#getProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| getProperty(property) | Hämta värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### setProperty{#setProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| setProperty(property, value) | Sätter värdet för den angivna egenskapen |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| property | Sträng | Egenskapsnamn |
+| värde | Objekt | Värdet för egenskapen |
+
+ **Result:**
+Objekt
+
+
+---
+
+
+### findProperty{#findProperty}
+
+| Namn | Beskrivning |
+| --- | --- |
+| findProperty(propertyName) | Hittar egenskapen. Det kan vara en dynamisk egenskap (Skapad av CreateDynamicProperty/SetProperty) eller en inbyggd egenskap (Identifierad av dess namn) |
+
+ **Parameters:**
+
+| Namn | Typ | Beskrivning |
+| --- | --- | --- |
+| propertyName | Sträng | Egenskapsnamn. |
+
+ **Result:**
+Property
+
+
+---
+
+
+


### PR DESCRIPTION
Automated translation of the NODEJS-JAVA API Reference to **Swedish** (`sv`) generated by RDA.

- Pages translated: 204/204
- Errors: 0
- Source: `english/nodejs-java`
- Output: `swedish/nodejs-java`

🤖 Generated by RDA